### PR TITLE
Update update and dest commands to use new _error/_ok functions

### DIFF
--- a/adm/daemons/alarm.c
+++ b/adm/daemons/alarm.c
@@ -412,9 +412,9 @@ private int next_minute_start() {
     return next_minute_time;
 }
 
-void event_boot(object prev) {
+void execute_boot_alarms(object prev) {
     class Alarm *boot_alarms, boot_alarm ;
-    if(prev != master())
+    if(prev != find_object(BOOT_D))
         return ;
 
     boot_alarms = filter(alarms, (: $1.type == "B" :)) ;

--- a/adm/daemons/boot.c
+++ b/adm/daemons/boot.c
@@ -1,11 +1,17 @@
-// /adm/daemons/boot.c
-// The boot daemon.
-//
-// Created:     2024/03/05: Gesslar
-// Last Change: 2024/03/05: Gesslar
-//
-// 2024/03/05: Gesslar - Created
+/**
+ * @file /adm/daemons/boot.c
+ * @description Daemon to manage incrementing boot number and calling the
+ * boot alarm.
+ *
+ * @created 2024/03/05 - Gesslar
+ * @last_modified 2024/03/05 - Gesslar
+ *
+ * @history
+ * 2024/03/05 - Gesslar - Created
+ */
 
+
+#include <daemons.h>
 #include <origin.h>
 
 inherit STD_DAEMON ;
@@ -13,14 +19,25 @@ inherit STD_DAEMON ;
 private nomask int boot_number ;
 
 void setup() {
+    set_log_level(0) ;
     set_persistent(1) ;
 }
 
+/**
+ * @daemon_function event_boot
+ * @description Called when the mud boots up. Increments the boot number and
+ *              saves the data. Must be included in `adm/etc/preload`.
+ * @param {object} prev - The previous object that called this function.
+ */
 void event_boot(object prev) {
     if(previous_object() != master())
         return ;
-    _debug("Boot #%d loaded.", ++boot_number) ;
+
+    _log(1, "Boot #%d loaded.", ++boot_number) ;
+
     save_data() ;
+
+    catch(ALARM_D->execute_boot_alarms()) ;
 }
 
 int query_boot_number() {

--- a/cmds/object/dest.c
+++ b/cmds/object/dest.c
@@ -29,9 +29,10 @@ mixed main(object caller, string str) {
             tmp = replace_string(tmp, "$N", caller->query_name());
 
             catch(tell_room(environment(caller), capitalize(tmp) + "\n", caller));
-            write("Success [dest]: Destroyed object '" + get_short(ob) + "'.\n");
+            return _ok("Destroyed object '%s.", get_short(ob));
+
         } else {
-            write("Success [dest]: Destroyed object '" + get_short(ob) + "'.\n");
+            return _ok("Destroyed object '%s.", get_short(ob));
             catch(tell_room(environment(caller), capitalize(caller->query_name()) + " nullifies '" + get_short(ob) + ".\n", ({caller})));
         }
         catch(ob->remove());
@@ -47,9 +48,9 @@ mixed main(object caller, string str) {
             tmp = replace_string(tmp, "$N", caller->query_name());
 
             catch(tell_room(environment(caller), capitalize(tmp) + "\n", caller));
-            write("Success [dest]: Destroyed object '" + get_short(ob) + "'.\n");
+            return _ok("Destroyed object '%s.", get_short(ob));
         } else {
-            write("Success [dest]: Destroyed object '" + get_short(ob) + "'.\n");
+            return _ok("Destroyed object '%s.", get_short(ob));
             catch(tell_room(environment(caller), capitalize(caller->query_name()) + " nullifies '" + get_short(ob) + ".\n", ({caller})));
         }
         ob->remove();
@@ -65,12 +66,12 @@ mixed main(object caller, string str) {
             tmp = replace_string(tmp, "$N", caller->query_name());
 
             catch(tell_room(environment(caller), capitalize(tmp) + "\n", caller));
-            write("Success [dest]: Destroyed object '" + get_short(ob) + "'.\n");
+            return _ok("Destroyed object '%s.", get_short(ob));
         } else {
-            write("Success [dest]: Destroyed object '" + get_short(ob) + "'.\n");
+            return _ok("Destroyed object '%s.", get_short(ob));
             catch(tell_room(environment(caller), capitalize(caller->query_name()) + " nullifies '" + get_short(ob) + ".\n", ({caller})));
         }
-        tell_object(ob, "Notice [dest]: You have been nullified and hence disconnected from the mud.\n");
+        tell_object(ob, "You have been nullified and hence disconnected from the mud.\n");
         if(ob) destruct(ob);
         return 1;
     }
@@ -78,14 +79,13 @@ mixed main(object caller, string str) {
     if(str[<2..<1] != ".c") str += ".c";
     str = resolve_path(caller->query("cwd"), str);
     if(ob = find_object(str)) {
-        write("Success [dest]: Destructing master object for '" + str + "'.\n");
         caller->set("cwf", str);
         ob->remove() ;
         if(ob) destruct(ob);
-        return 1;
+        return _ok("Destructing master object for '%s'.", str);
     }
 
-    return(notify_fail("Error [dest]: Object '" + str + "' not found.\n"));
+    return _error("Object '%s' not found.", str);
 }
 
 string help(object caller) {

--- a/cmds/object/update.c
+++ b/cmds/object/update.c
@@ -37,20 +37,20 @@ mixed main(object caller, string arg) {
 
     if(!file) {
         if(!caller->query("cwf"))
-            return "Error [update]: You must provide an argument. Syntax: update [-rR] [<file>]\n" ;
+            return _error("You must provide an argument. Syntax: update [-rR] [<file>]") ;
         file = caller->query("cwf");
     }
 
     file = resolve_path(caller->query("cwd"), file);
     file = append(file, ".c") ;
     if(file == append(file_name(), ".c")) {
-        return "Error [update]: You cannot update the update command. Destruct it instead.\n";
+        return _error("You cannot update the update command. Destruct it instead.") ;
     }
 
     start = file ;
 
     if(file[0..<3] == VOID_OB) {
-        return "Error [update]: You cannot update the void object.\n";
+        return _error("You cannot update the void object.") ;
     }
 
     obj = find_object(file) ;
@@ -70,7 +70,7 @@ mixed main(object caller, string arg) {
     }
 
     if(!file_exists(file))
-        return "Error [update]: " + file  + " does not exist.\n";
+        return _error("%s does not exist.", file);
 
     caller->set("cwf", start);
 
@@ -86,10 +86,8 @@ mixed main(object caller, string arg) {
     error = catch(obj = load_object(file));
 
 
-    if(error){
-        write("Error [update]: Failed to load: "+file+"\nError: "+error+"\n");
-        return 1;
-    }
+    if(error)
+        return _error("Failed to load %s\n%s", file, error);
 
     return "Successful [update]: " +  file+" was updated.\n" ;
 }
@@ -105,17 +103,17 @@ void do_update(string file, string vfile) {
     }
 
     if(!file_exists(file))
-        write("Error [update]: " + file  + " does not exist.\n") ;
+        _error("%s does not exist.", file);
 
     error = catch(obj = load_object(file));
 
     if(error){
-        write("Error [update]: Failed to load: "+file+"\nError: "+error+"\n");
+        _error("Failed to load: %s\n%s", file, error);
         return ;
     }
 
     if(pointerp(users)) users->move(obj, 1);
-    write("Successful [update]: " + file + " was updated.\n") ;
+    _ok("%s was updated.", file) ;
 }
 
 // Function to collect immediate and deep inherits.

--- a/doc/wiki/docs/daemon_function/boot.md
+++ b/doc/wiki/docs/daemon_function/boot.md
@@ -1,0 +1,22 @@
+---
+title: boot
+---
+# boot.c
+
+## event_boot
+
+### Synopsis
+
+```c
+void event_boot(object prev)
+```
+
+### Parameters
+
+* `object prev` - The previous object that called this function.
+
+### Description
+
+Called when the mud boots up. Increments the boot number and
+saves the data. Must be included in `adm/etc/preload`.
+

--- a/doc/wiki/docs/daemon_function/index.md
+++ b/doc/wiki/docs/daemon_function/index.md
@@ -1,0 +1,9 @@
+---
+title: daemon_function
+---
+# daemon_function
+
+## boot
+
+* [event_boot](boot#event_boot)
+


### PR DESCRIPTION
Previously, the update and dest commands were using the write function to display success and error messages. This pull request updates the commands to use the new _error and _ok functions, which provide more consistent and visually appealing messages.

Fixes #59