### PR TITLE
Fix relative path resolution in LPML

### DIFF
--- a/adm/simul_efun/lpml.c
+++ b/adm/simul_efun/lpml.c
@@ -88,7 +88,7 @@ private string resolve_relative_path(string relative_path, string relative_to) {
           "from '"+relative_to+"'"
         );
 
-      relative_path_parts = ({relative_to_parts[<1]}) + relative_path_parts;
+      relative_path_parts = ({relative_to_parts[<1]}) + relative_path_parts[2..];
       relative_to_parts = relative_to_parts[0..<2];
     }
 


### PR DESCRIPTION
Fixed a bug in `resolve_relative_path` function where relative paths were incorrectly processed. The fix ensures that when resolving paths relative to another path, we correctly handle the path parts by only including elements after the first two entries (which typically represent the "../" part) from the relative path. This prevents duplicate path segments in the resolved path.