### PR TITLE
Add Boot and Signal daemons to gLPU documentation

### DIFF
--- a/doc/wiki/docs/systems/daemons/index.md
+++ b/doc/wiki/docs/systems/daemons/index.md
@@ -3,5 +3,7 @@
 The following daemons are available in gLPU:
 
 * [Alarm](alarm)
+* [Boot](boot)
 * [Configuration](config)
 * [GitHub Issues](github_issues)
+* [Signal](signal)


### PR DESCRIPTION
This pull request adds the Boot and Signal daemons to the gLPU documentation. The documentation previously did not include these daemons, but they are now listed alongside the existing daemons (Alarm, Configuration, and GitHub Issues).