### PR TITLE
Fix prompt text being sent to editor on reporter commands

### DIFF
--- a/std/object/editor.c
+++ b/std/object/editor.c
@@ -27,11 +27,12 @@ void edit(object tp, string source_file, mixed *callback) {
     if(nullp(callback))
         error("ERROR: No valid callback to edit_file()." );
 
-    text =
+    tell(tp,
 "
     Enter text. When finished, enter '.' on a blank line, or '#' to abort.
-  ---------------------------------------------------------------------------" ;
+  ---------------------------------------------------------------------------\n") ;
 
+    text = "" ;
     if(stringp(source_file)) {
         if(!file_exists(source_file)) {
             error("ERROR: File does not exist: " + source_file);


### PR DESCRIPTION
This pull request fixes the issue where the prompt text is being sent to the editor on reporter commands. The problem was caused by the incorrect formatting of the prompt text in the code. This pull request includes the necessary changes to properly format the prompt text and prevent it from being sent to the editor. The issue is fixed by modifying the `edit()` function in the code. The changes ensure that the prompt text is displayed correctly and does not interfere with the editor. This improves the user experience and prevents any unintended behavior when using reporter commands. Fixes #41