### PR TITLE
_ok() and friends are now non-wizard-friendly

### DIFF
--- a/adm/simul_efun/system.c
+++ b/adm/simul_efun/system.c
@@ -1,4 +1,5 @@
 #include "/adm/obj/simul_efun.h"
+#include <modules.h>
 
 //system.c
 
@@ -154,6 +155,8 @@ varargs void _debug(mixed str, mixed args...) {
     debug_message(str) ;
 }
 
+private nosave string _brief_circle = "\u25CB" ;
+
 /**
  * @function _format_message
  * @description Formats a message with a color and the name of the previous object.
@@ -164,15 +167,41 @@ varargs void _debug(mixed str, mixed args...) {
  */
 private string _format_message(string color, string str, mixed args...) {
     object po ;
+    object body = this_body() ;
     string name ;
 
     if(!po = previous_object())
         return null ;
 
-    name = query_file_name(po) ;
-    name = upper_case(name) ;
-    name = replace_string(name, "_", " ") ;
-    name = "["+color+name+"\eres\e] " ;
+    if(body) {
+        if(devp(body)) {
+            if(body->query_env("feedback_level") == "brief") {
+                if(body->has_screenreader())
+                    name = "" ;
+                else
+                    if(M_UNICODE->supports_unicode())
+                        name = color + _brief_circle + "\eres\e " ;
+                    else
+                        name = color + "o\eres\e " ;
+            } else {
+                name = query_file_name(po) ;
+                name = upper_case(name) ;
+                name = replace_string(name, "_", " ") ;
+
+                if(!body->has_screenreader()) {
+                    name = "["+color+name+"\eres\e] " ;
+                }
+            }
+        } else {
+            if(body->has_screenreader())
+                name = "" ;
+            else
+                if(M_UNICODE->supports_unicode())
+                    name = color + _brief_circle + "\eres\e " ;
+                else
+                    name = color + "o\eres\e " ;
+        }
+    }
 
     str = name + str ;
     str = sprintf(str, args...) ;
@@ -250,7 +279,7 @@ varargs int _error(mixed args...) {
     if(!tp)
         tp = this_player() ;
 
-    mess = _format_message("\e0124\e", str, args...) ;
+    mess = _format_message("\e0160\e", str, args...) ;
     if(nullp(mess))
         return 0 ;
 

--- a/cmds/std/colour.c
+++ b/cmds/std/colour.c
@@ -43,7 +43,7 @@ mixed main(object caller, string str) {
             if(!arg)
                 return _error(caller, "Invalid colour code.") ;
 
-            if(!caller->query_env("colour"))
+            if(!caller->query_env("colour") != "on")
                 return _error(caller, "Colour is currently disabled.") ;
 
             if(sscanf(arg, "%d", num) != 1)

--- a/cmds/std/look.c
+++ b/cmds/std/look.c
@@ -77,7 +77,7 @@ mixed render_room(object caller, object room) {
     if(!objectp(room))
         return "You see nothing because you have no environment!\n" ;
 
-    if(devp(caller) && caller->query_env("look_filename") == "on") {
+    if(devp(caller) && of(caller->query_env("look_filename"), ({ "on", "all" }))) {
         result += "\e0032\e"+prepend(file_name(room), "/") + "\eres\e\n" ;
     }
 
@@ -156,7 +156,7 @@ mixed render_object(object caller, object room, string target) {
 
 
     if(strlen(desc)) {
-        if(devp(caller) && caller->query_env("look_filename") == "on") {
+        if(devp(caller) && caller->query_env("look_filename") == "all") {
             desc = "\e0032\e"+prepend(file_name(ob), "/") + "\eres\e\n" + desc ;
         }
     }
@@ -188,7 +188,7 @@ mixed render_living(object caller, object room, object target, object user) {
     }
 
     if(strlen(result)) {
-        if(devp(caller) && caller->query_env("look_filename") == "on") {
+        if(devp(caller) && caller->query_env("look_filename") == "all") {
             result = "\e0032\e"+prepend(file_name(target), "/") + "\eres\e\n" + result ;
         }
     }

--- a/doc/wiki/docs/.vitepress/config.ts
+++ b/doc/wiki/docs/.vitepress/config.ts
@@ -19,6 +19,13 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: "Home", link: "/" },
+          {
+            collapsed: true,
+            text: "Help",
+            items: [
+              { text: "Environment Variables", link: "environment_variables" },
+            ],
+          },
           { text: "Contributing", link: "/contributing" },
         ]
       },

--- a/doc/wiki/docs/environment_variables/administrator-environment-variables.md
+++ b/doc/wiki/docs/environment_variables/administrator-environment-variables.md
@@ -1,0 +1,107 @@
+# Administrator Environment Variables
+
+All of the environment variables listed in the [User Environment
+Variables](index) section apply to administrators as well.
+In addition, the following environment variables are available to
+administrators:
+
+## custom_clone
+
+This variable allows you to provide a custom message to be printed whenever you
+clone an object. `$N` will be replaced with your name, and `$O` will be replaced
+with the name of the object.
+
+## custom_dest
+
+This variable allows you to provide a custom message to be printed whenever you
+destruct an object. `$N` will be replaced with your name, and `$O` will be
+replaced with the name of the object.
+
+## feedback_level
+
+When you receive system messages of `ok`, `inform`, `warn`, or `error`, this
+variable allows you to set the tagging that appears before the message.
+
+If this is not set, then you will receive the default system tags for feedback
+messages.
+
+If it is set to `brief`, then you will receive a coloured symbol before the
+message. If you are using a screenreader, then you will receive nothing.
+
+## log_level
+
+This variable allows you to set the level of logging that body and user events
+will generate. This can be set on players, but as this information is printed
+to the `debug.log`, they won't see it. This is useful for debugging purposes.
+
+REMEMBER: This will generate a lot of information, so be careful with this and
+don't forget to turn it off.
+
+Levels are `1` to `4`, with `1` being the least nerdy information and `4` being
+the most nerdy information. `0` or unset will turn off logging.
+
+## look_filename
+
+This variable allows you to set whether you see the file names of the room
+or objects when you look at them. The default is `on`.
+
+* `on` - show for rooms only
+* `off` - do not show for rooms or objects
+* `all` - show for rooms and objects
+
+## move_in
+
+This variable allows you to provide a custom message for whenever you move
+normally to a room. The `move_in` message will be printed to the room the you
+move into.
+
+`$N` will be replaced with your name, and `$D` will be replaced with the
+direction/exit you use.
+
+*Note: You are not required to use either `$N` or `$D` you may put your name in
+literally if you wish.*
+
+## move_out
+
+This variable allows you to provide a custom message for whenever you move
+normally from a room. The `move_out` message will be printed to the room you
+move from.
+
+`$N` will be replaced with your name, and `$D` will be replaced with the
+
+*Note: You are not required to use either `$N` or `$D` you may put your name in
+literally if you wish.*
+
+## start_location
+
+This variable allows you to set a start_location besides the standard one
+You must provide a full path to a room or set it to `last_location` to return
+to the last room you were in before logging out.
+
+If you do not set a start_location, you will default to your workroom in your
+home directory if it exists. Otherwise, you will login to the same start
+location as players.
+
+## teleport_in
+
+This variable allows you to provide custom messages for whenever you teleport
+to a different place. The `teleport_in` message is printed to the room the you
+teleport to.
+
+`$N` in the message will be replaced with your name, and $D will be replaced
+with the location being teleported to.
+
+*Note: You are not required to use either `$N` or `$D` you may put your name in
+literally if you wish.*
+
+## teleport_out
+
+This variable allows you to provide custom messages for whenever you teleport
+from a room. The `teleport_out` message is printed to the room you teleport
+from.
+
+`$N` in the message will be replaced with your name, and $D will be replaced
+with the location being teleported from.
+
+*Note: You are not required to use either `$N` or `$D` you may put your name in
+literally if you wish.*

--- a/doc/wiki/docs/environment_variables/index.md
+++ b/doc/wiki/docs/environment_variables/index.md
@@ -1,0 +1,94 @@
+# Environment Variables
+
+The following categories of environment variables apply to whether you are
+an [administrator](administrator-environment-variables) or a player.
+
+Generally, if an environment variable offers `on` or `off` as options, the
+default is `off`, unless otherwise noted.
+
+## auto_tune
+
+This variable allows you to specify which channels or channels you wish to
+automatically tune into when you login. If you wish to tune into multiple
+channels or modules, separate the names by spaces, or `all` to tune into all
+available channels or modules.
+
+To see a list of channels, type `channel list all`.
+
+## biff
+
+This variable will set whether or not you recieve the new mail notification
+when you log in, or when someone sends you a piece of mail. The default is
+`on`.
+
+* `on` - Enable the new mail notification.
+* `off` - Disable the new mail notification.
+
+## colour
+
+Determines whether colour is enabled and will be sent to the terminal.
+
+* `on` - Enable colour.
+* `off` - Disable colour.
+
+Use the `colour` command to set this variable.
+
+## gmcp
+
+Determines whether GMCP is enabled. The default is `off`. May also be managed
+by the `gmcp` command.
+
+* `on` - Enable GMCP.
+* `off` - Disable GMCP.
+
+## highlight
+
+Determines whether items of interest are highlighted when you look in a room
+or at an item. The default for the distribution is `on`.
+
+* `on` - Enable highlighting.
+* `off` - Disable highlighting.
+
+## highlight_color
+
+Determines the colour used for highlighting. The default for the distribution
+is `243`. Use the `colour list` command for a list of available colours.
+
+## keepalive
+
+Determines whether the game will send keepalive packets to the client. The
+default is `off`.
+
+* `on` - Enable keepalive packets.
+* `off` - Disable keepalive packets.
+
+## morelines
+
+Determines the number of lines to display before pausing when the `more`
+prompt is displayed. The default is `40`.
+
+## unicode
+
+Determines whether Unicode characters are used in the client. The default is
+`off`.
+
+* `on` - Enable Unicode.
+* `off` - Disable Unicode.
+
+## page_display
+
+This variable allows you to change whether you see the percentage of a document
+viewed or the line numbers of the current page of a document. The default is
+`lines`.
+
+* `percent` - Display the percentage of the document viewed.
+* `line` - Display the line numbers of the current page.
+
+## screenreader
+
+Determines whether the client is in screen reader mode. The default is `off`.
+However, if you connect with a client that the game detects has screenreading
+capabilities, this will be overridden.
+
+* `on` - Enable screen reader mode.
+* `off` - Disable screen reader mode.

--- a/std/user/body.c
+++ b/std/user/body.c
@@ -741,7 +741,13 @@ void set_environ(mapping data) {
 }
 
 int has_screenreader() {
-    return query_environ("SCREEN_READER") || false ;
+    if(query_environ("SCREEN_READER") == true)
+        return true ;
+
+    if(query_env("screenreader") == "on")
+        return true ;
+
+    return false ;
 }
 
 int query_log_level() {
@@ -752,7 +758,7 @@ int query_log_level() {
 
 int supports_unicode() {
     if(has_screenreader()) return 0 ;
-    return to_int(query_env("unicode")) ;
+    return query_env("unicode") == "on" ;
 }
 
 int is_pc() { return 1 ; }


### PR DESCRIPTION
Instead of showing the command or object name when receiving a feedback message, a nice unicode circle will print!

Wizards can set their `feedback_level` environment variable to see this instead of the object name.

Added documentation to the wiki to show all available environment variables.