### PR TITLE
Convert lines system from Ellenia for use in gLPU

### DIFF
--- a/adm/daemons/lines.c
+++ b/adm/daemons/lines.c
@@ -1,0 +1,142 @@
+/**
+ * @file /adm/daemons/lines.c
+ * @description Daemon to handle line-drawing.
+ *
+ * I know I stole this from someone, but I don't know who. Maybe Lima? idk.
+ * Could have been @michaelprograms, but I'm not sure. Shout out tho whomever
+ * though! This is a great module.
+ *
+ * It is somewhat reminiscent of LP Terminal mappings, inasmuch as it's kind
+ * of exactly the same thing.
+ *
+ * @created 2024/07/13 - Gesslar
+ * @last_modified 2024/07/13 - Gesslar
+ *
+ * @history
+ * 2024/07/13 - Gesslar - Created
+ */
+
+inherit STD_DAEMON ;
+
+private nosave mapping line_drawing = ([ ]) ;
+
+void setup() {
+    line_drawing["UTF-8"] = ([
+        // lines
+        "─" : "─",
+        "═" : "═",
+        "│" : "│",
+        "║" : "║",
+        // diagonals
+        "╲" : "╲",
+        "╱" : "╱",
+        // corners
+        "┌" : "┌",
+        "╔" : "╔",
+        "╓" : "╓",
+        "╒" : "╒",
+        "┐" : "┐",
+        "╗" : "╗",
+        "╕" : "╕",
+        "╖" : "╖",
+        "┘" : "┘",
+        "╝" : "╝",
+        "╛" : "╛",
+        "╜" : "╜",
+        "└" : "└",
+        "╚" : "╚",
+        "╘" : "╘",
+        "╙" : "╙",
+        // joints
+        "┬" : "┬",
+        "╤" : "╤",
+        "╥" : "╥",
+        "╦" : "╦",
+        "┴" : "┴",
+        "╧" : "╧",
+        "╨" : "╨",
+        "╩" : "╩",
+        "├" : "├",
+        "╞" : "╞",
+        "╟" : "╟",
+        "╠" : "╠",
+        "┤" : "┤",
+        "╡" : "╡",
+        "╢" : "╢",
+        "╣" : "╣",
+        "┼" : "┼",
+        "╬" : "╬",
+        "╪" : "╪",
+        "╫" : "╫",
+        "╳" : "╳",
+    ]) ;
+
+    line_drawing["US-ASCII"] = ([
+        // lines
+        "─" : "-",
+        "═" : "=",
+        "│" : "|",
+        "║" : "|",
+        // diagonals
+        "╲" : "\\",
+        "╱" : "/",
+        // corners
+        "┌" : ".",
+        "╔" : ".",
+        "╓" : ".",
+        "╒" : ".",
+        "┐" : ".",
+        "╗" : ".",
+        "╕" : ".",
+        "╖" : ".",
+        "┘" : "'",
+        "╝" : "'",
+        "╛" : "'",
+        "╜" : "'",
+        "└" : "'",
+        "╚" : "'",
+        "╘" : "'",
+        "╙" : "'",
+        "╚" : "'",
+        // joints
+        "┬" : "-",
+        "╤" : "-",
+        "╥" : "-",
+        "╦" : "-",
+        "┴" : "-",
+        "╧" : "-",
+        "╨" : "-",
+        "╩" : "-",
+        "├" : "|",
+        "╞" : "|",
+        "╟" : "|",
+        "╠" : "|",
+        "┤" : "|",
+        "╡" : "|",
+        "╢" : "|",
+        "╣" : "|",
+        "┼" : "+",
+        "╬" : "+",
+        "╪" : "+",
+        "╫" : "+",
+        "╳" : "╳",
+    ]) ;
+
+    line_drawing["screenreader"] = allocate_mapping(keys(line_drawing["UTF-8"]), " ") ;
+}
+
+private string replace_lines_characters(string mess, mapping replacement) {
+    string k, v ;
+
+    foreach(k, v in replacement) {
+        while(strsrch(mess, k) > -1) mess = replace_string(mess, k, v) ;
+    }
+
+    return mess ;
+}
+
+string substitute_lines(string mess, string encoding) {
+    if(encoding == "UTF-8") return mess ;
+    if(of(encoding, line_drawing)) return replace_lines_characters(mess, line_drawing[encoding]) ;
+    return replace_lines_characters(mess, line_drawing["US-ASCII"]) ;
+}

