### PR TITLE
implement call_if()

### DIFF
--- a/adm/obj/simul_efun.h
+++ b/adm/obj/simul_efun.h
@@ -59,6 +59,8 @@ int valid_function(mixed f) ;
 mixed *assemble_call_back(mixed arg...) ;
 mixed call_back(mixed *cb, mixed arg...) ;
 varargs string call_trace(int colour) ;
+mixed call_if(mixed ob, string func, mixed arg) ;
+
 
 // File: grammar
 string int_string (int num) ;

--- a/adm/simul_efun/function.c
+++ b/adm/simul_efun/function.c
@@ -185,3 +185,34 @@ mixed call_back(mixed cb, mixed new_arg...) {
 
     return catch((*fun)(final_arg...)) ;
 }
+
+/**
+ * @simul_efun call_if
+ * @description Calls the specified function on the given object if it exists.
+ * @param {mixed} ob - The object to call the function on.
+ * @param {string} func - The name of the function to call.
+ * @param {mixed} arg - The argument to pass to the function.
+ * @returns {mixed} - The return value of the function, or null if the function
+ *                    does not exist.
+ */
+varargs mixed call_if(mixed ob, string func, mixed arg...) {
+    if(nullp(ob))
+        error("Missing argument 1 to call_if()") ;
+
+    if(!objectp(ob) && !stringp(ob))
+        error("Bad argument 1 to call_if()") ;
+
+    if(nullp(func))
+        error("Missing argument 2 to call_if()") ;
+
+    if(!stringp(func))
+        error("Bad argument 2 to call_if()") ;
+
+    if(stringp(ob))
+        ob = load_object(ob);
+
+    if(function_exists(func, ob))
+        return call_other(ob, func, arg...);
+
+    return null ;
+}

--- a/doc/wiki/docs/simul_efun/function.md
+++ b/doc/wiki/docs/simul_efun/function.md
@@ -68,6 +68,24 @@ mixed call_back(mixed cb, mixed new_arg...)
 
 Executes a callback with the given arguments.
 
+## call_if
+
+### Synopsis
+
+```c
+varargs mixed call_if(mixed ob, string func, mixed arg...)
+```
+
+### Parameters
+
+* `mixed ob` - The object to call the function on.
+* `string func` - The name of the function to call.
+* `mixed arg` - The argument to pass to the function.
+
+### Description
+
+Calls the specified function on the given object if it exists.
+
 ## valid_function
 
 ### Synopsis

--- a/doc/wiki/docs/simul_efun/index.md
+++ b/doc/wiki/docs/simul_efun/index.md
@@ -67,6 +67,7 @@ title: simul_efun
 
 * [assemble_call_back](function#assemble_call_back)
 * [call_back](function#call_back)
+* [call_if](function#call_if)
 * [call_trace](function#call_trace)
 * [valid_function](function#valid_function)
 


### PR DESCRIPTION
This feature includes a new sefun to behave like first calling `function_exists()` and then calling `call_other()` standard chain.

Fixes #68