### PR TITLE
refactor groups, replace noname literals with NONAME, and remove overrides.c valid_override check

### DIFF
--- a/adm/etc/groups
+++ b/adm/etc/groups
@@ -1,4 +1,4 @@
-(developer)gesslar:claude
+(developer)(admin):(owner):claude
 (admin)[admin]:[daemon]:[master]:[cmd_admin]:[adm_obj]:(owner):claude
 (soul)(admin)
 (owner)gesslar

--- a/adm/obj/master/valid.c
+++ b/adm/obj/master/valid.c
@@ -320,7 +320,7 @@ private int valid_object(object ob) {
     name = query_privs(previous_object());
 
   if(!name)
-    name = "noname";
+    name = NONAME;
 
   if(file_name(ob) == "/adm/daemons/login")
     return 1;
@@ -347,9 +347,6 @@ private int valid_override(string _file, string efun_name, string mainfile) {
     return 1;
 
   if(mainfile == "/adm/simul_efun/override.c")
-    return 1;
-
-  if(mainfile == "/adm/simul_efun/overrides.c")
     return 1;
 
   if(efun_name == "this_player" && mainfile == "/adm/simul_efun/object.c")
@@ -408,7 +405,7 @@ private int valid_read(string file, object user, string func) {
     name = query_privs(user);
 
   if(!name)
-    name = "noname";
+    name = NONAME;
 
   if(strlen(file) > strlen(user_data_directory(name))) {
     if(file[0..(strlen(user_data_directory(name))-1)] == user_data_directory(name))
@@ -463,7 +460,7 @@ private int valid_write(string file, object user, string _func) {
     name = query_privs(user);
 
   if(!name)
-    name = "noname";
+    name = NONAME;
 
   if(user == this_object() || user == master())
     return 1;


### PR DESCRIPTION
Replaces hardcoded `"noname"` string literals with the `NONAME` constant across the validation functions in `valid.c`, ensuring consistency and easier maintenance if the value ever needs to change.

Removes the now-obsolete override permission for `/adm/simul_efun/overrides.c`, which appears to have been superseded by `/adm/simul_efun/override.c`.

Updates the `groups` file to replace the named `gesslar` developer entry with role-based group references `(developer)(admin):(owner):claude`, aligning developer access with the existing group hierarchy rather than granting it to a specific user directly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a focused cleanup that replaces three hardcoded `"noname"` string literals with the `NONAME` constant in `valid.c`, removes a dead `valid_override` check for the non-existent `overrides.c` file, and restructures the `(developer)` group entry to use role-based references instead of a named user.

- **`valid.c` constant refactor**: All three `"noname"` literals are replaced with `NONAME`, which resolves to the same string via the driver's globally auto-included `<global.h>` — no semantic change.
- **`valid.c` dead code removal**: The `valid_override` guard for `/adm/simul_efun/overrides.c` is removed; this file does not exist in the repository and `override.c` is already permitted on the line above.
- **`groups` restructure**: `(developer)gesslar:claude` becomes `(developer)(admin):(owner):claude`, granting developer membership to the `(admin)` and `(owner)` role groups rather than a specific username, while `claude` retains its direct membership.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three changes are well-scoped refactors with no semantic risk.

The NONAME substitution is purely symbolic (the constant expands to the same string). The override removal eliminates a dead code path for a file that no longer exists. The groups change preserves existing access for all users while making the grant role-based rather than name-based; the parser handles nested group references correctly.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["updating groups and valid"](https://github.com/gesslar/oxidus-mudlib/commit/f9b3fc1a3f8d40e33c206f51ccdf29fa18f43bd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36094457)</sub>

<!-- /greptile_comment -->