### PR TITLE
fix splice negative start, standardize callback signatures, add string simul_efun tests

### DIFF
--- a/adm/simul_efun/array.c
+++ b/adm/simul_efun/array.c
@@ -111,6 +111,9 @@ varargs mixed *splice(mixed *arr, int start, int delete_count, mixed *items_to_a
   if(!pointerp(items_to_add))
     items_to_add = ({});
 
+  if(start < 0)
+    start = sizeof(arr) + start;
+
   before = arr[0..start - 1];
   after = arr[start + delete_count..];
 
@@ -564,8 +567,9 @@ varargs mixed *slice(mixed *arr, int start, int end) {
  * The function accumulates a result as it processes each element.
  *
  * @param {mixed*} arr Array to reduce
- * @param {function} fun Function taking (accumulator, current_value, index, array)
+ * @param {function} fun Function taking (accumulator, current_value, index, array, ...arg)
  * @param {mixed} [init=arr[0]] Initial value for accumulator
+ * @param {mixed} [arg] Additional arguments passed to the callback starting at $5
  * @returns {mixed} Final accumulated value
  *
  * @example
@@ -869,8 +873,8 @@ mixed *flatten(mixed *arr) {
  * Returns the index of the first element that passes the test function.
  *
  * @param {mixed*} arr - Array to search
- * @param {function} fun - Test function
- * @param {mixed} [extra] - Additional arguments to pass to test function
+ * @param {function} fun - Test function taking (element, index, array, ...extra)
+ * @param {mixed} [extra] - Additional arguments passed to the callback starting at $4
  * @returns {int} Index of first matching element or -1 if none found
  * @errors If arguments are invalid types
  */
@@ -881,7 +885,7 @@ varargs int find_index(mixed *arr, function fun, mixed extra...) {
   assert_arg(valid_function(fun), 2, "Function is required");
 
   for(i = 0, sz = sizeof(arr); i < sz; i++) {
-    if(extra ? fun(arr[i], extra...) : fun(arr[i])) {
+    if(fun(arr[i], i, arr, extra...)) {
       return i;
     }
   }
@@ -893,8 +897,8 @@ varargs int find_index(mixed *arr, function fun, mixed extra...) {
  * Returns the first element that passes the test function.
  *
  * @param {mixed*} arr - Array to search
- * @param {function} fun - Test function
- * @param {mixed} [extra] - Additional arguments to pass to test function
+ * @param {function} fun - Test function taking (element, index, array, ...extra)
+ * @param {mixed} [extra] - Additional arguments passed to the callback starting at $4
  * @returns {mixed} First matching element or null if none found
  * @errors If arguments are invalid types
  */
@@ -928,6 +932,10 @@ int in_range(int index, mixed *arr) {
  *
  * For arrays, the function is called with (element, index, array, ...extra).
  * For mappings, the function is called with (key, value, mapping, ...extra).
+ *
+ * @param {mixed} src - Array or mapping to iterate over
+ * @param {function} fun - Function called per element/pair (see above)
+ * @param {mixed} [extra] - Additional arguments passed to the callback starting at $4
  */
 varargs void each(mixed src, function fun, mixed extra...) {
   assert_arg(pointerp(src) || mapp(src), 1, "Array or mapping required.");
@@ -936,16 +944,15 @@ varargs void each(mixed src, function fun, mixed extra...) {
   if(pointerp(src)) {
     int i, sz;
 
-    for(i = 0, sz = sizeof(src); i < sz; i++) {
-      extra ? fun(src[i], i, src, extra...) : fun(src[i], i, src);
-    }
+    for(i = 0, sz = sizeof(src); i < sz; i++)
+      fun(src[i], i, src, extra...);
   }
 
   if(mapp(src)) {
     mixed key, val;
 
     foreach(key, val in src) {
-      extra ? fun(key, val, src, extra...) : fun(key, val, src);
+      fun(key, val, src, extra...);
     }
   }
 }
@@ -961,7 +968,7 @@ varargs void each(mixed src, function fun, mixed extra...) {
  * @param {mixed*} src - The array to search
  * @param {function} fun - The function to apply to each element (called as
  *                         fun(element, index, array, size, ...extra))
- * @param {mixed...} [extra] - Optional extra arguments passed to the function
+ * @param {mixed...} [extra] - Additional arguments passed to the callback starting at $5
  * @returns {mixed} The first non-null result, or UNDEFINED if none found
  */
 varargs mixed eval_first(mixed *src, function fun, mixed extra...) {
@@ -972,9 +979,7 @@ varargs mixed eval_first(mixed *src, function fun, mixed extra...) {
 
   if((sz = sizeof(src)) > 0) {
     for(; i < sz; i++) {
-      mixed result = extra
-        ? fun(src[i], i,  src, sz, extra...)
-        : fun(src[i], i, src, sz);
+      mixed result = fun(src[i], i,  src, sz, extra...);
 
       if(!nullp(result))
         return result;
@@ -994,7 +999,7 @@ varargs mixed eval_first(mixed *src, function fun, mixed extra...) {
  *
  * @param {mixed*} src The array to search
  * @param {function} fun The function to apply to each element (called as fun(element, index, array, size, ...extra))
- * @param {mixed...} [extra] Optional extra arguments passed to the function
+ * @param {mixed...} [extra] Additional arguments passed to the callback starting at $5
  * @returns {mixed} The last non-null result, or UNDEFINED if none found
  *
  * @example

--- a/tests/adm/simul_efun/array.functional.test.c
+++ b/tests/adm/simul_efun/array.functional.test.c
@@ -148,7 +148,7 @@ void setup() {
     }),
     test("forwards extra varargs to the predicate", function() {
       ASSERT_EQ(1, find_index(({ 1, 2, 3 }),
-        (: $1 == $2 :), 2));
+        (: $1 == $4 :), 2));
     }),
     test("non-array first arg errors", function() {
       string err = catch(find_index(0, (: 1 :)));
@@ -179,7 +179,7 @@ void setup() {
     }),
     test("forwards extra varargs to the predicate", function() {
       ASSERT_EQ(20, find(({ 10, 20, 30 }),
-        (: $1 == $2 :), 20));
+        (: $1 == $4 :), 20));
     }),
     test("non-array first arg errors", function() {
       string err = catch(find(0, (: 1 :)));
@@ -238,6 +238,16 @@ void setup() {
       // elem in original order: 4.
       ASSERT_EQ(4, eval_last(({ 1, 2, 3, 4 }),
         (: $1 > 1 ? $1 : null :)));
+    }),
+    test("callback receives size as fourth arg", function() {
+      ASSERT_EQ(5, eval_last(({ 10, 20, 30, 40, 50 }),
+        (: $4 :)));
+    }),
+    test("forwards extra varargs to the callback", function() {
+      // $1=elem, $2=idx, $3=src, $4=sz, $5=bonus. Reversed iteration
+      // hits 2 before 1, so the first non-null match is 2 + 5 = 7.
+      ASSERT_EQ(7, eval_last(({ 1, 2, 3 }),
+        (: $1 == 2 ? $1 + $5 : null :), 5));
     }),
     test("returns UNDEFINED when no element yields non-null",
       function() {

--- a/tests/adm/simul_efun/array.predicate.test.c
+++ b/tests/adm/simul_efun/array.predicate.test.c
@@ -49,7 +49,7 @@ void setup() {
     }),
     test("uses custom comparator when provided", function() {
       ASSERT_EQ(1, includes(({ 1, 2, 3, 4 }), 6,
-        (: $1 + $2 == 10 :)));
+        (: $1 + $4 == 10 :)));
     }),
     test("custom comparator returns 0 when no match", function() {
       ASSERT_EQ(0, includes(({ 1, 2, 3 }), 99,
@@ -66,7 +66,7 @@ void setup() {
     }),
     test("alias accepts an optional comparator", function() {
       ASSERT_EQ(1, in_array(6, ({ 1, 2, 3, 4 }),
-        (: $1 + $2 == 10 :)));
+        (: $1 + $4 == 10 :)));
     }),
   }));
 

--- a/tests/adm/simul_efun/array.transform.test.c
+++ b/tests/adm/simul_efun/array.transform.test.c
@@ -198,6 +198,18 @@ void setup() {
         same_array(({ 0, 1, 2, 3 }),
                    splice(({ 1, 2, 3 }), 0, 0, ({ 0 })), 1));
     }),
+    test("negative start counts from the end", function() {
+      // start=-1 maps to sizeof+(-1) = last index. Insert before it.
+      ASSERT_EQ(1,
+        same_array(({ 1, 2, 3, 99, 4 }),
+                   splice(({ 1, 2, 3, 4 }), -1, 0, ({ 99 })), 1));
+    }),
+    test("negative start with delete removes from the end", function() {
+      // start=-2 maps to index 2; delete_count=1 drops the 3.
+      ASSERT_EQ(1,
+        same_array(({ 1, 2, 99, 4 }),
+                   splice(({ 1, 2, 3, 4 }), -2, 1, ({ 99 })), 1));
+    }),
     test("delete_count beyond end removes to end", function() {
       ASSERT_EQ(1,
         same_array(({ 1 }),
@@ -295,7 +307,7 @@ void setup() {
       // returns elements from it that have a matching element in the
       // larger array under the custom predicate.
       mixed *result = intersection(a, b,
-        (: ($1 % 2 == 0) && ($2 % 2 == 0) :));
+        (: ($1 % 2 == 0) && ($4 % 2 == 0) :));
       // Every element of b is even; 2 and 4 in a are even and match,
       // so every element of b is included in the result.
       ASSERT_EQ(({ 10, 20, 30 }), result);

--- a/tests/adm/simul_efun/string.affix.test.c
+++ b/tests/adm/simul_efun/string.affix.test.c
@@ -1,0 +1,128 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/string.affix.test.c
+ *
+ * Tests for the affix simul_efuns from /adm/simul_efun/string.c:
+ * append(), prepend(), chop(), starts_with(), and ends_with().
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("append", ({
+    test("appends when the suffix is absent", function() {
+      ASSERT_EQ("foobar", append("foo", "bar"));
+    }),
+    test("leaves the string unchanged when the suffix is present", function() {
+      ASSERT_EQ("foobar", append("foobar", "bar"));
+    }),
+    test("appending an empty string is a no-op", function() {
+      ASSERT_EQ("foo", append("foo", ""));
+    }),
+    test("appends to an empty source", function() {
+      ASSERT_EQ("bar", append("", "bar"));
+    }),
+    test("does not double up a longer existing suffix", function() {
+      ASSERT_EQ("the end.", append("the end.", "."));
+    }),
+  }));
+
+  describe("prepend", ({
+    test("prepends when the prefix is absent", function() {
+      ASSERT_EQ("foobar", prepend("bar", "foo"));
+    }),
+    test("leaves the string unchanged when the prefix is present", function() {
+      ASSERT_EQ("foobar", prepend("foobar", "foo"));
+    }),
+    test("prepending an empty string is a no-op", function() {
+      ASSERT_EQ("bar", prepend("bar", ""));
+    }),
+    test("prepends to an empty source", function() {
+      ASSERT_EQ("foo", prepend("", "foo"));
+    }),
+  }));
+
+  describe("chop", ({
+    test("removes the suffix from the right by default direction -1", function() {
+      ASSERT_EQ("foo", chop("foobar", "bar", -1));
+    }),
+    test("leaves the string unchanged when the suffix is absent", function() {
+      ASSERT_EQ("foobar", chop("foobar", "xyz", -1));
+    }),
+    test("removes a trailing newline", function() {
+      ASSERT_EQ("line", chop("line\n", "\n", -1));
+    }),
+    test("missing first argument errors", function() {
+      string err = catch(chop(0, "x"));
+      ASSERT_NE(0, err);
+    }),
+    test("missing second argument errors", function() {
+      string err = catch(chop("foo", 0));
+      ASSERT_NE(0, err);
+    }),
+    // The left-chop branch (dir == 1) tests `sub[0..sub_len-1] == sub`, which
+    // compares sub to itself and is always true, then slices `str[0..sub_len]`.
+    // chop("foobar", "foo", 1) yields "foob" instead of "bar".
+    pending("left direction removes the prefix",
+      "dir==1 branch is broken — compares sub to itself, see string.c#L67-70"),
+    // With no dir argument, dir defaults to 0 and `if(dir != -1) dir = 1` routes
+    // to the broken left-chop branch, so chop("foobar", "bar") yields "foob"
+    // rather than the documented right-chop result "foo".
+    pending("default direction chops from the right",
+      "default dir routes to the broken left branch, see string.c#L57-70"),
+  }));
+
+  describe("starts_with", ({
+    test("returns 1 when the prefix matches", function() {
+      ASSERT_EQ(1, starts_with("foobar", "foo"));
+    }),
+    test("returns 0 when the prefix does not match", function() {
+      ASSERT_EQ(0, starts_with("foobar", "bar"));
+    }),
+    test("identical strings start with each other", function() {
+      ASSERT_EQ(1, starts_with("foo", "foo"));
+    }),
+    test("a longer prefix than the string returns 0", function() {
+      ASSERT_EQ(0, starts_with("foo", "foobar"));
+    }),
+    test("every string starts with the empty string", function() {
+      ASSERT_EQ(1, starts_with("foo", ""));
+    }),
+    test("non-string first argument errors", function() {
+      string err = catch(starts_with(42, "foo"));
+      ASSERT_NE(0, err);
+    }),
+    test("non-string second argument errors", function() {
+      string err = catch(starts_with("foo", 42));
+      ASSERT_NE(0, err);
+    }),
+  }));
+
+  describe("ends_with", ({
+    test("returns 1 when the suffix matches", function() {
+      ASSERT_EQ(1, ends_with("foobar", "bar"));
+    }),
+    test("returns 0 when the suffix does not match", function() {
+      ASSERT_EQ(0, ends_with("foobar", "foo"));
+    }),
+    test("identical strings end with each other", function() {
+      ASSERT_EQ(1, ends_with("foo", "foo"));
+    }),
+    test("a longer suffix than the string returns 0", function() {
+      ASSERT_EQ(0, ends_with("bar", "foobar"));
+    }),
+    test("every string ends with the empty string", function() {
+      ASSERT_EQ(1, ends_with("foo", ""));
+    }),
+    test("non-string first argument errors", function() {
+      string err = catch(ends_with(42, "foo"));
+      ASSERT_NE(0, err);
+    }),
+    test("non-string second argument errors", function() {
+      string err = catch(ends_with("foo", 42));
+      ASSERT_NE(0, err);
+    }),
+  }));
+}

--- a/tests/adm/simul_efun/string.colour.test.c
+++ b/tests/adm/simul_efun/string.colour.test.c
@@ -1,0 +1,47 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/string.colour.test.c
+ *
+ * Tests for the colour-related simul_efuns from /adm/simul_efun/string.c:
+ * no_ansi(), colour(), and colourp(). These delegate to COLOUR_D.
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("no_ansi", ({
+    test("strips a colour code, leaving the plain text", function() {
+      ASSERT_EQ("hi", no_ansi("{{FF0000}}hi"));
+    }),
+    test("plain text with no codes is unchanged", function() {
+      ASSERT_EQ("hello", no_ansi("hello"));
+    }),
+    test("strips a trailing reset code", function() {
+      ASSERT_EQ("hi", no_ansi("{{FF0000}}hi{{res}}"));
+    }),
+  }));
+
+  describe("colour", ({
+    test("plain text with no codes is unchanged", function() {
+      ASSERT_EQ("hello", colour("hello"));
+    }),
+    test("resolves a colour code into an ANSI escape, keeping the text", function() {
+      string result = colour("{{FF0000}}hi");
+      // The code becomes an escape sequence, but the literal text remains and
+      // the result is no longer the raw colour code.
+      ASSERT_EQ(1, ends_with(result, "hi"));
+      ASSERT_NE("{{FF0000}}hi", result);
+    }),
+  }));
+
+  describe("colourp", ({
+    test("returns truthy when a colour code is present", function() {
+      ASSERT_EQ(1, !!colourp("{{FF0000}}hi"));
+    }),
+    test("returns falsy for plain text", function() {
+      ASSERT_EQ(0, !!colourp("plain text"));
+    }),
+  }));
+}

--- a/tests/adm/simul_efun/string.convert.test.c
+++ b/tests/adm/simul_efun/string.convert.test.c
@@ -1,0 +1,62 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/string.convert.test.c
+ *
+ * Tests for from_string() from /adm/simul_efun/string.c, which parses an LPC
+ * value out of its string representation.
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("from_string scalars", ({
+    test("parses a positive integer", function() {
+      ASSERT_EQ(123, from_string("123"));
+    }),
+    test("parses a negative integer", function() {
+      ASSERT_EQ(-5, from_string("-5"));
+    }),
+    test("parses a hexadecimal integer", function() {
+      ASSERT_EQ(32, from_string("0x20"));
+    }),
+    test("parses a float", function() {
+      ASSERT_EQ(3.14, from_string("3.14"));
+    }),
+    test("parses a quoted string", function() {
+      ASSERT_EQ("hello", from_string("\"hello\""));
+    }),
+    // The hex scan loop only accepts digits 0-9, never a-f, so any hex literal
+    // containing a letter digit stops early: from_string("0xFF") yields 0.
+    pending("parses a hexadecimal integer with letter digits",
+      "hex loop excludes a-f, see string.c#L316"),
+    test("an empty string parses to 0", function() {
+      ASSERT_EQ(0, from_string(""));
+    }),
+    test("a whitespace-only string parses to 0", function() {
+      ASSERT_EQ(0, from_string("   "));
+    }),
+  }));
+
+  describe("from_string collections", ({
+    test("parses an array of integers", function() {
+      ASSERT_EQ(1, same(({ 1, 2, 3 }), from_string("({1,2,3,})")));
+    }),
+    test("parses an array of strings", function() {
+      ASSERT_EQ(1, same(({ "a", "b" }), from_string("({\"a\",\"b\",})")));
+    }),
+    test("parses an empty array", function() {
+      ASSERT_EQ(1, same(({}), from_string("({})")));
+    }),
+    test("parses a mapping", function() {
+      ASSERT_EQ(1, same(([ "a": 1 ]), from_string("([\"a\":1,])")));
+    }),
+  }));
+
+  describe("from_string with flag", ({
+    test("returns value and remaining string for an integer", function() {
+      ASSERT_EQ(1, same(({ 123, "rest" }), from_string("123 rest", 1)));
+    }),
+  }));
+}

--- a/tests/adm/simul_efun/string.format.test.c
+++ b/tests/adm/simul_efun/string.format.test.c
@@ -1,0 +1,64 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/string.format.test.c
+ *
+ * Tests for the formatting simul_efuns from /adm/simul_efun/string.c:
+ * add_commas() and stringify().
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("add_commas", ({
+    test("a value under one thousand is unchanged", function() {
+      ASSERT_EQ("100", add_commas(100));
+    }),
+    test("inserts a comma at the thousands boundary", function() {
+      ASSERT_EQ("1,000", add_commas(1000));
+    }),
+    test("inserts commas in a six-figure number", function() {
+      ASSERT_EQ("123,456", add_commas(123456));
+    }),
+    test("inserts commas in a seven-figure number", function() {
+      ASSERT_EQ("1,000,000", add_commas(1000000));
+    }),
+    test("zero is unchanged", function() {
+      ASSERT_EQ("0", add_commas(0));
+    }),
+    test("a negative number keeps its sign", function() {
+      ASSERT_EQ("-1,000", add_commas(-1000));
+    }),
+    test("accepts a numeric string", function() {
+      ASSERT_EQ("12,345", add_commas("12345"));
+    }),
+    test("preserves the fractional part of a numeric string", function() {
+      ASSERT_EQ("12,345.67", add_commas("12345.67"));
+    }),
+  }));
+
+  describe("stringify", ({
+    test("an integer becomes its decimal string", function() {
+      ASSERT_EQ("42", stringify(42));
+    }),
+    test("zero becomes \"0\"", function() {
+      ASSERT_EQ("0", stringify(0));
+    }),
+    test("undefined becomes \"0\"", function() {
+      ASSERT_EQ("0", stringify(undefined));
+    }),
+    test("a float becomes its formatted string", function() {
+      ASSERT_EQ("3.500000", stringify(3.5));
+    }),
+    test("a string is returned verbatim", function() {
+      ASSERT_EQ("hello", stringify("hello"));
+    }),
+    test("an array serialises to a non-empty string", function() {
+      ASSERT_EQ(1, stringp(stringify(({ 1, 2, 3 }))));
+    }),
+    test("a mapping serialises to a non-empty string", function() {
+      ASSERT_EQ(1, stringp(stringify(([ "a": 1 ]))));
+    }),
+  }));
+}

--- a/tests/adm/simul_efun/string.search.test.c
+++ b/tests/adm/simul_efun/string.search.test.c
@@ -1,0 +1,92 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/string.search.test.c
+ *
+ * Tests for the search / predicate simul_efuns from /adm/simul_efun/string.c:
+ * reverse_strsrch(), pcre_strsrch(), is_numeric(), and sanitize_regex().
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("reverse_strsrch", ({
+    test("finds the last occurrence of a substring", function() {
+      ASSERT_EQ(3, reverse_strsrch("abcabc", "abc"));
+    }),
+    test("finds the last single character", function() {
+      ASSERT_EQ(3, reverse_strsrch("hello", "l"));
+    }),
+    test("returns -1 when the substring is absent", function() {
+      ASSERT_EQ(-1, reverse_strsrch("abc", "z"));
+    }),
+    test("returns -1 when the substring is longer than the string", function() {
+      ASSERT_EQ(-1, reverse_strsrch("ab", "abc"));
+    }),
+    test("missing first argument errors", function() {
+      string err = catch(reverse_strsrch(0, "x"));
+      ASSERT_NE(0, err);
+    }),
+    test("missing second argument errors", function() {
+      string err = catch(reverse_strsrch("abc", 0));
+      ASSERT_NE(0, err);
+    }),
+  }));
+
+  // pcre_strsrch relies on pcre_extract, which returns capture groups, so the
+  // search pattern must wrap the text of interest in a capturing group.
+  describe("pcre_strsrch", ({
+    test("finds the position of a literal capture group", function() {
+      ASSERT_EQ(6, pcre_strsrch("hello world", "(wor)"));
+    }),
+    test("finds the position of a regex capture group", function() {
+      ASSERT_EQ(3, pcre_strsrch("abc123", "(\\d+)"));
+    }),
+    test("returns -1 when there is no match", function() {
+      ASSERT_EQ(-1, pcre_strsrch("abcdef", "(\\d+)"));
+    }),
+  }));
+
+  describe("is_numeric", ({
+    test("a positive integer is numeric", function() {
+      ASSERT_EQ(1, is_numeric("3"));
+    }),
+    test("a negative integer is numeric", function() {
+      ASSERT_EQ(1, is_numeric("-42"));
+    }),
+    test("a float is not numeric without the float flag", function() {
+      ASSERT_EQ(0, is_numeric("3.14"));
+    }),
+    test("a float is numeric with the float flag", function() {
+      ASSERT_EQ(1, is_numeric("3.14", 1));
+    }),
+    test("a negative float is numeric with the float flag", function() {
+      ASSERT_EQ(1, is_numeric("-3.14", 1));
+    }),
+    test("letters are not numeric", function() {
+      ASSERT_EQ(0, is_numeric("abc"));
+    }),
+    test("an empty string is not numeric", function() {
+      ASSERT_EQ(0, is_numeric(""));
+    }),
+    test("a trailing-dot value is not a valid float", function() {
+      ASSERT_EQ(0, is_numeric("3.", 1));
+    }),
+  }));
+
+  describe("sanitize_regex", ({
+    test("escapes a lone percent sign", function() {
+      ASSERT_EQ("50%%", sanitize_regex("50%"));
+    }),
+    test("leaves an already-escaped percent untouched", function() {
+      ASSERT_EQ("%%", sanitize_regex("%%"));
+    }),
+    test("a string with no percent is unchanged", function() {
+      ASSERT_EQ("hello", sanitize_regex("hello"));
+    }),
+    test("escapes multiple separated percents", function() {
+      ASSERT_EQ("a%%b%%c", sanitize_regex("a%b%c"));
+    }),
+  }));
+}

--- a/tests/adm/simul_efun/string.slice.test.c
+++ b/tests/adm/simul_efun/string.slice.test.c
@@ -1,0 +1,81 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/string.slice.test.c
+ *
+ * Tests for the slicing / casing simul_efuns from /adm/simul_efun/string.c:
+ * extract(), substr(), reverse_string(), and all_caps().
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("extract", ({
+    test("extracts from a start position to the end", function() {
+      ASSERT_EQ("llo", extract("hello", 2));
+    }),
+    test("extracts an inclusive range", function() {
+      ASSERT_EQ("ell", extract("hello", 1, 3));
+    }),
+    test("a single character range", function() {
+      ASSERT_EQ("h", extract("hello", 0, 0));
+    }),
+    test("from at the start returns the whole string", function() {
+      ASSERT_EQ("hello", extract("hello", 0));
+    }),
+  }));
+
+  describe("substr", ({
+    test("returns the text before the first occurrence", function() {
+      ASSERT_EQ("hello", substr("hello world", " "));
+    }),
+    test("stops at the first delimiter", function() {
+      ASSERT_EQ("a", substr("a/b/c", "/"));
+    }),
+    test("reverse returns the text after the last occurrence", function() {
+      ASSERT_EQ("c", substr("a/b/c", "/", 1));
+    }),
+    test("missing substring returns the empty string", function() {
+      ASSERT_EQ("", substr("hello", "z"));
+    }),
+    test("missing first argument errors", function() {
+      string err = catch(substr(undefined, "x"));
+      ASSERT_NE(0, err);
+    }),
+    test("missing second argument errors", function() {
+      string err = catch(substr("hello", undefined));
+      ASSERT_NE(0, err);
+    }),
+  }));
+
+  describe("reverse_string", ({
+    test("reverses a word", function() {
+      ASSERT_EQ("olleh", reverse_string("hello"));
+    }),
+    test("a palindrome reverses to itself", function() {
+      ASSERT_EQ("level", reverse_string("level"));
+    }),
+    test("a single character is unchanged", function() {
+      ASSERT_EQ("x", reverse_string("x"));
+    }),
+    test("the empty string reverses to itself", function() {
+      ASSERT_EQ("", reverse_string(""));
+    }),
+  }));
+
+  describe("all_caps", ({
+    test("uppercases a lowercase word", function() {
+      ASSERT_EQ("HELLO", all_caps("hello"));
+    }),
+    test("uppercases mixed case", function() {
+      ASSERT_EQ("ABC", all_caps("aBc"));
+    }),
+    test("leaves non-letters alone", function() {
+      ASSERT_EQ("A1-B2", all_caps("a1-b2"));
+    }),
+    test("the empty string stays empty", function() {
+      ASSERT_EQ("", all_caps(""));
+    }),
+  }));
+}


### PR DESCRIPTION
Callbacks for `find_index`, `find`, `each`, `eval_first`, `eval_last`, and related functions now always receive the full `(element, index, array, ...extra)` signature, matching the documented contract. Previously, extra arguments were passed starting at `$2`, which conflicted with the index and array positional parameters. Extra args now start at `$4` (or `$5` for functions that also receive the array size). The conditional `extra ? fun(...) : fun(...)` branching has been removed in favor of unconditionally spreading `extra...`, which is a no-op when no extras are provided.

`splice` now accepts negative `start` values, resolving them from the end of the array in the same way JavaScript's `Array.prototype.splice` does.

Tests for `find_index`, `find`, `includes`, `in_array`, and `intersection` have been updated to reference the correct positional parameter for extra arguments. New tests cover the negative-index behavior of `splice` and the extra-argument forwarding in `eval_last`.

A full test suite for the string simul_efuns has been added, covering `append`, `prepend`, `chop`, `starts_with`, `ends_with`, `no_ansi`, `colour`, `colourp`, `from_string`, `add_commas`, `stringify`, `reverse_strsrch`, `pcre_strsrch`, `is_numeric`, `sanitize_regex`, `extract`, `substr`, `reverse_string`, and `all_caps`. Known bugs in `chop` (broken left-direction branch and incorrect default routing) and `from_string` (hex digits `a–f` not recognized) are documented as `pending` tests rather than skipped silently.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR standardises callback signatures across array simul_efuns so that extra arguments always start at `$4` (or `$5` for functions that also receive the array size), fixes `splice` to accept negative `start` values, and adds a comprehensive test suite for the string simul_efuns.

- **Callback signature fix** (`find_index`, `find`, `each`, `eval_first`, `eval_last`, `includes`, `in_array`, `intersection`): the conditional `extra ? fun(...) : fun(...)` branching is removed in favour of unconditionally spreading `extra...`, and the index + array are now always forwarded.
- **`splice` negative-start support**: `start < 0` is resolved from the end of the array before slicing; out-of-range negative values intentionally throw per LPC idiom.
- **New string tests** across six files cover `append`/`prepend`/`chop`, colour helpers, `from_string`, `add_commas`/`stringify`, search predicates, and slice/casing utilities; two known bugs are documented as `pending`.

<h3>Confidence Score: 4/5</h3>

The array simul_efun callback change is correct within the module, but one caller in adm/simul_efun/seq.c was not updated and is now broken.

seq_set in adm/simul_efun/seq.c uses find_index with (: $1[0] == $2 :) to locate an existing key. After this PR moves the extra argument from $2 to $4, that closure compares against the integer loop index instead of the key, so seq_set will never match an existing entry and will append a duplicate on every call to a non-empty map.

adm/simul_efun/seq.c line 50 — the find_index closure needs $2 changed to $4.

<sub>Reviews (2): Last reviewed commit: ["array updates"](https://github.com/gesslar/oxidus-mudlib/commit/5d0430c94ba6989a7439c27e4856d1aeede5100b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36094458)</sub>

<!-- /greptile_comment -->