### PR TITLE
Fix relative path resolution in LPML

### DIFF
--- a/adm/simul_efun/lpml.c
+++ b/adm/simul_efun/lpml.c
@@ -88,7 +88,7 @@ private string resolve_relative_path(string relative_path, string relative_to) {
           "from '"+relative_to+"'"
         );
 
-      relative_path_parts = ({relative_to_parts[<1]}) + relative_path_parts[2..];
+      relative_path_parts = ({relative_to_parts[<1]}) + relative_path_parts[1..];
       relative_to_parts = relative_to_parts[0..<2];
     }
 


### PR DESCRIPTION
Fixed a bug in `resolve_relative_path` function where relative path parts were incorrectly sliced. Changed the slice from `relative_path_parts[2..]` to `relative_path_parts[1..]` to properly handle relative paths.