### PR TITLE
fix off-by-one in starts_with

### DIFF
--- a/adm/simul_efun/string.c
+++ b/adm/simul_efun/string.c
@@ -590,7 +590,7 @@ int starts_with(string str, string starting_string) {
   if(len2 > len)
     return false;
 
-  return str[0 .. len2] == starting_string;
+  return str[0 .. len2-1] == starting_string;
 }
 
 /**


### PR DESCRIPTION
Fixes an off-by-one error in `starts_with` where the substring slice `str[0 .. len2]` included one extra character beyond the length of `starting_string`, causing incorrect comparisons.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an off-by-one error in `starts_with` in `adm/simul_efun/string.c`. Because LPC string ranges are inclusive on both ends, `str[0 .. len2]` was extracting `len2 + 1` characters, causing the equality check against `starting_string` (of length `len2`) to always return false for any non-identical string.

- The slice is corrected from `str[0 .. len2]` to `str[0 .. len2-1]`, now extracting exactly `len2` characters as intended.
- The analogous `ends_with` function uses `str[<len2 ..]` (LPC's from-end indexing), which already correctly selects the last `len2` characters and is unaffected.

<h3>Confidence Score: 5/5</h3>

Single targeted fix that correctly repairs a comparison that was never true for non-identical strings.

The change is a one-character fix to an inclusive range index. LPC's [a .. b] slicing is inclusive on both ends, so the original str[0 .. len2] extracted one extra character, guaranteeing a mismatch. The corrected str[0 .. len2-1] extracts exactly the right number of characters. No other logic is touched, and the parallel ends_with function is unaffected.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: correct starts\_with function to pro..."](https://github.com/gesslar/oxidus-mudlib/commit/3a65fd3f8942392ae2279866decdb4c2fca41fd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35299895)</sub>

<!-- /greptile_comment -->