### PR TITLE
update autodoc and documentation

### DIFF
--- a/adm/simul_efun/system.c
+++ b/adm/simul_efun/system.c
@@ -449,9 +449,9 @@ varargs int _question(mixed args...) {
 
 /**
  * @simul_efun boot_number
-    * @description Returns the boot number of the MUD. This is the number of
-    *              times the MUD has been booted.
-    * @returns {int} - The current boot number.
+ * @description Returns the boot number of the MUD. This is the number of
+ *              times the MUD has been booted.
+ * @returns {int} - The current boot number.
  */
 int boot_number() {
     return BOOT_D->query_boot_number() ;

--- a/doc/autodoc/daemon_function/autodoc_scan
+++ b/doc/autodoc/daemon_function/autodoc_scan
@@ -1,0 +1,14 @@
+public nomask mixed autodoc_scan()
+
+Start the autodoc scan process. This will trigger the daemon to
+scan the directories specified in the AUTODOC_SOURCE_DIRS
+configuration variable for LPC source files and parse the
+JSDoc-style comments in those files.
+
+The parsed documentation will be written to the
+AUTODOC_ROOT directory in a structured format for use in
+generating documentation for the mudlib.
+
+The parsed documentation will also be written to the
+WIKI_DOC_ROOT directory in a structured format for use in
+generating documentation for the wiki.

--- a/doc/autodoc/simul_efun/assemble_call_back
+++ b/doc/autodoc/simul_efun/assemble_call_back
@@ -12,11 +12,13 @@ Assembles a callback function from the provided arguments.
 This function is used to create a callable structure that can be
 invoked later. The callback can be either a method on an object or
 a function. The assembled callback is returned as an array.
+
 Usage:
 - When you need to create a callback for an object method:
 `assemble_call_back(object, "method", args...)`
 - When you need to create a callback for a function:
 `assemble_call_back(function, args...)`
+
 The function performs the following steps:
 1. Checks if the provided arguments form a valid array.
 2. Determines the size of the arguments array.

--- a/doc/autodoc/simul_efun/boot_number
+++ b/doc/autodoc/simul_efun/boot_number
@@ -5,3 +5,4 @@ Returns
 `int` - The current boot number.
 
 Returns the boot number of the MUD. This is the number of
+times the MUD has been booted.

--- a/doc/autodoc/simul_efun/prompt_colour
+++ b/doc/autodoc/simul_efun/prompt_colour
@@ -10,5 +10,6 @@ Prompt the user for a colour. The user will be presented with a
 list of colours to choose from. The user can also enter a
 number corresponding to an xterm 256 colour, or the word "plain"
 to select no colour.
+
 Upon selection, the callback function will be called with the
 selected colour as the argument.

--- a/doc/autodoc/simul_efun/this_caller
+++ b/doc/autodoc/simul_efun/this_caller
@@ -8,5 +8,6 @@ This is a simul_efun that will return the object that called
 the current operation. This may be this_body(), but it may
 also be a shadow another player who initiated the chain.
 For example, a wizard using the force command.
+
 Be careful with this one, you don't want to accidentally
 perform operations on the wrong object.

--- a/doc/wiki/docs/daemon_function/autodoc.md
+++ b/doc/wiki/docs/daemon_function/autodoc.md
@@ -1,0 +1,28 @@
+---
+title: autodoc
+---
+# autodoc.c
+
+## autodoc_scan
+
+### Synopsis
+
+```c
+public nomask mixed autodoc_scan()
+```
+
+### Description
+
+Start the autodoc scan process. This will trigger the daemon to
+scan the directories specified in the AUTODOC_SOURCE_DIRS
+configuration variable for LPC source files and parse the
+JSDoc-style comments in those files.
+
+The parsed documentation will be written to the
+AUTODOC_ROOT directory in a structured format for use in
+generating documentation for the mudlib.
+
+The parsed documentation will also be written to the
+WIKI_DOC_ROOT directory in a structured format for use in
+generating documentation for the wiki.
+

--- a/doc/wiki/docs/daemon_function/index.md
+++ b/doc/wiki/docs/daemon_function/index.md
@@ -3,7 +3,11 @@ title: daemon_function
 ---
 # daemon_function
 
-## github_issues
+## [autodoc](autodoc)
+
+* [autodoc_scan](autodoc#autodoc_scan)
+
+## [github_issues](github_issues)
 
 * [create_issue](github_issues#create_issue)
 * [process_backlog](github_issues#process_backlog)

--- a/doc/wiki/docs/efun_override/index.md
+++ b/doc/wiki/docs/efun_override/index.md
@@ -3,7 +3,7 @@ title: efun_override
 ---
 # efun_override
 
-## overrides
+## [overrides](overrides)
 
 * [ctime](overrides#ctime)
 * [exec](overrides#exec)

--- a/doc/wiki/docs/simul_efun/function.md
+++ b/doc/wiki/docs/simul_efun/function.md
@@ -45,11 +45,13 @@ Assembles a callback function from the provided arguments.
 This function is used to create a callable structure that can be
 invoked later. The callback can be either a method on an object or
 a function. The assembled callback is returned as an array.
+
 Usage:
 - When you need to create a callback for an object method:
 `assemble_call_back(object, "method", args...)`
 - When you need to create a callback for a function:
 `assemble_call_back(function, args...)`
+
 The function performs the following steps:
 1. Checks if the provided arguments form a valid array.
 2. Determines the size of the arguments array.

--- a/doc/wiki/docs/simul_efun/index.md
+++ b/doc/wiki/docs/simul_efun/index.md
@@ -3,36 +3,36 @@ title: simul_efun
 ---
 # simul_efun
 
-## arrays
+## [arrays](arrays)
 
 * [distinct_array](arrays#distinct_array)
 * [remove_array_element](arrays#remove_array_element)
 * [reverse_array](arrays#reverse_array)
 * [splice](arrays#splice)
 
-## base64
+## [base64](base64)
 
 * [base64_decode](base64#base64_decode)
 * [base64_encode](base64#base64_encode)
 
-## data
+## [data](data)
 
 * [data_del](data#data_del)
 * [data_inc](data#data_inc)
 * [data_value](data#data_value)
 * [data_write](data#data_write)
 
-## description
+## [description](description)
 
 * [get_long](description#get_long)
 * [get_short](description#get_short)
 
-## directory
+## [directory](directory)
 
 * [assure_dir](directory#assure_dir)
 * [query_directory](directory#query_directory)
 
-## english
+## [english](english)
 
 * [cap_significant_words](english#cap_significant_words)
 * [cap_words](english#cap_words)
@@ -43,7 +43,7 @@ title: simul_efun
 * [reflexive](english#reflexive)
 * [subjective](english#subjective)
 
-## exists
+## [exists](exists)
 
 * [cfile_exists](exists#cfile_exists)
 * [directory_exists](exists#directory_exists)
@@ -51,7 +51,7 @@ title: simul_efun
 * [ofile_exists](exists#ofile_exists)
 * [user_exists](exists#user_exists)
 
-## file
+## [file](file)
 
 * [assure_file](file#assure_file)
 * [dir_file](file#dir_file)
@@ -64,7 +64,7 @@ title: simul_efun
 * [temp_file](file#temp_file)
 * [touch](file#touch)
 
-## function
+## [function](function)
 
 * [assemble_call_back](function#assemble_call_back)
 * [call_back](function#call_back)
@@ -72,27 +72,27 @@ title: simul_efun
 * [call_trace](function#call_trace)
 * [valid_function](function#valid_function)
 
-## grammar
+## [grammar](grammar)
 
 * [consolidate](grammar#consolidate)
 * [int_string](grammar#int_string)
 * [ordinal](grammar#ordinal)
 
-## identify
+## [identify](identify)
 
 * [identify](identify#identify)
 
-## json
+## [json](json)
 
 * [json_decode](json#json_decode)
 * [json_encode](json#json_encode)
 
-## mappings
+## [mappings](mappings)
 
 * [element_of_weighted](mappings#element_of_weighted)
 * [pretty_map](mappings#pretty_map)
 
-## messaging
+## [messaging](messaging)
 
 * [tell](messaging#tell)
 * [tell_all](messaging#tell_all)
@@ -100,7 +100,7 @@ title: simul_efun
 * [tell_down](messaging#tell_down)
 * [tell_up](messaging#tell_up)
 
-## numbers
+## [numbers](numbers)
 
 * [percent](numbers#percent)
 * [percent_of](numbers#percent_of)
@@ -108,7 +108,7 @@ title: simul_efun
 * [remainder](numbers#remainder)
 * [sum](numbers#sum)
 
-## object
+## [object](object)
 
 * [find_ob](object#find_ob)
 * [get_living](object#get_living)
@@ -124,12 +124,12 @@ title: simul_efun
 * [this_caller](object#this_caller)
 * [top_environment](object#top_environment)
 
-## prompt
+## [prompt](prompt)
 
 * [prompt_colour](prompt#prompt_colour)
 * [prompt_password](prompt#prompt_password)
 
-## resolve_path
+## [resolve_path](resolve_path)
 
 * [resolve_dir](resolve_path#resolve_dir)
 * [resolve_file](resolve_path#resolve_file)
@@ -138,31 +138,31 @@ title: simul_efun
 * [valid_file](resolve_path#valid_file)
 * [valid_path](resolve_path#valid_path)
 
-## save
+## [save](save)
 
 * [assure_object_save_dir](save#assure_object_save_dir)
 * [object_save_directory](save#object_save_directory)
 * [object_save_file](save#object_save_file)
 
-## security
+## [security](security)
 
 * [adminp](security#adminp)
 * [devp](security#devp)
 * [is_member](security#is_member)
 * [wizardp](security#wizardp)
 
-## signal
+## [signal](signal)
 
 * [emit](signal#emit)
 * [signal_d](signal#signal_d)
 * [slot](signal#slot)
 * [unslot](signal#unslot)
 
-## socket
+## [socket](socket)
 
 * [dump_socket_status](socket#dump_socket_status)
 
-## string
+## [string](string)
 
 * [add_commas](string#add_commas)
 * [append](string#append)
@@ -177,7 +177,7 @@ title: simul_efun
 * [stringify](string#stringify)
 * [substr](string#substr)
 
-## system
+## [system](system)
 
 * [_error](system#_error)
 * [_info](system#_info)
@@ -200,14 +200,14 @@ title: simul_efun
 * [port](system#port)
 * [tmp_dir](system#tmp_dir)
 
-## time
+## [time](time)
 
 * [ldate](time#ldate)
 * [ltime](time#ltime)
 * [time_frac](time#time_frac)
 * [time_ms](time#time_ms)
 
-## user
+## [user](user)
 
 * [user_core_data_directory](user#user_core_data_directory)
 * [user_data_directory](user#user_data_directory)
@@ -215,7 +215,7 @@ title: simul_efun
 * [user_mob_data](user#user_mob_data)
 * [user_path](user#user_path)
 
-## util
+## [util](util)
 
 * [generate_uuid](util#generate_uuid)
 * [of](util#of)

--- a/doc/wiki/docs/simul_efun/object.md
+++ b/doc/wiki/docs/simul_efun/object.md
@@ -198,6 +198,7 @@ This is a simul_efun that will return the object that called
 the current operation. This may be this_body(), but it may
 also be a shadow another player who initiated the chain.
 For example, a wizard using the force command.
+
 Be careful with this one, you don't want to accidentally
 perform operations on the wrong object.
 

--- a/doc/wiki/docs/simul_efun/prompt.md
+++ b/doc/wiki/docs/simul_efun/prompt.md
@@ -23,6 +23,7 @@ Prompt the user for a colour. The user will be presented with a
 list of colours to choose from. The user can also enter a
 number corresponding to an xterm 256 colour, or the word "plain"
 to select no colour.
+
 Upon selection, the callback function will be called with the
 selected colour as the argument.
 

--- a/doc/wiki/docs/simul_efun/system.md
+++ b/doc/wiki/docs/simul_efun/system.md
@@ -330,6 +330,7 @@ int boot_number()
 ### Description
 
 Returns the boot number of the MUD. This is the number of
+times the MUD has been booted.
 
 ## log_dir
 


### PR DESCRIPTION
this PR adds the ability for autodoc to respect blank lines in multi-line tags.

for example, description. or example.

to do so, you need to tell it to expect such behaviour by adding the tag to the multi_line_tags array.

when parsing, it knows to then, if it sees a tag that is multine, will add new lines when it finds them.

otherwise, it just trims and joins like usual.