--- a/include/daemons.h
+++ b/include/daemons.h
@@ -17,6 +17,7 @@
 #define GH_ISSUES_D     DIR_DAEMONS "github_issues"
 #define GMCP_D          DIR_DAEMONS "gmcp"
 #define HTTPC_D         DIR_DAEMONS "httpc"
+#define LINES_D         DIR_DAEMONS "lines"
 #define LOCKDOWN_D      DIR_DAEMONS "lockdown_d"
 #define MAIL_D          DIR_DAEMONS "mail_d"
 #define MOVE_D          DIR_DAEMONS "movement"

--- a/std/modules/messaging.c
+++ b/std/modules/messaging.c
@@ -7,7 +7,10 @@
 // 2024/02/03: Gesslar - Created
 
 // Functions
-void do_receive(string message, int message_type);
+void do_receive(string message, int message_type) ;
+
+// Functions from other objects
+mixed query_environ(string key) ;
 
 // Variables
 private nosave int _contents_can_hear = 1, _environment_can_hear = 1;
@@ -143,6 +146,20 @@ void do_receive(string message, int message_type) {
         message = XTERM256->substitute_colour(message, "plain");
     } else {
         message = XTERM256->substitute_colour(message, term);
+    }
+
+    if(function_exists("query_environ")) {
+        string encoding ;
+
+        if(query_environ("SCREEN_READER")) {
+            encoding = "screenreader" ;
+        } else if(query_environ("UTF-8")) {
+            encoding = "UTF-8" ;
+        } else {
+            encoding = "US-ASCII" ;
+        }
+
+        message = LINES_D->substitute_lines(message, encoding) ;
     }
 
     // if(!(message_type & MSG_PROMPT)) {

--- a/std/object/editor.c
+++ b/std/object/editor.c
@@ -30,7 +30,7 @@ void edit(object tp, string source_file, mixed *callback) {
     tell(tp,
 "
     Enter text. When finished, enter '.' on a blank line, or '#' to abort.
-  ---------------------------------------------------------------------------\n") ;
+  ═══════════════════════════════════════════════════════════════════════════\n") ;
 
     text = "" ;
     if(stringp(source_file)) {

--- a/std/user/body.c
+++ b/std/user/body.c
@@ -605,6 +605,22 @@ object get_module(string module) {
     return modules[module] ;
 }
 
+mixed query_environ(string key) {
+    return environ_data[key] ;
+}
+
+mapping query_all_environ() {
+    return copy(environ_data) ;
+}
+
+void set_environ_option(string key, mixed value) {
+    environ_data[key] = from_string(value) ;
+}
+
+void receive_environ(string var, mixed value) {
+    set_environ_option(var, value) ;
+}
+
 void set_environ(mapping data) {
     if(base_name(previous_object()) != LOGIN_OB)
         return;
@@ -614,22 +630,10 @@ void set_environ(mapping data) {
 
     foreach(string key, mixed value in data) {
         if(stringp(value))
-            environ_data[key] = from_string(value) ;
+            set_environ_option(key, value) ;
         else
             environ_data[key] = value ;
     }
-}
-
-mixed query_environ(string key) {
-    return environ_data[key] ;
-}
-
-mapping query_all_environ() {
-    return copy(environ_data) ;
-}
-
-void receive_environ(string var, mixed value) {
-    environ_data[var] = from_string(value) ;
 }
 
 int has_screenreader() {


### PR DESCRIPTION
This pull request converts the lines system from Ellenia for use in gLPU. The lines system handles line-drawing and includes mappings for different line characters in different encodings. This conversion ensures that the lines system works correctly in gLPU and supports UTF-8, US-ASCII, and screenreader encodings.

Fixes #32