### PR TITLE
Switch configuration format from JSON to LPML

### DIFF
--- a/adm/daemons/config.c
+++ b/adm/daemons/config.c
@@ -3,12 +3,12 @@
  *
  * Configuration management daemon that provides a centralized system for
  * game settings. Uses a cascading configuration pattern where default values
- * are loaded from default.json and can be overridden by local settings in
- * config.json.
+ * are loaded from default.lpml and can be overridden by local settings in
+ * config.lpml.
  *
  * The two-file system enables:
- * - Default values stored in git (/adm/etc/default.json)
- * - Local overrides in /adm/etc/config.json (not in git)
+ * - Default values stored in git (/adm/etc/default.lpml)
+ * - Local overrides in /adm/etc/config.lpml (not in git)
  * - Easy upgrades without losing custom settings
  * - Environment-specific configurations
  *
@@ -25,10 +25,10 @@ inherit STD_DAEMON;
 public void rehash_config();
 public mixed get_mud_config(string key);
 
-private nosave string DEFAULT_CONFIG = "/adm/etc/default.json";
-private nosave string CONFIG_FILE = "/adm/etc/config.json";
+private nosave string DEFAULT_CONFIG = "/adm/etc/default.lpml";
+private nosave string CONFIG_FILE = "/adm/etc/config.lpml";
 private nosave mapping config = ([ ]);
