### PR TITLE
Update LPML file association and disable formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,7 +42,11 @@
     ]
   },
   "files.associations": {
-    "*.lpml": "yaml",
+    "*.lpml": "lpml",
+  },
+  "[lpml]": {
+    "editor.formatOnSave": false,
+    "editor.defaultFormatter": null
   },
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,


### PR DESCRIPTION
Updated VS Code settings to properly handle LPML files by:
- Changed file association for `.lpml` files from `yaml` to `lpml`
- Added specific editor settings for LPML files:
  - Disabled format on save
  - Set default formatter to null

These changes ensure LPML files are treated as their own language type with appropriate formatting behavior.