### PR TITLE
Fix typo in doc

### DIFF
--- a/adm/simul_efun/prompt.c
+++ b/adm/simul_efun/prompt.c
@@ -55,7 +55,7 @@ void prompt_password(object body, int attempts, mixed *cb) {
  * @description Prompt the user for a colour. The user will be presented with a
  *              list of colours to choose from. The user can also enter a
  *              number corresponding to an xterm 256 colour, or the word "plain"
- *              tp select no colour.
+ *              to select no colour.
  *
  *              Upon selection, the callback function will be called with the
  *              selected colour as the argument.

--- a/doc/autodoc/simul_efun/prompt_colour
+++ b/doc/autodoc/simul_efun/prompt_colour
@@ -9,6 +9,6 @@ Parameters:
 Prompt the user for a colour. The user will be presented with a
 list of colours to choose from. The user can also enter a
 number corresponding to an xterm 256 colour, or the word "plain"
-tp select no colour.
+to select no colour.
 Upon selection, the callback function will be called with the
 selected colour as the argument.

--- a/doc/wiki/docs/simul_efun/prompt.md
+++ b/doc/wiki/docs/simul_efun/prompt.md
@@ -22,7 +22,7 @@ varargs void prompt_colour(object body, mixed *cb, string prompt)
 Prompt the user for a colour. The user will be presented with a
 list of colours to choose from. The user can also enter a
 number corresponding to an xterm 256 colour, or the word "plain"
-tp select no colour.
+to select no colour.
 Upon selection, the callback function will be called with the
 selected colour as the argument.
 


### PR DESCRIPTION
This pull request fixes a typo in the documentation. The word "tp" has been corrected to "to" in several places where the user is prompted to select no color.