-
+private nosave int loaded = false;
 /**
  * Initializes the configuration daemon.
  *
@@ -37,6 +37,8 @@ private nosave mapping config = ([ ]);
 void setup() {
   set_no_clean(1);
   rehash_config();
+
+  loaded = true;
 }
 
 /**
@@ -47,6 +49,9 @@ void setup() {
  * @errors If config is null, key is missing, or key is invalid
  */
 public mixed get_mud_config(string key) {
+  if(!loaded)
+    return null;
+
   if(nullp(config))
     error("get_mud_config: No configuration found.");
 
@@ -54,6 +59,7 @@ public mixed get_mud_config(string key) {
     error("get_mud_config: Missing key.");
 
   if(nullp(config[key]))
+    // return null;
     error("get_mud_config: Invalid key: " + key + ".");
 
   return config[key];
@@ -63,23 +69,25 @@ public mixed get_mud_config(string key) {
  * Reloads configuration from both default and override files.
  *
  * Loads and merges configurations in this order:
- * 1. /adm/etc/default.json - Base configuration
- * 2. /adm/etc/config.json - Local overrides
+ * 1. /adm/etc/default.lpml - Base configuration
+ * 2. /adm/etc/config.lpml - Local overrides
  *
  * Later values override earlier ones for the same keys.
  */
 public void rehash_config() {
   mapping temp;
 
+  debug_message(call_trace(false));
+
   if(file_exists(DEFAULT_CONFIG)) {
-    temp = json_decode(read_file(DEFAULT_CONFIG));
+    temp = lpml_decode(read_file(DEFAULT_CONFIG));
 
     if(mapp(temp))
       config += temp;
   }
 
   if(file_exists(CONFIG_FILE)) {
-    temp = json_decode(read_file(CONFIG_FILE));
+    temp = lpml_decode(read_file(CONFIG_FILE));
 
     if(mapp(temp))
       config += temp;

--- a/adm/etc/default.lpml
+++ b/adm/etc/default.lpml
@@ -1,124 +1,149 @@
-LIB_VERSION: 1.4.0
-LIB_NAME: gLPU
-OPEN_STATUS: Mudlib Development
-ADMIN_EMAIL: gesslar@gmail.com
-LOG_DIR: /log/
-LOG_CATCH: /log/catch
-LOG_RUNTIME: /log/runtime
-TMP_DIR: /tmp/
-DISPLAY_NEWS: true
-LOGIN_MSG: /adm/etc/login/splash
-LOGIN_NEWS: /adm/etc/login/motd
-FLOGIN_NEWS: /adm/etc/login/first_login
-FIRST_USER: /adm/etc/first_user
-ALLOW_SHUTDOWN:
-  - /adm/daemons/shutdown_d
-  - /adm/daemons/autodoc
-LOOK_HIGHLIGHT: on
-LOOK_HIGHLIGHT_COLOUR: "669"
-COLOUR_TOO_DARK: on
-COLOUR_MININUM_LUMINANCE: 50
-USE_MASS: true
-AUTODOC_SOURCE_DIRS:
-  - /adm/simul_efun/
-  - /adm/daemons/
-  - /std/modules/
-  - /std/object/
-DOC_DIR: /doc/
-AUTODOC_ROOT: /doc/autodoc/
-DOCS:
-  general:
-    - general
-    - game
-  developer:
-    - autodoc/daemon_function
-    - autodoc/efun_override
-    - autodoc/simul_efun
-    - autodoc/module_function
-    - autodoc/object_function
-CURRENCY:
-  - - copper
-    - 1
-  - - silver
-    - 10
-  - - gold
-    - 100
-  - - platinum
-    - 1000
-TIMEOUT_PLAYERS: on
-TIMEOUT_PLAYERS_TIME: 3600
-TIMEOUT_DEVS: off
-TIMEOUT_DEVS_TIME: 86400
-TIMEOUT_ADMINS: off
-TIMEOUT_ADMINS_TIME: 604800
-ALARMS: on
-ALARMS_PATH: /adm/etc/alarms/
-DB_PATH: /data/db/
-DB_SUFFIX: .sqlite3
-DB_TABLE_SUFFIX: .tbl
-DB_CHUNK_SIZE: 100
-DECIMAL: .
-THOUSANDS: ","
-MORELINES: 40
-PAGE_DISPLAY: line
-HEART_PULSE: 2000
-HEARTBEATS_TO_REGEN: 5
-DEFAULT_HEART_RATE: 10
-OBJECT_DATA_DIR: /data/obj/
-DEFAULT_RACE: human
-DAMAGE_LEVEL_MODIFIER: 25
-DEFAULT_HIT_CHANCE: 65
-PLAYER_AUTOLEVEL: true
-BASE_TNL: 100
-TNL_RATE: 1.25
-OVERLEVEL_THRESHOLD: 5
-OVERLEVEL_XP_PUNISH: 0.05
-UNDERLEVEL_THRESHOLD: 0
-UNDERLEVEL_XP_BONUS: 0.05
-ALLOW_RECURSE_RMDIR:
-  - /adm/daemons/autodoc
-  - /cmds/file/rm
-SKILLS:
-  combat:
-    defense:
-      - dodge
-      - parry
-    melee:
-      - attack
-      - bludgeoning
-      - piercing
-      - slashing
-      - unarmed
-  social:
-    - barter
-    - charm
-    - intimidate
-    - persuade
-  general:
-    - appraise
-    - hide
-    - jump
-    - listen
-    - search
-    - spot
-    - swim
-ATTRIBUTES:
-  - strength
-  - dexterity
-  - constitution
-  - intelligence
-  - wisdom
-  - charisma
-STORAGE_DATA_DIR: /data/storage/
-GUI: true
-WAYPOINTS_MAX: 10
-TRAVEL_DESTINATIONS:
-  bank: /d/village/financier
-  bakery: /d/village/bakery
-  lockers: /d/village/lockers
-  square: /d/village/square
-  shop: /d/village/shop
-  tavern: /d/village/tavern
-  centre: /d/village/centre
-COIN_VALUE_PER_LEVEL: 15
-COIN_VARIANCE: 0.25
+{
+  LIB_VERSION: "1.4.0",
+  LIB_NAME: "gLPU",
+  OPEN_STATUS: "Mudlib Development",
+  ADMIN_EMAIL: "gesslar@gmail.com",
+  LOG_DIR: "/log/",
+  LOG_CATCH: "/log/catch",
+  LOG_RUNTIME: "/log/runtime",
+  TMP_DIR: "/tmp/",
+  DISPLAY_NEWS: true,
+  LOGIN_MSG: "/adm/etc/login/splash",
+  LOGIN_NEWS: "/adm/etc/login/motd",
+  FLOGIN_NEWS: "/adm/etc/login/first_login",
+  FIRST_USER: "/adm/etc/first_user",
+  ALLOW_SHUTDOWN: [
+    "/adm/daemons/shutdown_d",
+    "/adm/daemons/autodoc",
+  ],
+  LOOK_HIGHLIGHT: "on",
+  LOOK_HIGHLIGHT_COLOUR: "669",
+  COLOUR_TOO_DARK: "on",
+  COLOUR_MININUM_LUMINANCE: 50,
+  USE_MASS: true,
+  AUTODOC_SOURCE_DIRS: [
+    "/adm/simul_efun/",
+    "/adm/daemons/",
+    "/std/modules/",
+    "/std/object/",
+  ],
+  DOC_DIR: "/doc/",
+  AUTODOC_ROOT: "/doc/autodoc/",
+  DOCS: {
+    general: [
+      "general",
+      "game",
+    ],
+    developer: [
+      "autodoc/daemon_function",
+      "autodoc/efun_override",
+      "autodoc/simul_efun",
+      "autodoc/module_function",
+      "autodoc/object_function",
+    ],
+  },
+  CURRENCY: [
+    [
+      "copper",
+      1,
+    ],
+    [
+      "silver",
+      10,
+    ],
+    [
+      "gold",
+      100,
+    ],
+    [
+      "platinum",
+      1000,
+    ],
+  ],
+  TIMEOUT_PLAYERS: "on",
+  TIMEOUT_PLAYERS_TIME: 3600,
+  TIMEOUT_DEVS: "off",
+  TIMEOUT_DEVS_TIME: 86400,
+  TIMEOUT_ADMINS: "off",
+  TIMEOUT_ADMINS_TIME: 604800,
+  ALARMS: "on",
+  ALARMS_PATH: "/adm/etc/alarms/",
+  DB_PATH: "/data/db/",
+  DB_SUFFIX: ".sqlite3",
+  DB_TABLE_SUFFIX: ".tbl",
+  DB_CHUNK_SIZE: 100,
+  DECIMAL: ".",
+  THOUSANDS: ",",
+  MORELINES: 40,
+  PAGE_DISPLAY: "line",
+  HEART_PULSE: 2000,
+  HEARTBEATS_TO_REGEN: 5,
+  DEFAULT_HEART_RATE: 10,
+  OBJECT_DATA_DIR: "/data/obj/",
+  DEFAULT_RACE: "human",
+  DAMAGE_LEVEL_MODIFIER: 25,
+  DEFAULT_HIT_CHANCE: 65,
+  PLAYER_AUTOLEVEL: true,
+  BASE_TNL: 100,
+  TNL_RATE: 1.25,
+  OVERLEVEL_THRESHOLD: 5,
+  OVERLEVEL_XP_PUNISH: 0.05,
+  UNDERLEVEL_THRESHOLD: 0,
+  UNDERLEVEL_XP_BONUS: 0.05,
+  ALLOW_RECURSE_RMDIR: [
+    "/adm/daemons/autodoc",
+    "/cmds/file/rm",
+  ],
+  SKILLS: {
+    combat: {
+      defense: [
+        "dodge",
+        "parry",
+      ],
+      melee: [
+        "attack",
+        "bludgeoning",
+        "piercing",
+        "slashing",
+        "unarmed",
+      ],
+    },
+    social: [
+      "barter",
+      "charm",
+      "intimidate",
+      "persuade",
+    ],
+    general: [
+      "appraise",
+      "hide",
+      "jump",
+      "listen",
+      "search",
+      "spot",
+      "swim",
+    ],
+  },
+  ATTRIBUTES: [
+    "strength",
+    "dexterity",
+    "constitution",
+    "intelligence",
+    "wisdom",
+    "charisma",
+  ],
+  STORAGE_DATA_DIR: "/data/storage/",
+  GUI: true,
+  WAYPOINTS_MAX: 10,
+  TRAVEL_DESTINATIONS: {
+    bank: "/d/village/financier",
+    bakery: "/d/village/bakery",
+    lockers: "/d/village/lockers",
+    square: "/d/village/square",
+    shop: "/d/village/shop",
+    tavern: "/d/village/tavern",
+    centre: "/d/village/centre",
+  },
+  COIN_VALUE_PER_LEVEL: 15,
+  COIN_VARIANCE: 0.25,
+}

--- a/adm/etc/mssp.example.lpml
+++ b/adm/etc/mssp.example.lpml
@@ -1,35 +1,37 @@
-HOSTNAME: localhost
-CRAWL DELAY: "-1"
-CODEBASE: Custom (LPU)
-CONTACT: admin@localhost
-CREATED: "2024"
-ICON: https://localhost/icon.jpg
-IP: 127.0.0.1
-LANGUAGE: English
-LOCATION: CA
-MINIMUM AGE: "18"
-WEBSITE: https://www.localhost.com/
-FAMILY: LPMud
-GENRE: Fantasy
-SUBGENRE: Medieval Fantasy
-GAMEPLAY: Adventure
-GAMESYSTEM: Custom
-INTERMUD: ""
-STATUS: Development
-CLASSES: "0"
-CLASSES-NOTES: No classes as yet.
-RACES: "0"
-RACES-NOTES: No races as yet.
-ANSI: "1"
-MCP: "0"
-MSP: "0"
-PUEBLO: "0"
-VT100: "0"
-SSL: "0"
-XTERM 256 COLORS: "1"
-XTERM TRU COLORS: "0"
-PAY TO PLAY: "0"
-PAY FOR PERKS: "0"
-HIRING BUILDERS: "0"
-HIRING CODERS: "0"
-DISCORD: https://discord.gg/XXXXXXXXXXX
+{
+  HOSTNAME: "localhost",
+  CRAWL DELAY: "-1",
+  CODEBASE: "Custom (LPU)",
+  CONTACT: "admin@localhost",
+  CREATED: "2024",
+  ICON: "https://localhost/icon.jpg",
+  IP: "127.0.0.1",
+  LANGUAGE: "English",
+  LOCATION: "CA",
+  MINIMUM AGE: "18",
+  WEBSITE: "https://www.localhost.com/",
+  FAMILY: "LPMud",
+  GENRE: "Fantasy",
+  SUBGENRE: "Medieval Fantasy",
+  GAMEPLAY: "Adventure",
+  GAMESYSTEM: "Custom",
+  INTERMUD: "",
+  STATUS: "Development",
+  CLASSES: "0",
+  CLASSES-NOTES: "No classes as yet.",
+  RACES: "0",
+  RACES-NOTES: "No races as yet.",
+  ANSI: "1",
+  MCP: "0",
+  MSP: "0",
+  PUEBLO: "0",
+  VT100: "0",
+  SSL: "0",
+  XTERM 256 COLORS: "1",
+  XTERM TRU COLORS: "0",
+  PAY TO PLAY: "0",
+  PAY FOR PERKS: "0",
+  HIRING BUILDERS: "0",
+  HIRING CODERS: "0",
+  DISCORD: "https://discord.gg/XXXXXXXXXXX",
+}

--- a/adm/etc/time/months.lpml
+++ b/adm/etc/time/months.lpml
@@ -1,36 +1,62 @@
-- - Aube
-  - 30
-  - winter
-- - Crowning
-  - 30
-  - winter
-- - Krelia
-  - 30
-  - spring
-- - Norebe
-  - 30
-  - spring
-- - Symka
-  - 30
-  - spring
-- - Median
-  - 30
-  - summer
-- - Teiris
-  - 30
-  - summer
-- - Dysis
-  - 30
-  - summer
-- - Imin
-  - 30
-  - autumn
-- - Tiide
-  - 30
-  - autumn
-- - Cresting
-  - 30
-  - autumn
-- - Zenith
-  - 30
-  - winter
+[
+  [
+    'Aube',
+    30,
+    'winter',
+  ],
+  [
+    'Crowning',
+    30,
+    'winter',
+  ],
+  [
+    'Krelia',
+    30,
+    'spring',
+  ],
+  [
+    'Norebe',
+    30,
+    'spring',
+  ],
+  [
+    'Symka',
+    30,
+    'spring',
+  ],
+  [
+    'Median',
+    30,
+    'summer',
+  ],
+  [
+    'Teiris',
+    30,
+    'summer',
+  ],
+  [
+    'Dysis',
+    30,
+    'summer',
+  ],
+  [
+    'Imin',
+    30,
+    'autumn',
+  ],
+  [
+    'Tiide',
+    30,
+    'autumn',
+  ],
+  [
+    'Cresting',
+    30,
+    'autumn',
+  ],
+  [
+    'Zenith',
+    30,
+    'winter',
+  ],
+]

--- a/adm/etc/time/seasons.lpml
+++ b/adm/etc/time/seasons.lpml
@@ -1,4 +1,6 @@
-- spring
-- summer
-- autumn
-- winter
+[
+  'spring',
+  'summer',
+  'autumn',
+  'winter',
+]

--- a/adm/etc/time/time.lpml
+++ b/adm/etc/time/time.lpml
@@ -1,4 +1,6 @@
-epoch_start: 1704085200
-year_start: 100
-hour_length: 600
-hours_per_day: 24
+{
+  epoch_start: 1704085200,
+  year_start: 100,
+  hour_length: 600,
+  hours_per_day: 24,
+}

--- a/adm/include/simul_efun.h
+++ b/adm/include/simul_efun.h
@@ -108,7 +108,8 @@ mixed json_decode(string str);
 mapping json_encode(mixed arg);
 
 // File: lpml.c
-mixed lpml_decode(string text);
+mixed lpml_decode(string text, string path);
+mixed lpml_encode(string text);
 
 // File: mapping.c
 string pretty_map(mapping map);

--- a/adm/simul_efun/lpml.c
+++ b/adm/simul_efun/lpml.c
@@ -1,639 +1,1058 @@
-#include <simul_efun.h>
-
 /**
- * @file /adm/simul_efun/lpml.c
+ * lpml.c (LPML implementation)
  *
- * YAML-flavoured parser and decoder for LPC. Provides functionality to parse
- * LPML format into LPC data structures (mappings and arrays).
+ * LPML (LPC Markup Language) - A human-friendly config format for MUDs
+ * Based on JSON5 with LPC-specific extensions
  *
- * @created 2025-04-06 - Gesslar
- * @last_modified 2025-04-06 - Gesslar
+ * Features supported:
+ * - Single and multi-line comments (// and \/* *\/)
+ * - Unquoted object keys (identifiers)
+ * - Single-quoted strings ('string')
+ * - Multiline strings with automatic folding (real newlines → spaces)
+ * - String concatenation: adjacent strings auto-join with smart spacing
+ * - Trailing commas in objects and arrays
+ * - Hexadecimal numbers (0xFF)
+ * - Leading/trailing decimal points (.5, 5.)
+ * - Plus sign on numbers (+5)
+ * - Infinity and NaN
+ * - File includes with "#path" syntax (use \# to escape literal #)
  *
- * @history
- * 2025-04-06 - Gesslar - Created
+ * mixed lpml_decode(string text, string base_path)
+ *     Deserializes LPML into an LPC value.
+ *     base_path is optional, used for resolving relative includes.
+ *
+ * string lpml_encode(mixed value)
+ *     Serializes an LPC value into JSON text.
+ *
+ * @created 2025-11-09 - Gesslar
+ * @version 1.0.0
+ * @see /doc/lpml-spec.md for full specification
  */
 
-#define LP_SEQ_ELEMENT          "LP_SEQ_ELEMENT"
-#define LP_BLOCK_START          "LP_BLOCK_START"
-#define LP_KV_PAIR              "LP_KV_PAIR"
-#define LP_COMMENT              "LP_COMMENT"
-#define LP_BLANK                "LP_BLANK"
-#define LP_MULTILINE_JOIN       "LP_MULTILINE_JOIN"
-#define LP_MULTILINE_PRESERVE   "LP_MULTILINE_PRESERVE"
-#define LP_MERGE_START          "LP_MERGE_START"
-#define LP_MERGE_INLINE         "LP_MERGE_INLINE"
-#define LP_UNKNOWN              "LP_UNKNOWN"
+#ifndef __STD_LPML_H
+#define __STD_LPML_H
 
-#define LP_ML_STRIP             "-"
-#define LP_ML_KEEP              "+"
-#define LP_ML_CLIP              ([])[0]
+#define to_string(x)                ("\\" + (x))
 
-#define PAGE_TITLE  0
-#define PAGE_SOURCE 1
-#define PAGE_RESULT 2
+#define LPML_DECODE_PARSE_TEXT      0
+#define LPML_DECODE_PARSE_POS       1
+#define LPML_DECODE_PARSE_LINE      2
+#define LPML_DECODE_PARSE_CHAR      3
+#define LPML_DECODE_PARSE_FIELDS    4
 
-private mixed *detect_line_type(string line);
-private int first_non_space(string text);
-varargs private mixed *parse_block(string *lines, mixed *pages, int curr_indent, int indent);
-private mixed lpml_parse_scalar(string val, mixed *pages);
-private string remove_inline_comment(string line);
-private mixed lpml_inherit(string text, mixed *pages);
-private mixed *paginate_document(string text);
-private string multiline_chomp(string text, string kind, string mode);
+private mixed lpml_decode_parse_value(mixed* parse);
+private varargs mixed lpml_decode_parse_string(mixed* parse, int quote_char);
+private string lpml_decode_parse_identifier(mixed* parse);
+private string lpml_decode_parse_spacey_key(mixed* parse);
 
-/**
- * Decodes a LPML string into LPC data structures.
- *
- * This function serves as the main entry point for LPML parsing, converting
- * a LPML formatted string into corresponding LPC mappings and arrays.
- *
- * @public
- * @param {string} text - The LPML text to decode
- * @returns {mixed} The parsed LPC data structure (mapping or array)
- * @example
- * mapping data = lpml_decode("key: value\nlist:\n  - item1\n  - item2");
- */
-public mixed lpml_decode(string text) {
-  mixed *pages = paginate_document(text);
-  int i, sz;
+// If at or below the relative path. We do not do multi-cross-traversal.
+// examples:
+//
+// good: ./file.txt
+//       ./subdir/file.txt
+//       ../file.txt
+//       ../../somedir/file.txt
+// bad:  ./../what/no.txt
+//       ../.././stop/it.c
+private string resolve_relative_path(string relative_path, string relative_to) {
+  string *relative_path_parts;
+  string *relative_to_parts;
 
-  for(i = 0, sz = sizeof(pages); i< sz; i++) {
-    mixed  *page;
-    string *lines;
-    string *page_result;
+  // If we don't have a valid string, the relative path is absolute, or
+  // we don't even have enough to work with, yeet it back. Similar tests
+  // for the relative_to.
+  if(!stringp(relative_path) ||
+     !strlen(relative_path) ||
+     relative_path[0] == '/' ||
 
-    page = pages[i];
+     !stringp(relative_to) ||
+     !strlen(relative_to ||
+     relative_to[0] != '/'))
 
-    // We need to always include a leading line feed, because
-    // explode removes the first one, if present. Don't worry
-    // about it. 😏
-    lines = explode("\n"+page[PAGE_SOURCE], "\n");
-    page_result = parse_block(lines, pages, 0)[0];
+    return relative_path;
 
-    pages[i][PAGE_RESULT] = page_result;
-  }
+  relative_path_parts = explode(relative_path, "/");
+  relative_path_parts = map(relative_path_parts, (: trim :));
+  relative_path_parts = filter(relative_path_parts, (: strlen :));
 
-  return pages[<1][PAGE_RESULT];
-}
+  relative_to_parts = explode(relative_to, "/");
+  relative_to_parts = map(relative_to_parts, (: trim :));
+  relative_to_parts = filter(relative_to_parts, (: strlen :));
 
-/**
- * Divides a LPML document into pages based on document separators.
- *
- * Pages in LPML are separated by "---" on a line by itself. Each page can
- * optionally have a title prefixed with "#@" on the first line. This function
- * splits the document into pages and prepares them for parsing.
- *
- * @private
- * @param {string} text - The complete LPML document text
- * @returns {mixed*} An array of page data, each containing title, source, and result
- */
-private mixed *paginate_document(string text) {
-  string *pages;
-  mixed *result;
-  int i, sz;
+  if(relative_path_parts[0] == "..") {
+    while(relative_path_parts[0] == "..") {
 
-  pages = explode(text, "---\n");
-  sz = sizeof(pages);
-  result = allocate(sz);
+      if(!sizeof(relative_to_parts))
+        error(
+          "Invalid path relative resolution to '"+relative_path+"' "
+          "from '"+relative_to+"'"
+        );
 
-  for(; i < sz; i++) {
-    string page = pages[i];
-    int first_eol;
-    string page_title;
-
-    // Append a newline to the end of the page if it doesn't already have one.
-    page = page[<1] == '\n' ? page : page + "\n";
-
-    first_eol = strsrch(page, "\n");
-    if(sscanf(page[0..first_eol-1], "#@%s", page_title) == 1) {
-      page = page[first_eol+1..];
-    } else {
-      page_title = sprintf("%d", i);
+      relative_path_parts = ({relative_to_parts[<1]}) + relative_path_parts;
+      relative_to_parts = relative_to_parts[0..<2];
     }
 
-    result[i] = ({ page_title, page, ([])[0] });
+    return sprintf("/%s/%s",
+      implode(relative_to_parts, "/"),
+      implode(relative_path_parts, "/")
+    );
   }
 
-  return result;
+  if(relative_path_parts[0] == ".")
+    relative_path_parts = relative_path_parts[1..];
+
+  return sprintf("/%s/%s",
+    implode(relative_to_parts, "/"),
+    implode(relative_path_parts, "/")
+  );
 }
 
 /**
- * Analyzes a line of LPML text to determine its type and structure.
- *
- * This function examines a line of LPML and identifies what kind of construct it
- * represents (e.g., sequence element, key-value pair, comment, etc.). It returns
- * an array containing the line type and any relevant extracted values.
- *
- * @private
- * @param {string} line - The line of LPML text to analyze
- * @param {int} indent - The current indentation level
- * @returns {mixed*} An array where the first element is the line type constant
- *                  and subsequent elements contain extracted values if applicable
+ * Advances the parse position by one character.
  */
-private mixed *detect_line_type(string line) {
-  string key, val, item;
-
-  line = ltrim(line);
-
-  if(line == "")
-    return ({ LP_BLANK });
-
-  // Return comment type for empty lines or lines starting with #
-  if(pcre_match(line, "^\\s*#"))
-    return ({ LP_COMMENT });
-
-  // Handle merge directives for inheritance/composition
-  if(sscanf(line, "- <<: %s", item) == 1)
-    return ({ LP_MERGE_INLINE, item });
-  if(sscanf(line, "<<: %s", item) == 1)
-    return ({ LP_MERGE_INLINE, item });
-  if(pcre_match(line, "^(?:(- )?)<<:$"))
-    return ({ LP_MERGE_START });
-
-  // Handle sequence elements (list items starting with -)
-  if(sscanf(line, "- %s", item) == 1)
-    return ({ LP_SEQ_ELEMENT, item });
-
-  { // Multiline string modes block
-    string mode;
-
-    // Check for preserved multiline (|) or folded multiline (>)
-    // Optional chomping indicators can follow (-, +, or none/clip)
-    if(sscanf(line, "%s: |%s", key, mode) >= 1)
-      return ({ LP_MULTILINE_PRESERVE, key, mode });
-
-    if(sscanf(line, "%s: >%s", key, mode) >= 1)
-      return ({ LP_MULTILINE_JOIN, key, mode });
-  }
-
-  // Standard key-value pairs (key: value)
-  if(sscanf(line, "%s: %s", key, val) == 2)
-    return ({ LP_KV_PAIR, key, val });
-
-  // Block scalar indicators (key: followed by indented block)
-  if(sscanf(line, "%s:", key) == 1)
-    return ({ LP_BLOCK_START, key });
-
-  // Anything not matching above patterns is considered unknown
-  return ({ LP_UNKNOWN, line });
+private void lpml_decode_parse_next_char(mixed* parse) {
+    parse[LPML_DECODE_PARSE_POS]++;
+    parse[LPML_DECODE_PARSE_CHAR]++;
 }
 
 /**
- * Finds the position of the first non-space character in a string.
- *
- * @private
- * @param {string} text - The string to examine
- * @returns {int} The position of the first non-space character, or
- *               the length of the string if it contains only spaces
+ * Advances the parse position by the specified number of characters.
  */
-private int first_non_space(string text) {
-  int x, len = strlen(text);
-
-  while(text[x++] == ' ' && x < len);
-
-  return x - 1;
-}
-
-private int find_next_line(string *lines, int curr) {
-  int sz = sizeof(lines);
-
-  while(++curr < sz) {
-    string *line_info = detect_line_type(lines[curr]);
-    // printf("Testing line %d of %d: %O\n", curr, sz, lines[curr]);
-    if(line_info[0] != LP_BLANK && line_info[0] != LP_COMMENT)
-      return curr;
-  }
-
-  return curr;
+private void lpml_decode_parse_next_chars(mixed* parse, int num) {
+    parse[LPML_DECODE_PARSE_POS] += num;
+    parse[LPML_DECODE_PARSE_CHAR] += num;
 }
 
 /**
- * Recursively parses a block of LPML text into LPC data structures.
- *
- * This function processes multiple lines of LPML text, handling indentation
- * and nested structures to build the appropriate LPC data structures.
- *
- * @param {string*} lines - Array of LPML text lines to parse
- * @param {int} curr_indent - The current indentation level
- * @param {int} [indent=0] - The indentation step size
- * @returns {mixed*} An array containing the parsed result and the number of lines processed
- * @private
+ * Advances the parse position to the next line.
  */
-// Recursive block parsing - this is the heart of the LPML parser
-varargs private mixed *parse_block(string *lines, mixed *pages, int curr_indent, int indent) {
-  int curr;
-  int sz = sizeof(lines);
-  mixed result;
-  string line, *line_info, line_type;
+private void lpml_decode_parse_next_line(mixed* parse) {
+    parse[LPML_DECODE_PARSE_POS]++;
+    parse[LPML_DECODE_PARSE_LINE]++;
+    parse[LPML_DECODE_PARSE_CHAR] = 1;
+}
 
-  if(!sz)
-    return ({ ([]), 0 });
+/**
+ * Skips whitespace and comments
+ */
+private void lpml_decode_skip_whitespace_and_comments(mixed* parse) {
+  int ch, next_ch;
 
-  // Find the first non-comment line, we use -1 to start from the beginning
-  // printf("Lines 0 = %O\n", lines[0]);
-  curr = find_next_line(lines, -1);
-  // printf("\n[[  Next line number = %d  ]]\n\n", curr);
-  if(curr >= sz)
-    return ({ ([]), 0 });
+  while(parse[LPML_DECODE_PARSE_POS] < sizeof(parse[LPML_DECODE_PARSE_TEXT])) {
+    ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
 
-  // We need to determine the shape of our block. These will get overwritten during
-  // the loop.
-  line = lines[curr];
-  line_info = detect_line_type(line);
-
-  // If it's a block, initialize the result as a mapping
-  if(line_info[0] == LP_BLOCK_START)
-    result = ([]);
-  // If it's a sequence element, initialize as an array
-  else if(line_info[0] == LP_SEQ_ELEMENT)
-    result = ({});
-  // For now, at least, let's just be an error. We will
-  // update this later to allow primitives. Maybe. Somehow.
-  else
-    // error("Invalid block type: " + line_info[0]);
-    result = ([]);
-
-  do {
-    int line_indent;
-    string key;
-    mixed value;
-
-    // printf("Line %d = %s\n", curr, lines[curr]);
-
-    line = lines[curr];
-    line = rtrim(remove_inline_comment(line));
-    line_info = detect_line_type(line);
-    line_type = line_info[0];
-    key = line_info[1];
-    line_indent = first_non_space(line);
-
-    // printf("Parsing block at line %d: %s\n", curr, line_info[0]);
-    // printf("Current line: %s\n", line);
-
-    // End of block - return the accumulated result
-    // printf("Comparing indentation: detected %d < passed %d\n", line_indent, indent);
-    if(line_indent < indent) {
-      // printf("New block at line %d\n", curr);
-      // printf("%O\n", ({ result, curr }));
-      break;
-      // return ({ result, curr });
-    } else if(line_indent > indent) {
-      // printf("Indentation increased at line %d from %d to %d\n", curr, indent, line_indent);
-      curr_indent++;
-      indent = line_indent;
+    // Whitespace
+    if(ch == ' ' || ch == '\t' || ch == '\r') {
+      lpml_decode_parse_next_char(parse);
+      continue;
     }
 
-    switch(line_type) {
-      case LP_BLOCK_START: {
-        mixed *sub;
+    if(ch == '\n' || ch == 0x0c) {
+      lpml_decode_parse_next_line(parse);
+      continue;
+    }
 
-        // printf("\n");
-        // printf("Key %O leads to line: %O\n", key, lines[curr+1]);
-        sub = parse_block(lines[curr+1..], pages, curr_indent, line_indent);
-        // printf("Result from parse_block = %O\n", sub);
-        value = sub[0];
-        curr += sub[1];
-        // printf("We ended key %O at line %d\n", key, sub[1]);
+    // Comments
+    if(ch == '/') {
+      next_ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS] + 1];
 
-        // printf("Adding to key %O`: %O\n", key, json_encode(value));
-
-        result[key] = value;
-        break;
-      }
-
-      // Complex parsing logic for handling merge directives
-      case LP_MERGE_START: {
-        // Tracks lines in the current merge block for processing
-        string *merge_lines = ({});
-
-        // Process each line that's more indented than current level
-        while(++curr < sz && first_non_space(lines[curr]) > indent) {
-          string val;
-          mixed merge_result;
-
-          // Only process lines that start with "- " (list items)
-          if(sscanf(trim(lines[curr]), "- %s", val) != 1)
-            continue;
-
-          merge_result = lpml_inherit(val, pages);
-
-          // Handle type coercion based on context:
-          // Array + Array = Concatenate arrays
-          // Array + Non-Array = Append non-array as element
-          // Otherwise = Combine mappings
-          if(typeof(result) == T_ARRAY && typeof(merge_result) == T_ARRAY) {
-            result += merge_result;
-          } else if(typeof(result) == T_ARRAY && typeof(merge_result) != T_ARRAY) {
-            result += ({ merge_result });
-          } else {
-            result += merge_result;
-          }
+      // Single-line comment
+      if(next_ch == '/') {
+        while(parse[LPML_DECODE_PARSE_POS] < sizeof(parse[LPML_DECODE_PARSE_TEXT]) &&
+              parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]] != '\n') {
+          lpml_decode_parse_next_char(parse);
         }
-
-        break;
+        continue;
       }
 
-      case LP_MERGE_INLINE: {
-        mixed pre;
+      // Multi-line comment
+      if(next_ch == '*') {
+        lpml_decode_parse_next_char(parse);  // Skip /
+        lpml_decode_parse_next_char(parse);  // Skip *
 
-        pre = lpml_parse_scalar(line_info[1], pages);
+        while(parse[LPML_DECODE_PARSE_POS] + 1 < sizeof(parse[LPML_DECODE_PARSE_TEXT])) {
+          ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+          next_ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS] + 1];
 
-        if(!stringp(pre) && !pointerp(pre))
-          error("Invalid merge inline value: " + pre);
-
-        if(stringp(pre))
-          pre = ({ pre });
-
-        foreach(string inc in pre) {
-          mixed merge_result;
-
-          if(!stringp(inc))
-            error("Invalid merge inline value: " + inc);
-
-          merge_result = lpml_inherit(inc, pages);
-          if(typeof(result) == T_ARRAY && typeof(merge_result) == T_ARRAY) {
-            result += merge_result;
-          } else if(typeof(result) == T_ARRAY && typeof(merge_result) != T_ARRAY) {
-            result += ({ merge_result });
-          } else {
-            result += merge_result;
-          }
-        }
-
-        break;
-      }
-
-      case LP_SEQ_ELEMENT: {
-        // We might have another array here, so, let's see!
-        string trimmed = ltrim(line);
-        mixed *subdetected = detect_line_type(trimmed[2..]);
-        string item_type = subdetected[0];
-        string item = subdetected[1];
-        mixed *sub;
-
-        if(item_type == LP_SEQ_ELEMENT) {
-          string *seq_lines = ({ trimmed[2..] });
-          int i = curr + 1;
-
-          while(i < sz && first_non_space(lines[i]) > indent) {
-            seq_lines += ({ trim(lines[i]) });
-            i++;
-          }
-
-          sub = parse_block(seq_lines, pages, curr_indent, indent);
-          value = sub[0];
-          curr += sub[1];
-        } else {
-          value = lpml_parse_scalar(item, pages);
-        }
-
-        result += ({ value });
-
-        break;
-      }
-
-      // Handle key-value pairs (key: value)
-      case LP_KV_PAIR: {
-        string block;
-        string val = line_info[2];
-
-        if(undefinedp(val) || val == "") {
-          mixed* sub = parse_block(lines[curr + 1..], pages, curr_indent, indent);
-          value = sub[0];
-          curr += sub[1];
-        } else {
-          value = lpml_parse_scalar(val, pages);
-        }
-
-        result[key] = value;
-        break;
-      }
-
-      case LP_MULTILINE_JOIN:
-      case LP_MULTILINE_PRESERVE: {
-        string block = "";
-        string mode = line_info[2];
-        string chunk;
-        string *inner_info;
-        string chunk_type;
-        int i = curr + 1;
-
-        do {
-          line = lines[i];
-          chunk = ltrim(line, " ");
-          inner_info = detect_line_type(chunk);
-          chunk_type = inner_info[0];
-
-          // printf("> Chunk type is [%s]: %O\n", chunk_type, chunk);
-
-          if(chunk_type == LP_BLANK ||
-             chunk_type == LP_COMMENT ||
-             chunk_type == LP_UNKNOWN) {
-            if(line_type == LP_MULTILINE_PRESERVE) {
-              chunk += "\n";
-            } else {
-              if(chunk_type == LP_BLANK) {
-                chunk += " ";
-              }
-            }
-          } else {
+          if(ch == '*' && next_ch == '/') {
+            lpml_decode_parse_next_char(parse);  // Skip *
+            lpml_decode_parse_next_char(parse);  // Skip /
             break;
           }
 
-          block += chunk, i++;
-        } while(i < sz && first_non_space(lines[i]) > indent);
+          if(ch == '\n') {
+            lpml_decode_parse_next_line(parse);
+          } else {
+            lpml_decode_parse_next_char(parse);
+          }
+        }
 
-        // Trim leading blank lines only if mode isn't KEEP
-        if(mode != LP_ML_KEEP)
-          block = ltrim(block, "\n");
-
-        result[key] = multiline_chomp(block, line_type, mode);
-
-        break;
+        continue;
       }
     }
-  } while((curr = find_next_line(lines, curr)) < sz);
 
-  // printf("@@@ Returning at line [%2d] of [%2d] - %O\n", curr, sz, curr == sz ? "DONE" : lines[curr]);
-  // printf("@@@ %O\n", ({ result, curr }));
-  return ({ result, curr });
+    // Not whitespace or comment
+    break;
+  }
 }
 
 /**
- * Processes multiline text according to specified chomping rules.
- *
- * This function handles LPML's multiline string handling, applying chomping
- * (trailing whitespace handling) based on the provided mode:
- * - STRIP (-): Remove all trailing whitespace
- * - KEEP (+): Keep all trailing whitespace and add a newline
- * - CLIP (default): Context-dependent handling based on kind
- *
- * @private
- * @param {string} text - The multiline text to process
- * @param {string} kind - The multiline mode (LP_MULTILINE_JOIN or LP_MULTILINE_PRESERVE)
- * @param {string} mode - The chomping mode (LP_ML_STRIP, LP_ML_KEEP, or LP_ML_CLIP)
- * @returns {string} The processed multiline text with appropriate chomping applied
+ * Converts a hexadecimal character to its integer value.
  */
-private string multiline_chomp(string text, string kind, string mode) {
-  // For joined multiline (>), handle chomping modes:
-  // STRIP (-): Remove all trailing whitespace
-  // KEEP (+): Keep all whitespace and add newline
-  // CLIP (default): Remove trailing space but keep one newline
-  if(kind == LP_MULTILINE_JOIN)
-    text =   (mode == LP_ML_STRIP) ? rtrim(text)
-           : (mode == LP_ML_KEEP)  ? text + "\n"
-           : rtrim(text) + "\n"; // default LP_ML_CLIP
-
-  // For preserved multiline (|), handle chomping modes:
-  // STRIP (-): Remove all trailing newlines
-  // KEEP (+): Keep all newlines and add one more
-  // CLIP (default): Keep existing newlines as is
-  if(kind == LP_MULTILINE_PRESERVE)
-    text =   (mode == LP_ML_STRIP) ? rtrim(text, "\n")
-           : (mode == LP_ML_KEEP)  ? text + "\n"
-           : text; // default LP_ML_CLIP
-
-  return text;
+private int lpml_decode_hexdigit(int ch) {
+  if(ch >= '0' && ch <= '9') return ch - '0';
+  if(ch >= 'a' && ch <= 'f') return ch - 'a' + 10;
+  if(ch >= 'A' && ch <= 'F') return ch - 'A' + 10;
+  return -1;
 }
 
 /**
- * Parses a LPML scalar value into its appropriate LPC type.
- *
- * This function handles conversion of LPML scalar values into appropriate
- * LPC data types, including numbers, booleans, strings, null values, and
- * inline arrays/mappings.
- *
- * @param {string} val - The LPML scalar value to parse
- * @returns {mixed} The parsed LPC representation of the scalar
- * @private
+ * Checks if the parse position matches the specified token.
  */
-// Handle inline arrays and mappings in scalar values
-private mixed lpml_parse_scalar(string val, mixed *pages) {
-  // Type conversion variables
-  int intval;
-  float fval;
+private varargs int lpml_decode_parse_at_token(mixed* parse, string token, int start) {
+  int i, j;
 
-  // Process inline array notation [item1, item2, ...]
-  if(val[0] == '[' && val[<1] == ']') {
-    // Transform each item into a sequence element for consistent parsing
-    string* parts = map(explode(val[1..<2], ","), (: trim($1) :));
-    string* seq_lines = map(parts, (: "- " + $1 :));  // Convert to LPML sequence format
+  for(i = start, j = strlen(token); i < j; i++)
+    if(parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS] + i] != token[i])
+      return 0;
 
-    return parse_block(seq_lines, pages, 0, 0)[0];
+  return 1;
+}
+
+/**
+ * Raises a parse error with the specified message and character.
+ */
+private varargs void lpml_decode_parse_error(mixed* parse, string msg, int ch) {
+  if(!nullp(ch))
+    msg = sprintf("%s, '%c'", msg, ch);
+
+  msg = sprintf("%s @ line %d char %d\n'%s'\n",
+    msg,
+    parse[LPML_DECODE_PARSE_LINE],
+    parse[LPML_DECODE_PARSE_CHAR],
+    string_decode(parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]..parse[LPML_DECODE_PARSE_POS]+20], "utf8")
+  );
+
+  error(msg);
+}
+
+/**
+ * Check if character is valid identifier start (letter, $, _)
+ */
+private int lpml_is_identifier_start(int ch) {
+  return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_' || ch == '$';
+}
+
+/**
+ * Check if character is valid identifier continuation (letter, digit, $, _)
+ */
+private int lpml_is_identifier_char(int ch) {
+  return lpml_is_identifier_start(ch) || (ch >= '0' && ch <= '9');
+}
+
+/**
+ * Parse an identifier (unquoted key)
+ */
+private string lpml_decode_parse_identifier(mixed* parse) {
+  int from, to;
+  string out;
+
+  from = parse[LPML_DECODE_PARSE_POS];
+
+  if(!lpml_is_identifier_start(parse[LPML_DECODE_PARSE_TEXT][from]))
+    lpml_decode_parse_error(parse, "Invalid identifier start");
+
+  lpml_decode_parse_next_char(parse);
+
+  while(parse[LPML_DECODE_PARSE_POS] < sizeof(parse[LPML_DECODE_PARSE_TEXT]) &&
+        lpml_is_identifier_char(parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]])) {
+    lpml_decode_parse_next_char(parse);
   }
 
-  // Handle inline mapping notation {key1: val1, key2: val2, ...}
-  // Directly constructs a mapping from the inline format
-  if(val[0] == '{' && val[<1] == '}') {
-    mapping result = ([]);
-    string* pairs = explode(val[1..<2], ",");
-    foreach(string pair in pairs) {
-      string k, v;
-      if(sscanf(trim(pair), "%s:%s", k, v) == 2)
-        result[trim(k)] = lpml_parse_scalar(trim(v), pages);
+  to = parse[LPML_DECODE_PARSE_POS] - 1;
+  out = string_decode(parse[LPML_DECODE_PARSE_TEXT][from .. to], "utf-8");
+
+  return out;
+}
+
+/**
+ * Parse a YAML-style spacey key (reads until ':')
+ */
+private string lpml_decode_parse_spacey_key(mixed* parse) {
+  int from, to;
+  string out;
+  int ch;
+
+  from = parse[LPML_DECODE_PARSE_POS];
+
+  // Read until we hit ':'
+  while(parse[LPML_DECODE_PARSE_POS] < sizeof(parse[LPML_DECODE_PARSE_TEXT])) {
+    ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+    if(ch == 0)
+      lpml_decode_parse_error(parse, "Unexpected end of data in spacey key");
+
+    if(ch == ':')
+      break;  // Found the key separator
+
+    if(ch == '\n')
+      lpml_decode_parse_next_line(parse);
+    else
+      lpml_decode_parse_next_char(parse);
+  }
+
+  to = parse[LPML_DECODE_PARSE_POS] - 1;
+  out = string_decode(parse[LPML_DECODE_PARSE_TEXT][from .. to], "utf-8");
+
+  // Trim leading/trailing whitespace
+  out = trim(out);
+
+  if(strlen(out) == 0)
+    lpml_decode_parse_error(parse, "Empty spacey key");
+
+  return out;
+}
+
+/**
+ * Parses a LPML object from the given parse state.
+ */
+private mixed lpml_decode_parse_object(mixed* parse) {
+  mapping out = ([]);
+  int done = 0;
+  mixed key, value;
+  int ch;
+
+  lpml_decode_parse_next_char(parse);  // Skip {
+  lpml_decode_skip_whitespace_and_comments(parse);
+
+  ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+  if(ch == '}') {
+    lpml_decode_parse_next_char(parse);
+    return out;
+  }
+
+  while(!done) {
+    lpml_decode_skip_whitespace_and_comments(parse);
+    ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+    if(ch == 0)
+      lpml_decode_parse_error(parse, "Unexpected end of data");
+
+    // Parse key (quoted string, single-quoted string, identifier, or spacey key)
+    if(ch == '"') {
+      key = lpml_decode_parse_string(parse, '"');
+    } else if(ch == '\'') {
+      key = lpml_decode_parse_string(parse, '\'');
+    } else if(lpml_is_identifier_start(ch)) {
+      // Could be identifier or start of spacey key
+      // Parse as identifier first
+      key = lpml_decode_parse_identifier(parse);
+      
+      // Check if next non-whitespace is ':' or if there's more (spacey key)
+      lpml_decode_skip_whitespace_and_comments(parse);
+      ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+      
+      if(ch != ':') {
+        // Not a simple identifier - must be a spacey key
+        // We already parsed part of it, so read the rest
+        string rest = lpml_decode_parse_spacey_key(parse);
+        key = key + " " + rest;
+      }
+    } else {
+      // YAML-style spacey key - read until ':'
+      key = lpml_decode_parse_spacey_key(parse);
     }
-    return result;
+
+    // Find colon
+    lpml_decode_skip_whitespace_and_comments(parse);
+    ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+    if(ch != ':')
+      lpml_decode_parse_error(parse, "Expected ':'", ch);
+
+    lpml_decode_parse_next_char(parse);
+
+    // Parse value
+    lpml_decode_skip_whitespace_and_comments(parse);
+    value = lpml_decode_parse_value(parse);
+    out[key] = value;
+
+    // Check for comma or closing brace
+    lpml_decode_skip_whitespace_and_comments(parse);
+    ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+    if(ch == ',') {
+      lpml_decode_parse_next_char(parse);
+      lpml_decode_skip_whitespace_and_comments(parse);
+      ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+      // Trailing comma - check for closing brace
+      if(ch == '}') {
+        done = 1;
+        lpml_decode_parse_next_char(parse);
+      }
+    } else if(ch == '}') {
+      done = 1;
+      lpml_decode_parse_next_char(parse);
+    } else {
+      lpml_decode_parse_error(parse, "Expected ',' or '}'", ch);
+    }
   }
 
-  // Null-like
-  if(val == "null" || val == "~" || val == "undefined") return ([])[0];
-
-  // Boolean-ish
-  if(val == "true" || val == "yes") return 1;
-  if(val == "false" || val == "no") return 0;
-
-  // Numbers (int, float, hex)
-  if(sscanf(val, "%d", intval) && !nullp(val)) return intval;
-  if(sscanf(val, "%f", fval) && !nullp(val)) return fval;
-  if(strlen(val) > 2 && val[0..1] == "0x" && sscanf(val, "%x", intval) && !nullp(val)) return intval;
-
-  // Quoted string
-  if((val[0] == '"' && val[<1] == '"') || (val[0] == '\'' && val[<1] == '\''))
-    return val[1..<2];
-
-  // Fallback as-is
-  return val;
+  return out;
 }
 
 /**
- * Removes inline comments from a LPML line.
- *
- * This function identifies and removes comment portions of a line (beginning with #),
- * while being careful not to remove # characters that are within quoted strings.
- *
- * @param {string} line - The line to process
- * @returns {string} The line with any inline comments removed
- * @private
+ * Parses a LPML array from the given parse state.
  */
-// Quote-aware comment detection
-private string remove_inline_comment(string line) {
-  int pound_pos, left_quote, right_quote;
-  string quoted;
+private mixed lpml_decode_parse_array(mixed* parse) {
+  mixed* out = ({});
+  int done = 0;
+  int ch;
+  mixed value;
 
-  // Early return if no comment marker found
-  pound_pos = strsrch(line, "#");
-  if(pound_pos == -1)
-    return line;
+  lpml_decode_parse_next_char(parse);  // Skip [
+  lpml_decode_skip_whitespace_and_comments(parse);
 
-  // Check if comment marker is inside quotes
-  // This preserves # characters that are part of string content
-  if( (left_quote = strsrch(line, "\"")) != -1 ||
-      (left_quote = strsrch(line, "'"))  != -1) {
+  ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
 
-    right_quote = strsrch(line, line[left_quote], -1);
-
-    // If no matching quote found, assume incomplete quoted string
-    if(right_quote == -1)
-      return line;
-
-    // Return up to the closing quote
-    return line[0..right_quote];
+  if(ch == ']') {
+    lpml_decode_parse_next_char(parse);
+    return out;
   }
 
-  // Return everything before the comment marker
-  return line[0..pound_pos - 1];
+  while(!done) {
+    lpml_decode_skip_whitespace_and_comments(parse);
+    value = lpml_decode_parse_value(parse);
+    out += ({ value });
+
+    // Check for comma or closing bracket
+    lpml_decode_skip_whitespace_and_comments(parse);
+    ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+    if(ch == ',') {
+      lpml_decode_parse_next_char(parse);
+      lpml_decode_skip_whitespace_and_comments(parse);
+      ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+      // Trailing comma - check for closing bracket
+      if(ch == ']') {
+        done = 1;
+        lpml_decode_parse_next_char(parse);
+      }
+    } else if(ch == ']') {
+      done = 1;
+      lpml_decode_parse_next_char(parse);
+    } else {
+      lpml_decode_parse_error(parse, "Expected ',' or ']'", ch);
+    }
+  }
+
+  return out;
 }
 
 /**
- * Loads and parses a LPML file for inheritance/inclusion.
- *
- * This function handles the inclusion of external LPML files, allowing for
- * composition and reuse of LPML configurations through inheritance.
- *
- * @private
- * @param {string} file - Path to the LPML file to inherit
- * @param {mixed*} pages - Array of parsed LPML pages
- * @returns {mixed} The parsed contents of the inherited file
- * @errors If the file does not exist or cannot be read
+ * Parses a LPML string from the given parse state.
+ * Supports double quotes and single quotes (both allow multiline).
+ * Adjacent strings are automatically concatenated:
+ *   "foo" "bar"   → "foo bar" (space added)
+ *   "foo\n" "bar" → "foo\nbar" (no space if ends with \n)
  */
-private mixed lpml_inherit(string file, mixed *pages) {
-  string text, *lines;
-  mixed result;
+private varargs mixed lpml_decode_parse_string(mixed* parse, int quote_char) {
+  int from, to, esc_state, esc_active;
+  string out;
+  int ch;
+  int has_real_newlines = 0;
+  int saved_pos, saved_line, saved_char;
+  string next_str;
+  int needs_space;
 
-  if(file[0] == '/') {
-    if(!file_exists(file))
-      error("No such inherited file: " + file);
+  if(!quote_char) {
+    ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
 
-    text = read_file(file);
-    if(!text)
-      error("Could not read inherited file: " + file);
-  } else {
+    if(ch == '"')
+      quote_char = '"';
+    else if(ch == '\'')
+      quote_char = '\'';
+    else
+      lpml_decode_parse_error(parse, "Expected string", ch);
+  }
+
+  lpml_decode_parse_next_char(parse);  // Skip opening quote
+  from = parse[LPML_DECODE_PARSE_POS];
+  to = -1;
+  esc_state = 0;
+  esc_active = 0;
+  has_real_newlines = 0;  // Track if string spans multiple lines in source
+
+  while(to == -1) {
+    ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+    if(ch == 0)
+      lpml_decode_parse_error(parse, "Unexpected end of data in string");
+
+    // Allow newlines in strings
+    if(ch == '\n') {
+      has_real_newlines = 1;  // String spans multiple lines in source
+      lpml_decode_parse_next_line(parse);
+      continue;
+    }
+
+    if(ch == '\\') {
+      esc_state = !esc_state;
+    } else if(ch == quote_char) {
+      if(esc_state) {
+        esc_state = 0;
+        esc_active++;
+      } else {
+        to = parse[LPML_DECODE_PARSE_POS] - 1;
+      }
+    } else {
+      if(esc_state) {
+        esc_state = 0;
+        esc_active++;
+      }
+    }
+
+    lpml_decode_parse_next_char(parse);
+  }
+
+  out = string_decode(parse[LPML_DECODE_PARSE_TEXT][from .. to], "utf-8");
+
+  // Check for string concatenation - look for adjacent strings
+  // Save position before processing escapes in case we need to concatenate
+  saved_pos = parse[LPML_DECODE_PARSE_POS];
+  saved_line = parse[LPML_DECODE_PARSE_LINE];
+  saved_char = parse[LPML_DECODE_PARSE_CHAR];
+
+  // Process escape sequences
+  // IMPORTANT: Process \\\\ first, then other escapes
+  if(esc_active) {
+    string quote_str = sprintf("%c", quote_char);
+
+    // First, convert \\\\ to a placeholder to avoid double-processing
+    string backslash_placeholder = "\x01BACKSLASH\x01";
+    if(member_array('\\', out) != -1)
+      out = replace_string(out, "\\\\", backslash_placeholder);
+
+    // Now process other escape sequences
+    if(member_array(quote_char, out) != -1)
+      out = replace_string(out, "\\" + quote_str, quote_str);
+    if(strsrch(out, "\\b") != -1)
+      out = replace_string(out, "\\b", "\b");
+    if(strsrch(out, "\\f") != -1)
+      out = replace_string(out, "\\f", "\x0c");
+    if(strsrch(out, "\\n") != -1)
+      out = replace_string(out, "\\n", "\n");
+    if(strsrch(out, "\\r") != -1)
+      out = replace_string(out, "\\r", "\r");
+    if(strsrch(out, "\\t") != -1)
+      out = replace_string(out, "\\t", "\t");
+    if(member_array('/', out) != -1)
+      out = replace_string(out, "\\/", "/");
+
+    // Finally, convert placeholder back to single backslash
+    if(strsrch(out, backslash_placeholder) != -1)
+      out = replace_string(out, backslash_placeholder, "\\");
+  }
+
+  // No @ literal mode needed - use string concatenation instead
+
+  // Only fold if string had real newlines in source (not just \n escapes)
+  if(has_real_newlines && strsrch(out, "\n") != -1) {
+    // Folded mode - replace newlines with spaces
+    string* lines;
     int i, sz;
 
-    for(i = 0, sz = sizeof(pages); i < sz; i++) {
-      string page_path = pages[i][PAGE_TITLE];
-      if(page_path == file) {
-        text = pages[i][PAGE_SOURCE];
-        break;
+    lines = explode(out, "\n");
+    out = "";
+
+    for(i = 0, sz = sizeof(lines); i < sz; i++) {
+      string line = trim(lines[i]);
+
+      if(strlen(line) == 0) {
+        // Blank line becomes paragraph break (double space or newline)
+        if(strlen(out) > 0 && out[<1] != '\n')
+          out += "\n";
+      } else {
+        // Add space before line if needed
+        if(strlen(out) > 0 && out[<1] != '\n' && out[<1] != ' ')
+          out += " ";
+        out += line;
       }
     }
 
-    if(!text)
-      error("No such inherited LPML page: " + file);
+    // Trim any trailing whitespace
+    out = trim(out);
   }
 
-  lines = explode(text, "\n");
-  result = parse_block(lines, pages, 0)[0];
+  // String concatenation: check if next non-whitespace token is another string
+  lpml_decode_skip_whitespace_and_comments(parse);
+  ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+  if(ch == '"' || ch == '\'') {
+    // Another string follows - concatenate!
+    needs_space = 1;
+
+    // Check if current string ends with newline
+    if(strlen(out) > 0 && out[<1] == '\n')
+      needs_space = 0;
+
+    // Recursively parse the next string
+    next_str = lpml_decode_parse_string(parse, ch);
+
+    // Concatenate with or without space
+    if(needs_space)
+      out = out + " " + next_str;
+    else
+      out = out + next_str;
+  }
+
+  return out;
+}
+
+/**
+ * Parses a LPML number from the given parse state.
+ * Supports hex (0xFF), leading/trailing decimals (.5, 5.), plus sign (+5)
+ */
+private mixed lpml_decode_parse_number(mixed* parse) {
+  int from, to, dot, exp, ch, next_ch;
+  string number;
+  int is_hex = 0;
+  int is_negative = 0;
+
+  from = parse[LPML_DECODE_PARSE_POS];
+  to = -1;
+  dot = -1;
+  exp = -1;
+
+  ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+  // Handle sign
+  if(ch == '-' || ch == '+') {
+    if(ch == '-')
+      is_negative = 1;
+
+    lpml_decode_parse_next_char(parse);
+    ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+  }
+
+  // Check for Infinity - use undefined since LPC doesn't have Infinity
+  if(ch == 'I' && lpml_decode_parse_at_token(parse, "Infinity", 0)) {
+    lpml_decode_parse_next_chars(parse, 8);
+
+    return ([])[0];  // undefined
+  }
+
+  // Check for NaN - use undefined since LPC doesn't have NaN
+  if(ch == 'N' && lpml_decode_parse_at_token(parse, "NaN", 0)) {
+    lpml_decode_parse_next_chars(parse, 3);
+    return ([])[0];  // undefined
+  }
+
+  // Check for hex
+  if(ch == '0') {
+    next_ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS] + 1];
+
+    if(next_ch == 'x' || next_ch == 'X') {
+      is_hex = 1;
+      lpml_decode_parse_next_char(parse);  // Skip 0
+      lpml_decode_parse_next_char(parse);  // Skip x
+
+      from = parse[LPML_DECODE_PARSE_POS];
+      while(parse[LPML_DECODE_PARSE_POS] < sizeof(parse[LPML_DECODE_PARSE_TEXT])) {
+          ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+          if(lpml_decode_hexdigit(ch) == -1) break;
+          lpml_decode_parse_next_char(parse);
+      }
+      to = parse[LPML_DECODE_PARSE_POS] - 1;
+      number = string_decode(parse[LPML_DECODE_PARSE_TEXT][from .. to], "utf-8");
+      sscanf(number, "%x", ch);
+
+      return is_negative ? -ch : ch;
+    }
+  }
+
+  // Leading decimal point
+  if(ch == '.') {
+    dot = parse[LPML_DECODE_PARSE_POS];
+    lpml_decode_parse_next_char(parse);
+  }
+
+  // Parse number
+  while(to == -1 && parse[LPML_DECODE_PARSE_POS] < sizeof(parse[LPML_DECODE_PARSE_TEXT])) {
+    ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+    if(ch >= '0' && ch <= '9') {
+      lpml_decode_parse_next_char(parse);
+    } else if(ch == '.' && dot == -1 && exp == -1) {
+      dot = parse[LPML_DECODE_PARSE_POS];
+      lpml_decode_parse_next_char(parse);
+    } else if((ch == 'e' || ch == 'E') && exp == -1) {
+      exp = parse[LPML_DECODE_PARSE_POS];
+      lpml_decode_parse_next_char(parse);
+      // Handle exponent sign
+      ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+      if(ch == '+' || ch == '-')
+        lpml_decode_parse_next_char(parse);
+    } else {
+      to = parse[LPML_DECODE_PARSE_POS] - 1;
+    }
+  }
+
+  if(to == -1)
+    to = parse[LPML_DECODE_PARSE_POS] - 1;
+
+  number = string_decode(parse[LPML_DECODE_PARSE_TEXT][from .. to], "utf-8");
+
+  if(dot != -1 || exp != -1)
+    return to_float(number);
+  else
+    return to_int(number);
+}
+
+/**
+ * Parses a LPML value from the given parse state.
+ */
+private mixed lpml_decode_parse_value(mixed* parse) {
+  int ch;
+
+  lpml_decode_skip_whitespace_and_comments(parse);
+  ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+  if(ch == 0)
+    lpml_decode_parse_error(parse, "Unexpected end of data");
+
+  // Object
+  if(ch == '{')
+    return lpml_decode_parse_object(parse);
+
+  // Array
+  if(ch == '[')
+    return lpml_decode_parse_array(parse);
+
+  // String (double or single quoted, both support multiline)
+  if(ch == '"' || ch == '\'')
+    return lpml_decode_parse_string(parse, ch);
+
+  // Number (including +, leading ., hex)
+  if(ch == '-' || ch == '+' || ch == '.' || (ch >= '0' && ch <= '9'))
+    return lpml_decode_parse_number(parse);
+
+  // true
+  if(ch == 't' && lpml_decode_parse_at_token(parse, "true", 0)) {
+    lpml_decode_parse_next_chars(parse, 4);
+    return 1;
+  }
+
+  // false
+  if(ch == 'f' && lpml_decode_parse_at_token(parse, "false", 0)) {
+    lpml_decode_parse_next_chars(parse, 5);
+    return 0;
+  }
+
+  // null
+  if(ch == 'n' && lpml_decode_parse_at_token(parse, "null", 0)) {
+    lpml_decode_parse_next_chars(parse, 4);
+    return ([])[0];  // undefined
+  }
+
+  // Infinity - use undefined since LPC doesn't have Infinity
+  if(ch == 'I' && lpml_decode_parse_at_token(parse, "Infinity", 0)) {
+    lpml_decode_parse_next_chars(parse, 8);
+    return ([])[0];  // undefined
+  }
+
+  // NaN - use undefined since LPC doesn't have NaN
+  if(ch == 'N' && lpml_decode_parse_at_token(parse, "NaN", 0)) {
+    lpml_decode_parse_next_chars(parse, 3);
+    return ([])[0];  // undefined
+  }
+
+  lpml_decode_parse_error(parse, "Unexpected character", ch);
+
+  return 0;
+}
+
+/**
+ * Main parse function
+ */
+private mixed lpml_decode_parse(mixed* parse) {
+  mixed out;
+  int ch;
+
+  out = lpml_decode_parse_value(parse);
+
+  lpml_decode_skip_whitespace_and_comments(parse);
+  ch = parse[LPML_DECODE_PARSE_TEXT][parse[LPML_DECODE_PARSE_POS]];
+
+  if(ch != 0)
+    lpml_decode_parse_error(parse, "Unexpected character after value", ch);
+
+  return out;
+}
+
+// File interpolation pattern: "#path"
+
+/**
+ * @simul_efun lpml_decode_preprocess
+ * @description Preprocesses LPML text to handle "#path" includes
+ * @param {string} text - The LPML string to preprocess
+ * @param {string} base_path - Base directory for relative paths
+ * @returns {string} - Preprocessed LPML text
+ *
+ * Looks for "#path" pattern and replaces with file contents.
+ * Use \# to escape literal # (per LPML spec).
+ */
+private string lpml_decode_preprocess(string text, string base_path) {
+  string source;
+  string result, file_path, file_text, include_base;
+  int start, end;
+
+  result = "";
+  source = text;
+
+  while(strlen(source) > 0) {
+    int dq_start, sq_start, dq_esc_start, sq_esc_start;
+    int is_single_quote = 0;
+    int is_escaped = 0;
+
+    // Look for "# or '# or "\# or '\# patterns
+    dq_start = strsrch(source, "\"#");
+    sq_start = strsrch(source, "'#");
+    dq_esc_start = strsrch(source, "\"\\#");
+    sq_esc_start = strsrch(source, "'\\#");
+
+    // Find the earliest match
+    start = -1;
+
+    if(dq_start != -1 && (start == -1 || dq_start < start)) {
+      start = dq_start;
+      is_single_quote = 0;
+      is_escaped = 0;
+    }
+    if(sq_start != -1 && (start == -1 || sq_start < start)) {
+      start = sq_start;
+      is_single_quote = 1;
+      is_escaped = 0;
+    }
+    if(dq_esc_start != -1 && (start == -1 || dq_esc_start < start)) {
+      start = dq_esc_start;
+      is_single_quote = 0;
+      is_escaped = 1;
+    }
+    if(sq_esc_start != -1 && (start == -1 || sq_esc_start < start)) {
+      start = sq_esc_start;
+      is_single_quote = 1;
+      is_escaped = 1;
+    }
+
+    if(start == -1) {
+      // No more includes or escapes
+      result += source;
+      break;
+    }
+
+    // If escaped, strip the backslash and skip
+    if(is_escaped) {
+      // Add everything before the escape, then quote+#
+      result += source[0..start-1];
+      if(is_single_quote)
+        result += "'#";
+      else
+        result += "\"#";
+      source = source[start+3..];
+      continue;
+    }
+
+    // Add text before the include (including the opening quote)
+    if(start > 0)
+      result += source[0..start-1];
+
+    // Find closing quote after the #
+    {
+      string remainder = source[start+2..];  // Skip quote + #
+      string close_quote = is_single_quote ? "'" : "\"";
+      int close_pos = strsrch(remainder, close_quote);
+      int i;
+
+      // Make sure the " isn't escaped
+      while(close_pos != -1) {
+        // Count preceding backslashes
+        int backslashes = 0;
+        i = close_pos - 1;
+
+        while(i >= 0 && remainder[i] == '\\') {
+          backslashes++;
+          i--;
+        }
+
+        // If odd number of backslashes, the " is escaped
+        if(backslashes % 2 == 0) {
+          // Not escaped - this is our closing quote
+          break;
+        }
+
+        // Escaped - keep looking
+        close_pos = strsrch(remainder, close_quote, close_pos + 1);
+      }
+
+      if(close_pos == -1) {
+        // No closing quote - keep the \"# and continue
+        result += source[start..start+1];
+        source = source[start+2..];
+        continue;
+      }
+
+      end = start + 2 + close_pos;  // Position of closing "
+    }
+
+    // Extract file path (between # and ")
+    file_path = source[start+2..end-1];
+
+    // Handle relative paths
+    file_path = resolve_relative_path(file_path, base_path);
+
+    // Try to read the file
+    if(!file_exists(file_path)) {
+      // File not found - keep the original string and continue
+      result += source[start..end];
+      source = source[end+1..];
+      continue;
+    }
+
+    file_text = read_file(file_path);
+    if(!file_text) {
+      // Could not read - keep the original string and continue
+      result += source[start..end];
+      source = source[end+1..];
+      continue;
+    }
+
+    // Trim trailing newline from read_file
+    if(file_text[<1] == '\n')
+      file_text = file_text[0..<2];
+
+    // Recursively preprocess (in case included file has includes)
+    include_base = strsrch(file_path, "/") != -1
+      ? file_path[0..strsrch(file_path, "/", -1)-1]
+      : "";
+
+    file_text = lpml_decode_preprocess(file_text, include_base);
+
+    // Insert the file content (no quotes around it)
+    result += file_text;
+
+    // Consume the processed part of source (skip the closing ")
+    source = source[end+1..];
+  }
+
+  // Final pass: strip \# escapes that weren't includes
+  result = replace_string(result, "\\#", "#");
 
   return result;
 }
+
+/**
+ * @simul_efun lpml_decode
+ * @description Deserializes a LPML string into an LPC value.
+ * @param {string} text - The LPML string to deserialize.
+ * @param {string} base_path - Optional base directory for relative includes
+ * @returns {mixed} - The deserialized LPC value.
+ */
+varargs mixed lpml_decode(string text, string base_path) {
+  mixed* parse;
+  buffer endl;
+
+  if(!text)
+    return 0;
+
+  // Preprocess includes
+  text = lpml_decode_preprocess(text, base_path);
+
+  debug(text);
+
+  endl = allocate_buffer(1);
+  endl[0] = 0;
+
+  parse = allocate(LPML_DECODE_PARSE_FIELDS);
+  parse[LPML_DECODE_PARSE_TEXT] = string_encode(text, "utf-8") + endl;
+  parse[LPML_DECODE_PARSE_POS] = 0;
+  parse[LPML_DECODE_PARSE_CHAR] = 1;
+  parse[LPML_DECODE_PARSE_LINE] = 1;
+
+  return lpml_decode_parse(parse);
+}
+
+/**
+ * @simul_efun lpml_encode
+ * @description Serializes an LPC value into JSON text.
+ * @param {mixed} value - The LPC value to serialize.
+ * @returns {string} - The JSON string representation.
+ *
+ * Note: Encoding produces standard JSON
+ */
+varargs string lpml_encode(mixed value, mixed* pointers) {
+  // Use standard JSON encoding - LPML is primarily for parsing
+  // For now, delegate to json_encode if available, or implement basic encoding
+
+  if(undefinedp(value))
+    return "null";
+  if(intp(value) || floatp(value))
+    return to_string(value);
+  if(stringp(value)) {
+    value = replace_string(value, "\\", "\\\\");
+    value = replace_string(value, "\"", "\\\"");
+    value = replace_string(value, "\n", "\\n");
+    value = replace_string(value, "\r", "\\r");
+    value = replace_string(value, "\t", "\\t");
+    return sprintf("\"%s\"", value);
+  }
+
+  if(mapp(value)) {
+    string out;
+    int ix = 0;
+
+    if(pointers && member_array(value, pointers) != -1)
+        return "null";
+
+    pointers = pointers ? pointers + ({ value }) : ({ value });
+
+    foreach(mixed k, mixed v in value) {
+      if(!stringp(k))
+        continue;
+
+      if(ix++)
+        out = sprintf("%s,%s:%s", out, lpml_encode(k, pointers), lpml_encode(v, pointers));
+      else
+        out = sprintf("%s:%s", lpml_encode(k, pointers), lpml_encode(v, pointers));
+    }
+
+    return sprintf("{%s}", out || "");
+  }
+
+  if(pointerp(value)) {
+    string out;
+    int ix = 0;
+
+    if(sizeof(value) == 0)
+      return "[]";
+
+    if(pointers && member_array(value, pointers) != -1)
+      return "null";
+
+    pointers = pointers ? pointers + ({ value }) : ({ value });
+
+    foreach(mixed v in value) {
+      if(ix++)
+        out = sprintf("%s,%s", out, lpml_encode(v, pointers));
+      else
+        out = lpml_encode(v, pointers);
+    }
+
+    return sprintf("[%s]", out);
+  }
+
+  return "null";
+}
+
+#endif /* __STD_LPML_H */

--- a/d/mobs/field_mouse.lpml
+++ b/d/mobs/field_mouse.lpml
@@ -1,16 +1,22 @@
-type: rodent
-name: field mouse
-short: field mouse
-long: >-
-  A small field mouse scurries about, searching for seeds and grains.
-id: [field mouse, mouse]
-weapon name: teeth
-weapon type: piercing
-level: [1, 1]
-gender: [male, female]
-loot:
-  - /obj/food/cheese.food
-  - /obj/loot/small_bone.loot
-loot chance: 50.0
-coins:
-  copper: [1, 25.0]
+{
+  type: "rodent",
+  name: "field mouse",
+  short: "field mouse",
+  long: "A small field mouse scurries about, searching for seeds and grains.",
+  id: [
+    "field mouse",
+    "mouse"
+  ],
+  weapon name: "teeth",
+  weapon type: "piercing",
+  level: [1,1], // [min,random]
+  gender: ["male","female"],
+  loot: [
+    "/obj/food/cheese.food",
+    "/obj/loot/small_bone.loot",
+  ],
+  loot chance: 50.0,
+  coins: {
+    copper: [1,25.0],
+  },
+}

--- a/d/mobs/field_rabbit.lpml
+++ b/d/mobs/field_rabbit.lpml
@@ -1,17 +1,26 @@
-type: mammal
-name: field rabbit
-short: field rabbit
-long: >-
-  A fluffy field rabbit hops around, its ears twitching alertly.
-id: [field rabbit, rabbit]
-weapon name: claws
-weapon type: slashing
-level: [1, 2]
-gender: [male, female]
-race: mammal
-loot:
-  - /obj/food/rabbit_meat.food
-  - /obj/loot/rabbit_fur.loot
-loot chance: 60.0
-coins:
-  copper: [1, 50.0]
+{
+  type: "mammal",
+  name: "field rabbit",
+  short: "field rabbit",
+  long: "A fluffy field rabbit hops around, its ears twitching alertly.",
+  id: [
+    "field rabbit",
+    "rabbit"
+  ],
+  weapon name: "claws",
+  weapon type: "slashing",
+  level: [1,2],
+  gender: [
+    "male",
+    "female"
+  ],
+  race: "mammal",
+  loot: [
+    "/obj/food/rabbit_meat.food",
+    "/obj/loot/rabbit_fur.loot",
+  ],
+  loot chance: 60.0,
+  coins: {
+    copper: [1,50.0],
+  },
+}

--- a/d/mobs/grasshopper.lpml
+++ b/d/mobs/grasshopper.lpml
@@ -1,17 +1,26 @@
-type: insect
-name: grasshopper
-short: grasshopper
-long: >-
-  A large grasshopper sits on a blade of grass, ready to leap away.
-id: [grasshopper, insect]
-weapon name: mandibles
-weapon type: slashing
-level: [1, 1]
-gender: [male, female]
-race: insect
-loot:
-  - /obj/loot/grasshopper_leg.loot
-  - /obj/loot/insect_wing.loot
-loot chance: 100.0
-coins:
-  copper: [1, 10.0]
+{
+  type: "insect",
+  name: "grasshopper",
+  short: "grasshopper",
+  long: "A large grasshopper sits on a blade of grass, ready to leap away.",
+  id: [
+    "grasshopper",
+    "insect"
+  ],
+  weapon name: "mandibles",
+  weapon type: "slashing",
+  level: [1,1],
+  gender: [
+    "male",
+    "female"
+  ],
+  race: "insect",
+  loot: [
+    "/obj/loot/grasshopper_leg.loot",
+    "/obj/loot/insect_wing.loot",
+  ],
+  loot chance: 100.0,
+  coins: {
+    copper: [1,10.0],
+  },
+}

--- a/d/mobs/waste_rat.lpml
+++ b/d/mobs/waste_rat.lpml
@@ -1,17 +1,27 @@
-type: mammal
-name: waste rat
-short: waste rat
-long: >-
-  A scrappy waste rat scurries through the debris, searching for scraps to eat.
-id: [waste rat, rat]
-weapon name: teeth
-weapon type: piercing
-level: [1, 3]
-gender: [male, female]
-race: mammal
-loot:
-  - /obj/food/rat_meat.food
-  - /obj/loot/rat_fur.loot
-loot chance: 70.0
-coins:
-  copper: [1, 20.0]
+{
+  type: "mammal",
+  name: "waste rat",
+  short: "waste rat",
+  long: "A scrappy waste rat scurries through the debris, searching for "
+        "scraps to eat.",
+  id: [
+    "waste rat",
+    "rat"
+  ],
+  weapon name: "teeth",
+  weapon type: "piercing",
+  level: [1,3],
+  gender: [
+    "male",
+    "female"
+  ],
+  race: "mammal",
+  loot: [
+    "/obj/food/rat_meat.food",
+    "/obj/loot/rat_fur.loot",
+  ],
+  loot chance: 70.0,
+  coins: {
+    copper: [1,20.0],
+  },
+}

--- a/d/mobs/wasterel.lpml
+++ b/d/mobs/wasterel.lpml
@@ -1,18 +1,27 @@
-type: mammal
-name: wasterel
-short: wasterel
-long: >-
-  A cunning wasteland cat prowls the desolate terrain, its eyes glinting with
-  hunger.
-id: [wasterel, cat]
-weapon name: claws
-weapon type: slashing
-level: [2, 4]
-gender: [male, female]
-race: mammal
-loot:
-  - /obj/food/cat_meat.food
-  - /obj/loot/cat_fur.loot
-loot chance: 50.0
-coins:
-  copper: [1, 30.0]
+{
+  type: "mammal",
+  name: "wasterel",
+  short: "wasterel",
+  long: "A cunning wasteland cat prowls the desolate terrain, its eyes "
+        "glinting with hunger.",
+  id: [
+    "wasterel",
+    "cat"
+  ],
+  weapon name: "claws",
+  weapon type: "slashing",
+  level: [2,4],
+  gender: [
+    "male",
+    "female"
+  ],
+  race: "mammal",
+  loot: [
+    "/obj/food/cat_meat.food",
+    "/obj/loot/cat_fur.loot",
+  ],
+  loot chance: 50.0,
+  coins: {
+    copper: [1,30.0],
+  },
+}

--- a/d/mobs/wild_boar.lpml
+++ b/d/mobs/wild_boar.lpml
@@ -1,20 +1,29 @@
-type: mammal
-name: wild boar
-short: wild boar
-long: >-
-  A wild boar is here, snuffling around for food. Its tusks look sharp and
-  dangerous.
-id: [wild boar, boar]
-weapon name: tusks
-weapon type: piercing
-level: [1, 2]
-gender: [male, female]
-race: pig
-loot:
-  - /obj/loot/boar_skin.loot
-  - /obj/loot/boar_tusk.loot
-  - /obj/food/raw_pork.food
-loot chance: 75.0
-coins:
-  copper: [1, 100.0]
-  silver: [1, 50.0]
+{
+  type: "mammal",
+  name: "wild boar",
+  short: "wild boar",
+  long: "A wild boar is here, snuffling around for food. Its tusks look sharp "
+        "and dangerous.",
+  id: [
+    "wild boar",
+    "boar"
+  ],
+  weapon name: "tusks",
+  weapon type: "piercing",
+  level: [1,2],
+  gender: [
+    "male",
+    "female"
+  ],
+  race: "pig",
+  loot: [
+    "/obj/loot/boar_skin.loot",
+    "/obj/loot/boar_tusk.loot",
+    "/obj/food/raw_pork.food",
+  ],
+  loot chance: 75.0,
+  coins: {
+    copper: [1,100.0],
+    silver: [1,50.0],
+  },
+}

--- a/doc/lpml-spec.md
+++ b/doc/lpml-spec.md
@@ -1,0 +1,515 @@
+# LPML Specification
+
+**LPML** (LPC Markup Language) is a human-friendly data serialization format designed for MUD configuration files. It extends JSON5 with features tailored for LPC environments.
+
+## Version
+
+Version: 1.0.0
+Created: 2025-11-09
+
+## Design Goals
+
+1. **Human-readable**: Easy to read and write by hand
+2. **Composable**: Support file includes for modular configs
+3. **Expressive**: Natural multiline strings without escape hell
+4. **Compatible**: Full JSON/JSON5 compatibility
+5. **Practical**: Fast enough for config files (not hot paths)
+
+---
+
+## Base Syntax (JSON5)
+
+LPML is built on JSON5, which extends JSON with:
+
+### Comments
+```lpml
+// Single-line comments
+/* Multi-line
+   comments */
+```
+
+### Unquoted Keys
+```lpml
+{
+  name: "Gesslar",           // Simple identifier
+  my cool key: "value",      // Spacey keys (YAML-style)
+  additional ids: [1, 2, 3], // Works great!
+  'quoted-key': "value"      // Use quotes when needed
+}
+```
+
+**Spacey Keys:** LPML supports YAML-style keys with spaces - just write the key naturally and end it with `:`. The parser reads everything until the colon as the key name.
+
+### Trailing Commas
+```lpml
+{
+  foo: "bar",
+  baz: 42,  // ← trailing comma is fine
+}
+```
+
+### Single-Quoted Strings
+```lpml
+name: 'single quotes work too'
+```
+
+### Number Formats
+```lpml
+{
+  hex: 0xFF,           // Hexadecimal
+  decimal: 3.14,       // Standard
+  leadingDot: .5,      // Leading decimal point
+  trailingDot: 5.,     // Trailing decimal point
+  positive: +42        // Plus sign allowed
+}
+```
+
+---
+
+## LPML Extensions
+
+### Spacey Keys (YAML-style)
+
+Unlike JSON5, LPML allows keys with spaces without requiring quotes:
+
+```lpml
+{
+  // All of these are valid:
+  simple: "value",
+  two words: "value",
+  multiple word key: "value",
+  crafting material: "leather",
+  
+  // Still works with quotes if you need them:
+  "key: with colon": "value",
+  'single quoted': "value"
+}
+```
+
+**How it works:**
+- The parser reads everything from the start of the key until it finds `:`
+- Leading and trailing whitespace is trimmed
+- Works alongside traditional identifiers and quoted keys
+
+**Examples:**
+```lpml
+{
+  // Character data with natural keys
+  hit points: 100,
+  mana points: 50,
+  experience points: 1500,
+  
+  // Crafting materials
+  crafting material: "yes",
+  material type: "leather",
+  quality level: "high"
+}
+```
+
+### String Concatenation
+
+Adjacent strings are automatically concatenated with intelligent spacing:
+
+```lpml
+// Concatenation with spaces (default)
+bio: "A seasoned adventurer"
+     "from the West."
+// Result: "A seasoned adventurer from the West."
+
+// Preserve newlines when strings end with \n
+poem: "Line 1\n"
+      "Line 2\n"
+      "Line 3"
+// Result: "Line 1\nLine 2\nLine 3"
+
+// Mixed mode
+text: "First paragraph."
+      "Second sentence.\n"
+      "New paragraph."
+// Result: "First paragraph. Second sentence.\nNew paragraph."
+```
+
+**Rules:**
+1. If a string ends with `\n`, the next string concatenates **without** adding a space
+2. Otherwise, strings are joined with a single space
+3. Works with any quote style: `"..."`, `'...'`
+
+### Multiline Strings
+
+Strings can span multiple lines in the source:
+
+```lpml
+// Source spans multiple lines
+description: "This is a long
+              description that spans
+              multiple lines."
+// Result: "This is a long description that spans multiple lines."
+```
+
+**Folding behavior:**
+- Actual newlines in the source (pressing Enter) are converted to spaces
+- Escape sequences like `\n` are preserved as actual newlines
+
+### File Includes
+
+Include external files with `"#path"` syntax:
+
+```lpml
+{
+  // Absolute path
+  config: "#/home/user/config.lpml",
+
+  // Relative path (requires base_path parameter)
+  stats: "#./stats.lpml",
+  parent: "#../shared.lpml",
+
+  // Missing files stay as literal strings (graceful degradation)
+  optional: "#/missing/file.lpml"  // → "#/missing/file.lpml"
+}
+```
+
+**Include behavior:**
+1. The `#path` pattern is replaced with the file's contents during preprocessing
+2. Included files are recursively preprocessed (supports nested includes)
+3. Relative paths are resolved based on the `base_path` parameter
+4. If a file doesn't exist, the include string is kept as-is (no error)
+5. Works with both double and single quotes
+
+**Escaping includes:**
+```lpml
+{
+  channel: "\#general"  // → "#general" (literal)
+}
+```
+
+The `\#` escape prevents include processing and removes the backslash.
+
+---
+
+## Data Types
+
+### Primitives
+
+```lpml
+{
+  string: "text",
+  number: 42,
+  float: 3.14,
+  boolean: true,
+  null: null
+}
+```
+
+### Arrays
+
+```lpml
+{
+  array: [1, 2, 3],
+  mixed: ["string", 42, true, null],
+  nested: [[1, 2], [3, 4]],
+  trailing: [1, 2, 3,]  // Trailing comma OK
+}
+```
+
+### Objects (Mappings)
+
+```lpml
+{
+  simple: { x: 1, y: 2 },
+  nested: {
+    stats: {
+      str: 10,
+      dex: 15
+    }
+  },
+  trailing: { a: 1, b: 2, }  // Trailing comma OK
+}
+```
+
+---
+
+## Special Values
+
+### Infinity and NaN
+
+```lpml
+{
+  inf: Infinity,      // Maps to undefined in LPC
+  negInf: -Infinity,  // Maps to undefined in LPC
+  notANumber: NaN     // Maps to undefined in LPC
+}
+```
+
+**Note:** LPC doesn't have native Infinity/NaN support, so these are converted to `undefined` (accessed as `([])[0]`).
+
+---
+
+## Escape Sequences
+
+Standard JSON escape sequences are supported:
+
+```lpml
+{
+  newline: "line1\nline2",
+  tab: "col1\tcol2",
+  quote: "He said \"hello\"",
+  backslash: "path\\to\\file",
+  unicode: "\u0041"  // 'A'
+}
+```
+
+Supported escapes:
+- `\"` - Double quote
+- `\'` - Single quote
+- `\\` - Backslash
+- `\/` - Forward slash
+- `\b` - Backspace
+- `\f` - Form feed
+- `\n` - Newline
+- `\r` - Carriage return
+- `\t` - Tab
+- `\uXXXX` - Unicode (if supported by parser)
+
+---
+
+## Usage in LPC
+
+### Decoding
+
+```lpc
+// Basic usage
+mixed data = lpml_decode(file_text);
+
+// With base_path for relative includes
+mixed data = lpml_decode(
+  read_file("/config/main.lpml"),
+  "/config"
+);
+```
+
+**Signature:**
+```lpc
+varargs mixed lpml_decode(string text, string base_path)
+```
+
+**Parameters:**
+- `text` - The LPML string to parse
+- `base_path` - (Optional) Base directory for resolving relative includes
+
+**Returns:**
+- Parsed LPC data structure (mapping, array, or primitive)
+- `0` if text is null/empty
+
+### Encoding
+
+```lpc
+// Encode LPC data to LPML/JSON
+string text = lpml_encode(data);
+```
+
+**Signature:**
+```lpc
+string lpml_encode(mixed value)
+```
+
+**Returns:**
+- JSON-formatted string (standard JSON, not LPML extensions)
+
+**Note:** Encoding produces standard JSON. LPML extensions (comments, includes, string concatenation) are **read-only** features.
+
+---
+
+## File Extension
+
+Recommended: `.lpml`
+
+Alternative: `.json` or `.json5` for editor syntax highlighting
+
+---
+
+## Examples
+
+### Character Configuration
+
+```lpml
+// character.lpml
+{
+  name: "Gesslar",
+  title: "Wielder of Sharp Things",
+  
+  // Load external configs
+  stats: "#./stats.lpml",
+  inventory: "#./inventory.lpml",
+  
+  // Spacey keys for natural language
+  hit points: 100,
+  max hit points: 120,
+  experience points: 1500,
+  
+  bio: "A seasoned adventurer from the West."
+       "Known for incredible fashion sense."
+       "Has a pet dragon named Sparky.",
+  
+  skills: {
+    combat: 85,
+    magic: 60,
+    social: 75,
+  },
+}
+```
+
+### Item/Loot Configuration
+
+```lpml
+// cat_fur.lpml
+{
+  id: ["fur"],
+  additional ids: ["hide", "piece"],  // Spacey key!
+  adj: ["cat", "soft"],
+  name: "cat fur",
+  short: "a piece of cat fur",
+  long: "This is a soft piece of fur from a wild cat."
+        "It could be useful for crafting.",
+  mass: 20,
+  material: ["fur"],
+  properties: {
+    autovalue: "yes",
+    crafting material: "yes",  // Spacey key!
+  }
+}
+```
+
+### Multi-line Text with Formatting
+
+```lpml
+{
+  // Paragraph with auto-folding
+  description: "This is a long description that"
+               "spans multiple lines in the source"
+               "but will be a single paragraph.",
+
+  // Preserve line breaks with \n
+  poem: "Roses are red,\n"
+        "Violets are blue,\n"
+        "LPML is awesome,\n"
+        "And so are you.",
+
+  // Mix folding and newlines
+  help: "Usage: command [options]\n"
+        "\n"
+        "This command does something useful."
+        "It has multiple paragraphs.\n"
+        "\n"
+        "See 'help topics' for more info."
+}
+```
+
+### Modular Configuration
+
+**main.lpml:**
+```lpml
+{
+  game: {
+    name: "My MUD",
+    port: 4000,
+
+    // Pull in modular configs
+    database: "#./db-config.lpml",
+    features: "#./features.lpml",
+    discord: "#./discord-config.lpml"
+  }
+}
+```
+
+**db-config.lpml:**
+```lpml
+{
+  host: "localhost",
+  port: 5432,
+  name: "mud_db",
+  pool_size: 10
+}
+```
+
+---
+
+## Implementation Notes
+
+### Performance
+
+- **Parsing cost:** ~2x slower than `json_decode()`
+- **Why:** UTF-8 safety, comment parsing, string concatenation, includes
+- **Recommendation:** Use for config files (parsed once), not hot paths
+
+### UTF-8 Safety
+
+LPML uses buffer-based encoding for UTF-8 safety:
+- Source text is converted to buffer via `string_encode(text, "utf-8")`
+- Buffer indexing is O(1) byte access (fast and safe)
+- Final strings are decoded via `string_decode(buffer, "utf-8")`
+
+### Compatibility
+
+- **Reads:** JSON, JSON5, LPML
+- **Writes:** JSON (standard format)
+
+---
+
+## Differences from JSON5
+
+| Feature | JSON5 | LPML |
+|---------|-------|------|
+| Comments | ✓ | ✓ |
+| Trailing commas | ✓ | ✓ |
+| Unquoted keys | ✓ | ✓ |
+| Spacey keys | ✗ | ✓ |
+| Single quotes | ✓ | ✓ |
+| Hex numbers | ✓ | ✓ |
+| String concatenation | ✗ | ✓ |
+| File includes | ✗ | ✓ |
+| Multiline folding | ✗ | ✓ |
+
+---
+
+## Limitations
+
+1. **Encoding is JSON only** - LPML extensions are not preserved when encoding
+2. **Include preprocessing** - Includes are resolved before parsing (text substitution)
+3. **No schema validation** - LPML doesn't enforce structure (like JSON)
+4. **Platform-specific** - Designed for LPC/FluffOS environments
+
+---
+
+## Grammar Summary
+
+```
+value       ::= object | array | string | number | boolean | null
+object      ::= '{' members? '}'
+members     ::= pair (',' pair)* ','?
+pair        ::= key ':' value
+key         ::= identifier | string
+array       ::= '[' elements? ']'
+elements    ::= value (',' value)* ','?
+string      ::= '"' chars '"' | "'" chars "'" | string string  // concatenation
+number      ::= hex | decimal
+boolean     ::= 'true' | 'false'
+null        ::= 'null'
+comment     ::= '//' [^\n]* | '/*' .*? '*/'
+```
+
+---
+
+## Credits
+
+Created by Gesslar for the Oxidus MUD codebase.
+
+Based on:
+- JSON5 specification
+- LPC/FluffOS runtime
+- Lessons learned from YAML complexity
+
+---
+
+## License
+
+This specification is provided as-is for use in LPC MUD development.

--- a/obj/food/cat_meat.lpml
+++ b/obj/food/cat_meat.lpml
@@ -1,11 +1,16 @@
-id: [meat]
-additional ids: [chunk]
-adj: [cat, raw, fresh]
-name: cat meat
-short: a chunk of cat meat
-long: >-
-  This is a fresh chunk of cat meat. It needs to be cooked before eating.
-mass: 25
-value: 30
-uses: 1
-properties: {food: yes, raw: yes}
+{
+  id: ["meat"],
+  additional ids: ["chunk"],
+  adj: ["cat", "raw", "fresh"],
+  name: "cat meat",
+  short: "a chunk of cat meat",
+  long: "This is a fresh chunk of cat meat. It needs to be cooked before "
+        "eating.",
+  mass: 25,
+  value: 30,
+  uses: 1,
+  properties: {
+    food: true,
+    raw: true,
+  },
+}

--- a/obj/food/cheese.lpml
+++ b/obj/food/cheese.lpml
@@ -1,12 +1,15 @@
-id: [cheese]
-additional ids: [food, snack]
-adj: [small]
-name: cheese
-short: a small piece of cheese
-long: >-
-  This is a small, round piece of cheese. It looks tasty and would make a good
-  snack.
-mass: 10
-value: 15
-uses: 1
-properties: {edible: yes}
+{
+  id: ["cheese"],
+  additional ids: ["food", "snack"],
+  adj: ["small"],
+  name: "cheese",
+  short: "a small piece of cheese",
+  long: "This is a small, round piece of cheese. It looks tasty and would"
+        "make a good snack.",
+  mass: 10,
+  value: 15,
+  uses: 1,
+  properties: {
+    edible: true,
+  },
+}

--- a/obj/food/rabbit_meat.lpml
+++ b/obj/food/rabbit_meat.lpml
@@ -1,12 +1,15 @@
-id: [meat]
-additional ids: [food]
-adj: [rabbit, raw]
-name: rabbit meat
-short: a piece of raw rabbit meat
-long: >-
-  This is a small piece of raw meat from a rabbit. It needs to be cooked before
-  eating.
-mass: 15
-value: 20
-uses: 1
-properties: {raw: yes}
+{
+  id: ["meat"],
+  additional ids: ["food"],
+  adj: ["rabbit", "raw"],
+  name: "rabbit meat",
+  short: "a piece of raw rabbit meat",
+  long: "This is a small piece of raw meat from a rabbit. It needs to be"
+        "cooked before eating.",
+  mass: 15,
+  value: 20,
+  uses: 1,
+  properties: {
+    raw: true,
+  },
+}

--- a/obj/food/rat_meat.lpml
+++ b/obj/food/rat_meat.lpml
@@ -1,11 +1,16 @@
-id: [meat]
-additional ids: [chunk]
-adj: [rat, raw, fresh]
-name: rat meat
-short: a chunk of rat meat
-long: >-
-  This is a fresh chunk of rat meat. It needs to be cooked before eating.
-mass: 15
-value: 20
-uses: 1
-properties: {food: yes, raw: yes}
+{
+  id: ["meat"],
+  additional ids: ["chunk"],
+  adj: ["rat", "raw", "fresh"],
+  name: "rat meat",
+  short: "a chunk of rat meat",
+  long: "This is a fresh chunk of rat meat. It needs to be cooked before"
+        "eating.",
+  mass: 15,
+  value: 20,
+  uses: 1,
+  properties: {
+    food: true,
+    raw: true,
+  },
+}

--- a/obj/food/raw_pork.lpml
+++ b/obj/food/raw_pork.lpml
@@ -1,12 +1,16 @@
-id: pork
-additional ids: [meat, chunk]
-adj: [raw, fresh]
-name: raw pork
-short: a chunk of raw pork
-long: >-
-  This is a fresh chunk of raw pork from a wild boar. It needs to be cooked
-  before eating.
-mass: 30
-value: 40
-uses: 1
-properties: {food: yes, raw: yes}
+{
+  id: ["pork"],
+  additional ids: ["meat", "chunk"],
+  adj: ["raw", "fresh"],
+  name: "raw pork",
+  short: "a chunk of raw pork",
+  long: "This is a fresh chunk of raw pork from a wild boar. It needs to be "
+        "cooked before eating.",
+  mass: 30,
+  value: 40,
+  uses: 1,
+  properties: {
+    food: true,
+    raw: true,
+  },
+}

--- a/obj/loot/boar_skin.lpml
+++ b/obj/loot/boar_skin.lpml
@@ -1,11 +1,15 @@
-id: [skin]
-additional ids: [hide, piece]
-adj: [boar, rough]
-name: boar skin
-short: a piece of boar skin
-long: >-
-  This is a rough piece of skin from a wild boar. It could be useful for
-  crafting.
-mass: 50
-material: [leather]
-properties: {autovalue: yes, crafting material: yes}
+{
+  id: ["skin"],
+  additional ids: ["hide","piece"],
+  adj: ["boar","rough"],
+  name: "boar skin",
+  short: "a piece of boar skin",
+  long: "This is a rough piece of skin from a wild boar. It could be useful "
+        "for crafting.",
+  mass: 50,
+  material: ["leather"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/boar_tusk.lpml
+++ b/obj/loot/boar_tusk.lpml
@@ -1,11 +1,15 @@
-id: [tusk]
-additional ids: [tooth]
-adj: [boar, sharp]
-name: boar tusk
-short: a sharp boar tusk
-long: >-
-  This is a curved, sharp tusk from a wild boar. It could be used for crafting
-  or as a primitive weapon.
-mass: 20
-material: [bone]
-properties: {autovalue: yes, crafting material: yes}
+{
+  id: ["tusk"],
+  additional ids: ["tooth"],
+  adj: ["boar","sharp"],
+  name: "boar tusk",
+  short: "a sharp boar tusk",
+  long: "This is a curved, sharp tusk from a wild boar. It could be used for "
+        "crafting or as a primitive weapon.",
+  mass: 20,
+  material: ["bone"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/cat_fur.lpml
+++ b/obj/loot/cat_fur.lpml
@@ -1,10 +1,17 @@
-id: [fur]
-additional ids: [hide, piece]
-adj: [cat, soft]
-name: cat fur
-short: a piece of cat fur
-long: >-
-  This is a soft piece of fur from a wild cat. It could be useful for crafting.
-mass: 20
-material: [fur]
-properties: {autovalue: yes, crafting material: yes}
+{
+  id: ["fur"],
+  additional ids: ["hide","piece"],
+  adj: ["cat","soft"],
+  name: "cat fur",
+  short: "a piece of cat fur",
+  long: "This is a soft piece of fur from a wild cat. It could be useful for "
+        "crafting.",
+  mass: 20,
+  material: [
+    "fur"
+  ],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/grasshopper_leg.lpml
+++ b/obj/loot/grasshopper_leg.lpml
@@ -1,11 +1,16 @@
-id: [leg]
-additional_ids: [insect leg, hopper leg]
-adj: [grasshopper, spindly]
-name: grasshopper leg
-short: a grasshopper's leg
-long: >-
-  This is a long, spindly leg from a grasshopper. It might be useful as bait
-  for fishing.
-mass: 1
-material: [insect]
-properties: {autovalue: yes, crafting_material: yes, bait: yes}
+{
+  id: ["leg"],
+  additional ids: ["insect leg","hopper leg"],
+  adj: ["grasshopper","spindly"],
+  name: "grasshopper leg",
+  short: "a grasshopper's leg",
+  long: "This is a long, spindly leg from a grasshopper. It might be useful "
+        "as bait for fishing.",
+  mass: 1,
+  material: ["insect"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+    bait: true,
+  },
+}

--- a/obj/loot/insect_wing.lpml
+++ b/obj/loot/insect_wing.lpml
@@ -1,11 +1,15 @@
-id: [wing]
-additional ids: [bug wing, fly wing]
-adj: [insect, delicate]
-name: insect wing
-short: a delicate insect wing
-long: >-
-  This is a thin, transparent wing from an insect. It's very fragile but might
-  be useful in certain alchemical recipes.
-mass: 1
-material: [insect]
-properties: {autovalue: yes, crafting material: yes}
+{
+  id: ["wing"],
+  additional ids: ["bug wing","fly wing"],
+  adj: ["insect","delicate"],
+  name: "insect wing",
+  short: "a delicate insect wing",
+  long: "This is a thin, transparent wing from an insect. It's very fragile "
+        "but might be useful in certain alchemical recipes.",
+  mass: 1,
+  material: ["insect"],
+  properties: {
+    autovalue: true,
+    crafting_material: true,
+  },
+}

--- a/obj/loot/rabbit_fur.lpml
+++ b/obj/loot/rabbit_fur.lpml
@@ -1,10 +1,14 @@
-id: [fur, patch]
-adj: [rabbit]
-name: rabbit fur
-short: a patch of soft rabbit fur
-long: >-
-  This is a small patch of soft, fluffy fur from a rabbit. It could be used for
-  crafting warm clothing.
-mass: 10
-material: [fur]
-properties: {autovalue: yes, crafting material: yes}
+{
+  id: ["fur","patch"],
+  adj: ["rabbit"],
+  name: "rabbit fur",
+  short: "a patch of soft rabbit fur",
+  long: "This is a small patch of soft, fluffy fur from a rabbit. It could be "
+        "used for crafting warm clothing.",
+  mass: 10,
+  material: ["fur"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/rat_fur.lpml
+++ b/obj/loot/rat_fur.lpml
@@ -1,11 +1,15 @@
-id: [fur]
-additional ids: [hide, piece]
-adj: [waste, scrappy]
-name: rat fur
-short: a piece of rat fur
-long: >-
-  This is a scrappy piece of fur from a waste rat. It could be useful for
-  crafting.
-mass: 10
-material: [fur]
-properties: {autovalue: yes, crafting material: yes}
+{
+  id: ["fur"],
+  additional ids: ["hide","piece"],
+  adj: ["waste","scrappy"],
+  name: "rat fur",
+  short: "a piece of rat fur",
+  long: "This is a scrappy piece of fur from a waste rat. It could be useful "
+        "for crafting.",
+  mass: 10,
+  material: ["fur"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/small_bone.lpml
+++ b/obj/loot/small_bone.lpml
@@ -1,10 +1,14 @@
-id: [bone]
-adj: [small, animal]
-name: small bone
-short: a small animal bone
-long: >-
-  This is a small bone from a tiny animal, possibly a mouse or a bird. It might
-  be useful for crafting small tools or jewelry.
-mass: 5
-material: [bone]
-properties: {autovalue: yes, crafting material: yes}
+{
+  id: ["bone"],
+  adj: ["small","animal"],
+  name: "small bone",
+  short: "a small animal bone",
+  long: "This is a small bone from a tiny animal, possibly a mouse or a bird."
+        "It might be useful for crafting small tools or jewelry.",
+  mass: 5,
+  material: ["bone"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}


### PR DESCRIPTION
# Switch from JSON to LPML for Configuration Files

This PR migrates the configuration system from JSON to LPML (LPC Markup Language), a more human-friendly configuration format for MUDs. The changes include:

1. Updated the configuration daemon to use `.lpml` files instead of `.json`
2. Added a new `loaded` flag to prevent errors during daemon initialization
3. Converted all configuration files to LPML format with proper JSON-style syntax
4. Added a comprehensive LPML specification document (`doc/lpml-spec.md`)
5. Implemented a new `lpml_decode()` function with support for:
   - Comments (single and multi-line)
   - Unquoted and space-containing keys
   - String concatenation with smart spacing
   - File includes with `#path` syntax
   - Multiline strings with automatic folding

The new format maintains backward compatibility with JSON while adding features that make configuration files more maintainable and readable. The implementation handles UTF-8 safely and provides graceful error handling.