### PR TITLE
add Docker image, Compose setup, entrypoint, and CI publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,59 @@
+name: Build & Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'adm/dist/docker/**'
+      - '.github/workflows/docker-publish.yml'
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/oxidus
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: adm/dist/docker
+          file: adm/dist/docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Build the exact commit that triggered this run for a reproducible lib.
+          # (fluffos still tracks master, per adm/dist/rebuild.)
+          build-args: |
+            OXIDUS_REF=${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,139 @@
 Information on setting up and further documentation of the systems and
 functions of Oxidus can be found on the [Oxidus documentation site](https://oxidus.online/).
 
+## Running with Docker
+
+A fresh, self-contained Oxidus MUD runs entirely in Docker. The image bundles
+the mudlib **and** a freshly-compiled FluffOS driver, so the only thing you need
+on the host is Docker.
+
+There are two ways in: just run the published image (no clone), or build it
+yourself from a clone of this repo.
+
+### Option 1 — Run the published image (lowest friction, no clone)
+
+You need nothing but Docker. The image is pulled automatically on first run:
+
+```bash
+docker run -d --name oxidus --init \
+  -p 1336:1336 \
+  -v oxidus-state:/oxidus/state \
+  ghcr.io/gesslar/oxidus:latest
+```
+
+- `--init` — clean signal handling, so `docker stop` shuts the driver down promptly
+- `-p 1336:1336` — exposes the telnet port on the host
+- `-v oxidus-state:/oxidus/state` — named volume holding all game state
+
+Watch it boot until you see `Accepting telnet connections...`:
+
+```bash
+docker logs -f oxidus
+```
+
+Connect and create a character — **the first character to log in becomes the
+superuser**:
+
+```bash
+telnet localhost 1336
+```
+
+Manage it:
+
+```bash
+docker stop oxidus       # stop (your world is kept in the volume)
+docker start oxidus      # start again
+docker pull ghcr.io/gesslar/oxidus:latest   # upgrade: then `docker rm -f oxidus` and re-run
+```
+
+**Reset to a brand-new MUD** (wipes the world — new accounts, superuser on first
+login again):
+
+```bash
+docker rm -f oxidus
+docker volume rm oxidus-state
+# then re-run the `docker run` command above
+```
+
+### Option 2 — Build it yourself (clone, then Docker)
+
+Clone the repo and build the image locally with Compose. This compiles the
+driver from source, so a rebuild always picks up the latest FluffOS:
+
+```bash
+git clone https://github.com/gesslar/oxidus-mudlib.git
+cd oxidus-mudlib/adm/dist/docker
+docker compose up -d --build      # build the driver + start the MUD
+docker compose logs -f            # watch it boot ("Accepting telnet connections...")
+```
+
+Connect (first login is superuser, as above):
+
+```bash
+telnet localhost 1336
+```
+
+Manage and upgrade:
+
+```bash
+docker compose down               # stop (world kept)
+docker compose up -d              # start
+docker compose build --no-cache   # rebuild against latest source, then `up -d`
+```
+
+**Reset to a brand-new MUD:**
+
+```bash
+docker compose down -v            # -v also drops the oxidus-state volume
+docker compose up -d
+```
+
+### What's actually happening
+
+- **The image is built in two stages.** The first stage clones a *pristine*
+  copy of this repository over HTTPS and compiles the driver using the canonical
+  [`adm/dist/rebuild`](adm/dist/rebuild) script (which also pins the mudlib paths
+  in `config.mud`). The second, slim runtime stage ships only the built tree.
+  (With Option 1 this has already been done for you on the published image.)
+- **Code is baked into the image; game state lives in a volume.** On first boot
+  the container's entrypoint moves every runtime-mutable path
+  (`data/`, `home/`, `log/`, `open/`, `tmp/`, `adm/etc/certs/`,
+  `adm/etc/secret/`, `adm/etc/alarms/`, and the `first_user` / `config.lpml` /
+  `mssp.lpml` files) into the `oxidus-state` volume and symlinks them back in.
+  This keeps the mudlib code pristine while your players, data and logs survive
+  restarts **and** image upgrades. Resetting the MUD is simply removing that
+  volume.
+- **The driver runs in a reboot loop**, mirroring `adm/dist/run`: an in-game
+  reboot restarts it automatically, while a real shutdown stops the container.
+
+### Running vs. rebuilding (stable at run, fresh at build)
+
+There are two clocks here, and they behave differently on purpose:
+
+- **Running is deterministic.** A built image is a frozen snapshot — a fixed
+  driver binary with the mudlib baked in. `docker run` / `docker start` /
+  `docker compose up` on the same image always behaves identically; all your
+  changing state lives in the `oxidus-state` volume, not the image.
+- **Rebuilding is when you pull the latest.** A rebuild re-clones the mudlib and,
+  via `adm/dist/rebuild`, checks out and compiles the **current** FluffOS
+  `master`. So the way to pick up a newer driver (or newer base packages) is to
+  rebuild — not to restart a container you already have.
+
+One gotcha for **local** builds: Docker's layer cache will happily reuse the
+clone/compile layers, so a plain `docker compose build` can hand you a *stale*
+rebuild (old FluffOS, old packages). To actually pull the latest, force a clean
+build:
+
+```bash
+docker compose build --no-cache && docker compose up -d
+```
+
+(CI doesn't have this problem: each push builds at its exact commit, which busts
+the cache and always recompiles against the latest FluffOS.)
+
+For TLS, build args, and the full option list, see
+[`adm/dist/docker/README.md`](adm/dist/docker/README.md).
+
 ## AI Assistant Guidelines
 
 Be aware of skills documented in .claude/skills

--- a/adm/dist/config.mud
+++ b/adm/dist/config.mud
@@ -42,7 +42,7 @@ global include file : <global.h>
 # like destructing the object. If the function isn't defined by the
 # object, then nothing will happen.
 # This time should be substantially longer than the swapping time.
-time to clean up : 120000
+time to clean up : 300
 
 # How long time until an unused object is swapped out.
 # Machine with too many players and too little memory: 900 (15 minutes)
@@ -110,7 +110,7 @@ default error message : Something went wrong.
 gametick msec : 100
 
 # Number of milliseconds between heartbeats
-heartbeat interval msec : 2000
+heartbeat interval msec : 100
 
 # explode():
 #
@@ -236,11 +236,11 @@ trace : 1
 #   out the previous lines of code to an error) eval_instruction() runs about
 #   twice as fast when this is not defined (for the most common eoperators).
 #
-trace code : 0
+trace code : 1
 
 # TRACE: set this to 1 to collect context information during LPC traces.
 trace lpc execution context : 0
-g
+
 # TRACE: set this to 1 to collect LPC instruction information during LPC traces.
 trace lpc instructions : 0
 

--- a/adm/dist/docker/.dockerignore
+++ b/adm/dist/docker/.dockerignore
@@ -1,0 +1,5 @@
+# The build context only needs the Dockerfile and entrypoint; the mudlib is
+# cloned fresh inside the image. Keep the context tiny.
+*
+!Dockerfile
+!docker-entrypoint.sh

--- a/adm/dist/docker/Dockerfile
+++ b/adm/dist/docker/Dockerfile
@@ -1,0 +1,116 @@
+# syntax=docker/dockerfile:1
+#
+# Oxidus mudlib + FluffOS driver, containerised.
+#
+# Reuses the canonical Oxidus build/run methodology in adm/dist:
+#   * adm/dist/rebuild  -> compiles the driver from the fluffos submodule and
+#                          rewrites config.mud with absolute paths.
+#   * adm/dist/run      -> reboot loop (mirrored by docker-entrypoint.sh so it
+#                          behaves correctly as PID 1).
+#
+# Stage 1 clones a pristine copy of the mudlib over public HTTPS and builds the
+# driver. Stage 2 ships only the built tree on a slim runtime base.
+
+############################
+# Stage 1: build
+############################
+FROM debian:bookworm-slim AS builder
+
+# Where the mudlib lives inside the image. The rebuild script bakes this exact
+# path into config.mud, so the runtime stage MUST use the same value.
+ARG OXIDUS_HOME=/oxidus
+# Repo + ref to clone. CI passes the exact commit SHA for a reproducible lib;
+# fluffos itself still tracks master (per the canonical rebuild script).
+ARG OXIDUS_REPO=https://github.com/gesslar/oxidus-mudlib.git
+ARG OXIDUS_REF=main
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Build toolchain + FluffOS build deps (see /mud/fluffos_deps_ubuntu).
+# Note: FluffOS's cmake always runs find_package(MySQL) and requires mysql.h
+# even though rebuild sets PACKAGE_DB_MYSQL=0, so the client headers must be
+# present (matches mysql-devel on the canonical Fedora build host).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential \
+      bison \
+      cmake \
+      git \
+      ca-certificates \
+      libssl-dev \
+      libz-dev \
+      libpcre3-dev \
+      libsqlite3-dev \
+      libpq-dev \
+      libjemalloc-dev \
+      libicu-dev \
+      default-libmysqlclient-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# Pristine clone of the mudlib.
+RUN git clone "${OXIDUS_REPO}" "${OXIDUS_HOME}" \
+ && git -C "${OXIDUS_HOME}" checkout "${OXIDUS_REF}"
+
+# Build the driver via the canonical script. It initialises the fluffos
+# submodule, compiles, installs binaries into adm/dist/bin, copies the driver
+# headers into include/driver, and rewrites config.mud's mudlib/log paths.
+WORKDIR ${OXIDUS_HOME}/adm/dist
+RUN ./rebuild
+
+# Slim the tree for the runtime stage: keep the FluffOS test certs (used for the
+# optional TLS opt-in) but drop the fluffos source/build tree and git metadata.
+RUN set -eux; cd "${OXIDUS_HOME}"; \
+    mkdir -p adm/dist/certs.dist; \
+    cp adm/dist/fluffos/testsuite/etc/cert.pem adm/dist/certs.dist/; \
+    cp adm/dist/fluffos/testsuite/etc/key.pem  adm/dist/certs.dist/; \
+    rm -rf adm/dist/fluffos .git
+
+############################
+# Stage 2: runtime
+############################
+FROM debian:bookworm-slim AS runtime
+
+ARG OXIDUS_HOME=/oxidus
+ENV OXIDUS_HOME=${OXIDUS_HOME}
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Shared libraries the dynamically-linked driver needs at runtime, plus bash
+# (run/entrypoint) and procps (pgrep, used by adm/dist/run's stop helper).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash \
+      procps \
+      ca-certificates \
+      libssl3 \
+      zlib1g \
+      libpcre3 \
+      libsqlite3-0 \
+      libpq5 \
+      libjemalloc2 \
+      libicu72 \
+      libstdc++6 \
+      libbz2-1.0 \
+      libmariadb3 \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd -r -m -d /home/oxidus -s /bin/bash oxidus
+
+COPY --from=builder ${OXIDUS_HOME} ${OXIDUS_HOME}
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+# state/ is the single persistence root; the entrypoint symlinks all mutable
+# mudlib paths into it. chown before declaring the VOLUME so a fresh named
+# volume initialises with the right ownership.
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
+ && mkdir -p ${OXIDUS_HOME}/state \
+ && chown -R oxidus:oxidus ${OXIDUS_HOME}
+
+USER oxidus
+WORKDIR ${OXIDUS_HOME}
+
+# Plain telnet on 1336; TLS telnet on 1338 is opt-in via OXIDUS_TLS=1 (see
+# docker-entrypoint.sh). EXPOSE is metadata only — you still map the port with
+# -p/ports; listing 1338 keeps the image self-describing and lets `docker run -P`
+# publish it.
+EXPOSE 1336
+EXPOSE 1338
+VOLUME ${OXIDUS_HOME}/state
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/adm/dist/docker/README.md
+++ b/adm/dist/docker/README.md
@@ -1,0 +1,126 @@
+# Oxidus in Docker
+
+A self-contained image of the [Oxidus](https://oxidus.online/) mudlib plus the
+FluffOS driver. The image clones a **pristine** copy of the mudlib and compiles
+the driver from the bundled `fluffos` submodule using the canonical
+`adm/dist/rebuild` script — so a fresh container is a brand-new mudlib, ready to
+play. The first character to log in becomes the superuser.
+
+## Quick start (build locally)
+
+```bash
+cd adm/dist/docker
+docker compose up -d --build
+docker compose logs -f          # watch it boot
+```
+
+Then connect:
+
+```bash
+telnet localhost 1336
+```
+
+Create a character — the first one to log in is made an admin.
+
+Stop it (game state is preserved in the `oxidus-state` volume):
+
+```bash
+docker compose down
+```
+
+## Run the published image
+
+```bash
+docker run -d --name oxidus --init \
+  -p 1336:1336 \
+  -v oxidus-state:/oxidus/state \
+  ghcr.io/gesslar/oxidus:latest
+```
+
+## What persists
+
+Code is baked into the image (pristine); only runtime state lives in the
+`/oxidus/state` volume. On first boot the entrypoint symlinks every mutable
+mudlib path into that volume, so it survives restarts **and** image upgrades:
+
+| Path                  | Contents                                  |
+| --------------------- | ----------------------------------------- |
+| `data/`               | accounts, areas, db, users, storage       |
+| `home/`               | player / wizard home directories          |
+| `log/`                | driver + mudlib logs                       |
+| `open/`, `tmp/`       | scratch / open data                       |
+| `adm/etc/certs/`      | TLS certs                                  |
+| `adm/etc/secret/`     | secrets                                    |
+| `adm/etc/alarms/`     | alarm files                               |
+| `adm/etc/first_user`  | superuser-assigned marker                  |
+| `adm/etc/config.lpml` | customised config                          |
+| `adm/etc/mssp.lpml`   | MSSP config                                |
+
+To start completely fresh, remove the volume: `docker volume rm oxidus-state`.
+
+## Upgrading
+
+Pull/rebuild the image and recreate the container. Because the lib is baked in
+and state is in the volume, you get the new code on top of your existing world:
+
+```bash
+docker compose pull   # or: docker compose build --no-cache
+docker compose up -d
+```
+
+**Running is stable; rebuilding is when you pull the latest.** A built image is
+a frozen snapshot — restarting a container never changes the driver or lib, only
+the volume state moves. To pick up a newer FluffOS or newer base packages you
+must *rebuild*, and because Docker's layer cache reuses the clone/compile layers,
+use `--no-cache` to force a genuinely fresh pull:
+
+```bash
+docker compose build --no-cache && docker compose up -d
+```
+
+(CI builds are always fresh: each push builds at its exact commit, busting the
+cache and recompiling against the latest FluffOS `master`.)
+
+## TLS (optional)
+
+Off by default. To enable TLS telnet using the FluffOS test certificates
+(self-signed — fine for testing, replace for production), set `OXIDUS_TLS=1`
+and publish the port:
+
+```yaml
+environment:
+  OXIDUS_TLS: "1"
+  OXIDUS_TLS_PORT: "1338"
+ports:
+  - "1336:1336"
+  - "1338:1338"
+```
+
+To use your own certificates instead, drop `cert.pem` / `key.pem` into the
+volume at `adm/etc/certs/` before first boot.
+
+## Configuration knobs
+
+Build args (Dockerfile):
+
+| Arg            | Default                                            | Purpose                          |
+| -------------- | -------------------------------------------------- | -------------------------------- |
+| `OXIDUS_REPO`  | `https://github.com/gesslar/oxidus-mudlib.git`     | mudlib repo to clone             |
+| `OXIDUS_REF`   | `main`                                             | branch / tag / commit to build   |
+| `OXIDUS_HOME`  | `/oxidus`                                          | install path inside the image    |
+
+Runtime env (entrypoint):
+
+| Env              | Default | Purpose                          |
+| ---------------- | ------- | -------------------------------- |
+| `OXIDUS_TLS`     | `0`     | `1` enables TLS telnet           |
+| `OXIDUS_TLS_PORT`| `1338`  | TLS telnet port                  |
+
+## Notes
+
+- Per the canonical `adm/dist/rebuild`, the **driver tracks fluffos `master`**:
+  rebuilding the image picks up the latest FluffOS. The mudlib itself is pinned
+  to whatever `OXIDUS_REF` you build (CI builds the exact pushed commit).
+- The container runs as a non-root `oxidus` user.
+- `--init` (compose: `init: true`) is recommended so signals/zombies are handled
+  cleanly and `docker stop` lets the driver shut down gracefully.

--- a/adm/dist/docker/docker-compose.yml
+++ b/adm/dist/docker/docker-compose.yml
@@ -1,0 +1,34 @@
+# Oxidus — local run / build.
+#
+#   docker compose up -d         # build locally and start
+#   docker compose up -d --build # force a rebuild (gets latest fluffos master)
+#   docker compose logs -f       # watch the driver
+#   docker compose down          # stop (state persists in the named volume)
+#
+# To run the published image instead of building, comment out `build:` and
+# uncomment the ghcr image line.
+
+services:
+  oxidus:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Pin a specific commit/branch/tag of the mudlib if you like.
+        OXIDUS_REF: main
+    # image: ghcr.io/gesslar/oxidus:latest
+    container_name: oxidus
+    init: true                 # tini as PID 1: clean signal forwarding + zombie reaping
+    restart: unless-stopped
+    stop_grace_period: 30s     # give the driver time to save on shutdown
+    ports:
+      - "1336:1336"            # plain telnet
+      # - "1338:1338"          # TLS telnet (also set OXIDUS_TLS=1 below)
+    # environment:
+    #   OXIDUS_TLS: "1"        # enable TLS telnet using the FluffOS test certs
+    #   OXIDUS_TLS_PORT: "1338"
+    volumes:
+      - oxidus-state:/oxidus/state
+
+volumes:
+  oxidus-state:

--- a/adm/dist/docker/docker-entrypoint.sh
+++ b/adm/dist/docker/docker-entrypoint.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+#
+# Container entrypoint for the Oxidus image.
+#
+#   1. Symlinks every runtime-mutable mudlib path into the persistent volume at
+#      $OXIDUS_HOME/state, so the baked image stays pristine while game state
+#      (players, data, logs, certs, ...) survives container/image upgrades.
+#   2. Optionally enables TLS telnet using the FluffOS test certs.
+#   3. Runs the driver in a reboot loop, mirroring adm/dist/run but with proper
+#      signal handling for PID 1.
+#
+# The set of persisted paths is derived from the mudlib .gitignore (everything
+# the lib writes at runtime). Add to PERSIST_DIRS / PERSIST_FILES if the lib
+# starts writing somewhere new.
+
+set -eo pipefail
+
+OXIDUS_HOME="${OXIDUS_HOME:-/oxidus}"
+STATE="${OXIDUS_HOME}/state"
+DIST="${OXIDUS_HOME}/adm/dist"
+DRIVER="${DIST}/bin/driver"
+CONFIG="${DIST}/config.mud"
+
+cd "${OXIDUS_HOME}"
+
+# Directories whose *contents* are runtime state.
+PERSIST_DIRS=(
+  data
+  open
+  home
+  log
+  tmp
+  adm/etc/certs
+  adm/etc/secret
+  adm/etc/alarms
+)
+
+# Individual files written at runtime (may not exist in a pristine clone).
+PERSIST_FILES=(
+  adm/etc/first_user
+  adm/etc/config.lpml
+  adm/etc/mssp.lpml
+)
+
+# Move a directory's pristine contents into the volume on first boot, then
+# replace it with a symlink into the volume.
+link_dir() {
+  local rel="$1"
+  local src="${OXIDUS_HOME}/${rel}"
+  local dst="${STATE}/${rel}"
+
+  if [ ! -e "${dst}" ]; then
+    mkdir -p "$(dirname "${dst}")"
+    if [ -d "${src}" ] && [ ! -L "${src}" ]; then
+      cp -a "${src}" "${dst}"   # seed from the pristine image copy (.keep files etc.)
+    else
+      mkdir -p "${dst}"
+    fi
+  fi
+
+  rm -rf "${src}"
+  mkdir -p "$(dirname "${src}")"
+  ln -s "${dst}" "${src}"
+}
+
+# Symlink a single file into the volume. A dangling link is fine: the first
+# write the lib makes lands in the volume.
+link_file() {
+  local rel="$1"
+  local src="${OXIDUS_HOME}/${rel}"
+  local dst="${STATE}/${rel}"
+
+  mkdir -p "$(dirname "${dst}")"
+  if [ ! -e "${dst}" ] && [ -f "${src}" ] && [ ! -L "${src}" ]; then
+    cp -a "${src}" "${dst}"
+  fi
+
+  rm -f "${src}"
+  mkdir -p "$(dirname "${src}")"
+  ln -s "${dst}" "${src}"
+}
+
+echo "[entrypoint] wiring persistent state into ${STATE}"
+for d in "${PERSIST_DIRS[@]}"; do link_dir "${d}"; done
+for f in "${PERSIST_FILES[@]}"; do link_file "${f}"; done
+
+# Optional TLS telnet. Default off (plain telnet on 1336 only).
+if [ "${OXIDUS_TLS:-0}" = "1" ]; then
+  tls_port="${OXIDUS_TLS_PORT:-1338}"
+  certdir="${OXIDUS_HOME}/adm/etc/certs"   # symlinked into the volume above
+  if [ ! -f "${certdir}/cert.pem" ] || [ ! -f "${certdir}/key.pem" ]; then
+    cp -a "${DIST}/certs.dist/cert.pem" "${certdir}/cert.pem"
+    cp -a "${DIST}/certs.dist/key.pem"  "${certdir}/key.pem"
+    echo "[entrypoint] installed FluffOS test certs into ${certdir}"
+  fi
+  if ! grep -q "external_port_2_tls" "${CONFIG}"; then
+    {
+      echo ""
+      echo "external_port_2: telnet ${tls_port}"
+      echo "external_port_2_tls: cert=adm/etc/certs/cert.pem key=adm/etc/certs/key.pem"
+    } >> "${CONFIG}"
+    echo "[entrypoint] enabled TLS telnet on port ${tls_port}"
+  fi
+fi
+
+# Reboot loop with signal handling (mirrors adm/dist/run; exit 0 == reboot).
+set +e
+child=""
+shutdown() {
+  echo "[entrypoint] received shutdown signal, stopping driver..."
+  [ -n "${child}" ] && kill -TERM "${child}" 2>/dev/null
+}
+trap shutdown TERM INT
+
+cd "${DIST}"
+while true; do
+  echo "[entrypoint] starting driver..."
+  "${DRIVER}" "${CONFIG}" &
+  child=$!
+  wait "${child}"
+  status=$?
+  echo "[entrypoint] driver exited with status ${status}"
+  if [ "${status}" -eq 0 ]; then
+    echo "[entrypoint] reboot requested, restarting..."
+    # No delay between reboots, matching bin/run (sleep commented out there).
+    # This also leaves no window for a stop signal to land between drivers.
+  else
+    break
+  fi
+done
+
+exit "${status}"

--- a/adm/dist/local_options
+++ b/adm/dist/local_options
@@ -27,7 +27,7 @@
 #define NO_LIGHT
 #define OLD_ED
 #undef ED_INDENT_CASE
-#define ED_INDENT_SPACES 4
+#define ED_INDENT_SPACES 2
 #undef ED_USE_TABS
 #define ED_TAB_WIDTH 8
 #undef RECEIVE_ED


### PR DESCRIPTION
## Add Docker support for running Oxidus as a containerised MUD

Introduces a complete Docker setup that packages the Oxidus mudlib together with a freshly compiled FluffOS driver into a self-contained image, published automatically to GitHub Container Registry.

### How it works

The image is built in two stages. The builder stage clones a pristine copy of the mudlib over HTTPS, compiles the FluffOS driver using the canonical `adm/dist/rebuild` script, and strips the source/build tree before handing off to a slim Debian runtime stage. The runtime stage ships only the built tree and the shared libraries the driver needs.

On first boot, the entrypoint symlinks every runtime-mutable path (`data/`, `home/`, `log/`, `open/`, `tmp/`, `adm/etc/certs/`, `adm/etc/secret/`, `adm/etc/alarms/`, and the `first_user`, `config.lpml`, `mssp.lpml` files) into a persistent `oxidus-state` volume, keeping the baked mudlib code pristine while player data, logs, and configuration survive restarts and image upgrades. Resetting to a brand-new MUD is as simple as removing the volume.

The entrypoint also mirrors the `adm/dist/run` reboot loop with proper PID 1 signal handling, so an in-game reboot restarts the driver automatically while a real shutdown stops the container cleanly.

### Running

**Published image (no clone required):**
```bash
docker run -d --name oxidus --init -p 1336:1336 -v oxidus-state:/oxidus/state ghcr.io/gesslar/oxidus:latest
```

**Build locally from a clone:**
```bash
cd adm/dist/docker
docker compose up -d --build
```

The first character to log in becomes the superuser in either case.

### TLS

TLS telnet is opt-in via `OXIDUS_TLS=1`. The entrypoint installs the bundled FluffOS test certificates automatically if no certs are already present in the volume, and patches `config.mud` to enable the TLS port.

### CI publishing

A new GitHub Actions workflow builds and pushes the image to GHCR on every push to `main` that touches the Docker files, on release publication, and on manual dispatch. The exact commit SHA is passed as `OXIDUS_REF` so CI builds are fully reproducible for the mudlib; FluffOS itself continues to track `master` per the canonical rebuild script.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a complete Docker setup — multi-stage Dockerfile, Compose file, entrypoint, and CI publish workflow — for running Oxidus as a containerised MUD. The Docker machinery itself is well-constructed, but three unrelated changes to `adm/dist/config.mud` will be baked into every published image and significantly degrade production performance.

- **Heartbeat interval** dropped from 2000 ms to 100 ms, causing every heartbeat-enabled object to fire 20× more often and dramatically increasing CPU load.
- **`trace code`** flipped from 0 to 1, halving interpreter throughput — the config comment explicitly warns that `eval_instruction()` runs "about twice as fast when this is not defined."
- **`time to clean up`** reduced from 120 000 s to 300 s, violating the config's own constraint that it must be substantially longer than the 10 000 s swap time, which can cause premature object destruction.

<h3>Confidence Score: 3/5</h3>

The Docker machinery is solid, but three config.mud changes unrelated to Docker will be baked into the published image and degrade production performance and correctness.

The Dockerfile, entrypoint, Compose file, and CI workflow are all well-constructed. The problem is three changes to adm/dist/config.mud: heartbeat interval at 100 ms fires all heartbeat objects 20× per second; trace code: 1 halves interpreter throughput; and time to clean up: 300 is far shorter than the swap time (10 000 s), which the config file itself warns against. All three will land in every container spun from the published latest image.

adm/dist/config.mud — the three runtime-configuration changes need to be reverted before this image is published.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aadm%2Fdist%2Fconfig.mud%3A112-113%0AThe%20heartbeat%20interval%20was%20reduced%20from%202000%20ms%20to%20100%20ms%20%E2%80%94%20a%2020%C3%97%20increase%20in%20frequency.%20Every%20object%20with%20a%20heartbeat%20function%20will%20now%20fire%2010%20times%20per%20second%2C%20which%20will%20massively%20increase%20CPU%20load%20on%20the%20server.%20This%20appears%20unrelated%20to%20the%20Docker%20work%20and%20will%20be%20baked%20into%20the%20published%20image%20as%20the%20default%20runtime%20configuration.%0A%0A%60%60%60suggestion%0A%23%20Number%20of%20milliseconds%20between%20heartbeats%0Aheartbeat%20interval%20msec%20%3A%202000%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aadm%2Fdist%2Fconfig.mud%3A235-239%0AThe%20config%20comment%20directly%20above%20this%20setting%20states%20that%20%60eval_instruction%28%29%60%20runs%20**about%20twice%20as%20fast%20when%20this%20is%20not%20defined**.%20Enabling%20%60trace%20code%60%20halves%20interpreter%20performance%20across%20every%20LPC%20call.%20This%20is%20a%20debug%2Ftracing%20aid%20that%20should%20not%20be%20shipped%20as%20the%20default%20in%20a%20production%20image%20published%20to%20GHCR.%0A%0A%60%60%60suggestion%0A%23%20TRACE_CODE%3A%20define%20this%20to%20enable%20code%20tracing%20%28the%20driver%20will%20print%0A%23%20%20%20out%20the%20previous%20lines%20of%20code%20to%20an%20error%29%20eval_instruction%28%29%20runs%20about%0A%23%20%20%20twice%20as%20fast%20when%20this%20is%20not%20defined%20%28for%20the%20most%20common%20eoperators%29.%0A%23%0Atrace%20code%20%3A%200%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aadm%2Fdist%2Fconfig.mud%3A44-45%0AThe%20config%20file's%20own%20comment%20for%20this%20setting%20says%20%22This%20time%20should%20be%20substantially%20longer%20than%20the%20swapping%20time.%22%20%60time%20to%20swap%60%20is%2010%20000%20s%20%28~2.7%20h%29%2C%20but%20%60time%20to%20clean%20up%60%20is%20now%20300%20s%20%285%20minutes%29%20%E2%80%94%20far%20shorter%20than%20the%20swap%20time%2C%20not%20longer.%20This%20inverts%20the%20intended%20relationship%20and%20means%20%60clean_up%28%29%60%20can%20be%20called%20on%20objects%20that%20are%20still%20cycling%20through%20the%20swap%20queue%2C%20potentially%20causing%20objects%20to%20be%20destructed%20prematurely.%0A%0A%60%60%60suggestion%0A%23%20This%20time%20should%20be%20substantially%20longer%20than%20the%20swapping%20time.%0Atime%20to%20clean%20up%20%3A%20120000%0A%60%60%60%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=213&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["adding docker"](https://github.com/gesslar/oxidus-mudlib/commit/7f1a7417b8842f07350667b1511c978247a10163) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36108451)</sub>

<!-- /greptile_comment -->