### PR TITLE
Fixing documentation for Signal daemon

### DIFF
--- a/doc/wiki/docs/systems/daemons/signal.md
+++ b/doc/wiki/docs/systems/daemons/signal.md
@@ -3,30 +3,30 @@
 The Signal daemon is responsible for managing signals that are sent to objects
 in the game. Signals are a way to send messages to objects that are not
 necessarily in the same room or even in the same area. It is an agnostic
-messaging system that allows for any object to subscribe to a signal and
-receive messages when that signal is sent. Any object can send a signal and
+messaging system that allows any object to subscribe to a signal and
+receive messages when that signal is sent. Any object can send a signal, and
 any object that is listening for that signal will receive it.
 
 All calls to the Signal daemon are done through [simul_efuns](/simul_efun/signal).
-his is to ensure that the daemon is the only object that can listen for signal
+This ensures that the daemon is the only object that can listen for signal
 emissions, send out the signals, and manage the subscriptions.
 
 ## Signals
 
 Signals are integer values that are used to identify the type of message that
 is being sent. They are used to differentiate between different types of
-messages and allow objects to subscribe to only the signals that they are
+messages and allow objects to subscribe to only the signals they are
 interested in.
 
-To send a signal, you simply call the `emit(int signal, mixed args...)`.
+To send a signal, you simply call `emit(int signal, mixed args...)`.
 This simul_efun does not return any result, due to the nature of signals. It
-is a fire-and-forget system, as it will be unaware of who is listening for the
-signal.
+is a fire-and-forget system; any number of objects could be listening, and
+a single return value is not feasible.
 
 ### Example
 
 ```c
-    emit(SYS_SIGNAL_BOOT) ;
+emit(SIG_SYS_BOOT);
 ```
 
 ## Slots
@@ -44,11 +44,14 @@ represents a function in the object that is listening for the signal.
 You may only subscribe to a signal with one function per object. Any subsequent
 calls to `slot` with the same signal will overwrite the previous function.
 
+The possible return values of `slot` are included in the `include/signal.h`
+file.
+
 ### Example
 
 ```c
 void setup() {
-    slot(SYS_SIGNAL_BOOT, "on_boot");
+    slot(SIG_SYS_BOOT, "on_boot");
 }
 
 void on_boot(mixed args...) {
@@ -62,17 +65,23 @@ To stop listening for a signal, you use the `unslot` simul_efun. You must pass
 the integer signal that you want to stop listening for. It is unnecessary to
 pass the function that you want to stop listening for.
 
+The possible return values of `unslot` are included in the `include/signal.h`
+file.
+
 ### Example
 
 ```c
-void cleanup() {
-    unslot(SYS_SIGNAL_BOOT);
+void clean_up() {
+    unslot(SIG_SYS_BOOT);
 }
 ```
 
-## Signals
+## Signal Definitions
 
 There are predefined signals in `include/signal.h` that are used by the game.
 A future update will include the ability to define custom signals in the
-`adm/etc/config.json` file. When this is implemented, only the signals that
-are defined in the config file will be available for use.
+`adm/etc/config.json` file.
+
+They are set up to be bit-shifted; however, the Signal daemon is not presently
+set up to handle bit-shifted signals. This is a future feature that will be
+added to the daemon.


### PR DESCRIPTION
The documentation for the Signal daemon has been updated to fix some inaccuracies and improve clarity. This includes correcting the description of the daemon's responsibilities, clarifying the usage of signals, and providing examples for subscribing and unsubscribing to signals. Additionally, the documentation mentions the future feature of defining custom signals in the config file.