### PR TITLE
fix alias resolution dropping args when no space in alias

### DIFF
--- a/std/object/command.c
+++ b/std/object/command.c
@@ -352,7 +352,10 @@ public int command_hook(string arg) {
     complete = verb;
 
   string aliased = ALIAS_D->resolve_alias(complete, this_object());
+
   if(aliased) {
+    arg = 0;
+
     sscanf(aliased, "%s %s", verb, arg) || verb = aliased;
   }
 


### PR DESCRIPTION
When a command matches an alias, the original argument is cleared before parsing the aliased command. This ensures that if the alias expands to a single word with no arguments, the previous `arg` value is not retained and incorrectly passed along.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in `std/object/command.c` where resolving an alias to a single-word command (no space) would retain the original `arg` value, causing it to be incorrectly passed to the aliased command's handler.

- The fix adds `arg = 0;` immediately before the `sscanf` call inside the `if(aliased)` block, so that if `sscanf` fails to find a space in the aliased string, `arg` is cleanly cleared rather than carrying over the previous value.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line reset that correctly clears `arg` before parsing the aliased command, matching the intended behavior described in the PR.

The change is minimal and targeted: clearing `arg` before `sscanf` ensures both branches (alias with args and alias without args) produce the correct state. The logic before and after the alias block is unaffected. No edge cases appear to be introduced.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fixing command hook"](https://github.com/gesslar/oxidus-mudlib/commit/2c80ba4be6aad4ceb260bab9add352c1c88afbf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36094455)</sub>

<!-- /greptile_comment -->