### PR TITLE
Add environ check for screenreader

### DIFF
--- a/std/user/body.c
+++ b/std/user/body.c
@@ -633,7 +633,7 @@ void receive_environ(string var, mixed value) {
 }
 
 int has_screenreader() {
-    return query_env("screenreader") ;
+    return query_environ("SCREEN_READER") || false ;
 }
 
 int is_pc() { return 1 ; }


### PR DESCRIPTION
This pull request adds an environ check for the screenreader feature. The `has_screenreader()` function now checks for the presence of the `SCREEN_READER` environ variable. This ensures that the screenreader feature is properly detected. Fixes #31.