### PR TITLE
Fix spacing issue in help file error message

### DIFF
--- a/cmds/std/help.c
+++ b/cmds/std/help.c
@@ -71,7 +71,7 @@ mixed main(object tp, string str) {
         }
     }
     log_file(LOG_HELP, "Not found: " + str + "\n");
-    return notify_fail("Error [help]: Unable to find helpfile for: " + str + "\n");
+    return notify_fail("Error [help]: Unable to find help file for: " + str + "\n");
 }
 
 string help(object caller) {


### PR DESCRIPTION
This pull request fixes a spacing issue in the error message displayed when a help file is not found. Currently, the error message does not have a space between "help" and "file", which can make it difficult to read. This pull request adds the missing space to improve the readability of the error message.

Fixes #89