### PR TITLE
Update autodoc to sequentially add files during dir check

### DIFF
--- a/adm/daemons/alarm.c
+++ b/adm/daemons/alarm.c
@@ -412,9 +412,9 @@ private int next_minute_start() {
     return next_minute_time;
 }
 
-void event_boot(object prev) {
+void execute_boot_alarms(object prev) {
     class Alarm *boot_alarms, boot_alarm ;
-    if(prev != master())
+    if(prev != find_object(BOOT_D))
         return ;
 
     boot_alarms = filter(alarms, (: $1.type == "B" :)) ;

--- a/adm/daemons/boot.c
+++ b/adm/daemons/boot.c
@@ -1,11 +1,17 @@
-// /adm/daemons/boot.c
-// The boot daemon.
-//
-// Created:     2024/03/05: Gesslar
-// Last Change: 2024/03/05: Gesslar
-//
-// 2024/03/05: Gesslar - Created
+/**
+ * @file /adm/daemons/boot.c
+ * @description Daemon to manage incrementing boot number and calling the
+ * boot alarm.
+ *
+ * @created 2024/03/05 - Gesslar
+ * @last_modified 2024/03/05 - Gesslar
+ *
+ * @history
+ * 2024/03/05 - Gesslar - Created
+ */
 
+
+#include <daemons.h>
 #include <origin.h>
 
 inherit STD_DAEMON ;
@@ -13,14 +19,25 @@ inherit STD_DAEMON ;
 private nomask int boot_number ;
 
 void setup() {
+    set_log_level(0) ;
     set_persistent(1) ;
 }
 
+/**
+ * @daemon_function event_boot
+ * @description Called when the mud boots up. Increments the boot number and
+ *              saves the data. Must be included in `adm/etc/preload`.
+ * @param {object} prev - The previous object that called this function.
+ */
 void event_boot(object prev) {
     if(previous_object() != master())
         return ;
-    _debug("Boot #%d loaded.", ++boot_number) ;
+
+    _log(1, "Boot #%d loaded.", ++boot_number) ;
+
     save_data() ;
+
+    catch(ALARM_D->execute_boot_alarms()) ;
 }
 
 int query_boot_number() {

--- a/adm/etc/default.json
+++ b/adm/etc/default.json
@@ -33,7 +33,8 @@
     "USE_MASS" : true,
     "USE_BULK" : true,
     "AUTODOC_SOURCE_DIRS" : [
-        "/adm/simul_efun/"
+        "/adm/simul_efun/",
+        "/adm/daemons/"
     ],
     "AUTODOC_ROOT" : "/doc/autodoc/",
     "CURRENCY" : [

--- a/doc/wiki/docs/daemon_function/boot.md
+++ b/doc/wiki/docs/daemon_function/boot.md
@@ -1,0 +1,22 @@
+---
+title: boot
+---
+# boot.c
+
+## event_boot
+
+### Synopsis
+
+```c
+void event_boot(object prev)
+```
+
+### Parameters
+
+* `object prev` - The previous object that called this function.
+
+### Description
+
+Called when the mud boots up. Increments the boot number and
+saves the data. Must be included in `adm/etc/preload`.
+

--- a/doc/wiki/docs/daemon_function/index.md
+++ b/doc/wiki/docs/daemon_function/index.md
@@ -1,0 +1,9 @@
+---
+title: daemon_function
+---
+# daemon_function
+
+## boot
+
+* [event_boot](boot#event_boot)
+


### PR DESCRIPTION
This pull request updates the autodoc functionality to sequentially add files during the directory check process. This prevents out of bounds errors in the check_file function. Additionally, it adds more information to the _log for statistics of the run. This fixes issue #60.