### PR TITLE
move Docker docs to DOCKER.md and simplify README to native build steps

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,198 @@
+# Running Oxidus in Docker
+
+A fresh, self-contained Oxidus MUD runs entirely in Docker. The image bundles
+the mudlib **and** a freshly-compiled FluffOS driver, so the only thing you need
+on the host is Docker.
+
+There are two ways in: just run the published image (no clone), or build it
+yourself from a clone of this repo.
+
+> Not using Docker? See [README.md](README.md) for the native build-and-run
+> pipeline.
+
+## Option 1 — Run the published image (lowest friction, no clone)
+
+You need nothing but Docker. The image is pulled automatically on first run:
+
+```bash
+docker run -d --name oxidus --init \
+  -p 1336:1336 \
+  -v oxidus-state:/oxidus/state \
+  ghcr.io/gesslar/oxidus:latest
+```
+
+- `--init` — clean signal handling, so `docker stop` shuts the driver down promptly
+- `-p 1336:1336` — exposes the telnet port on the host
+- `-v oxidus-state:/oxidus/state` — named volume holding all game state
+
+That `docker run -d` command **has already started the MUD** — it boots in the
+background the moment the command returns. You see no output because `-d`
+(detached) runs it silently and hands your prompt straight back.
+
+To *watch* it, attach to the logs. `docker logs` replays everything the
+container has printed since it started, and `-f` then follows live output —
+so you'll see the whole boot scroll past, ending at `Initializations complete.`
+once it's listening:
+
+```bash
+docker logs -f oxidus    # a viewer onto recorded + live output
+                         # Ctrl-C detaches the viewer; the MUD keeps running
+```
+
+You can run the above `docker logs` statement at any time to be re-plugged into
+the currently running docker to see any debug messages that the game has
+output. Doing so right after a boot is useful for checking for any issues with
+the boot process.
+
+`Ctrl+C` will exit you from tailing the driver output, but will not stop the
+game or the container.
+
+Connect and create a character — **the first character to log in becomes
+Oxidus's owner with the highest privileges**:
+
+```bash
+telnet localhost 1336
+```
+
+**Start / stop the MUD.** These control the container's lifecycle — whether the
+driver is actually running. Your world is preserved in the volume either way:
+
+```bash
+docker stop oxidus       # halt the running container
+docker start oxidus      # boot it back up (in the background again)
+docker restart oxidus    # stop + start in one step
+```
+
+Again, after starting or restarting Oxidus, you may opt to review the driver
+output to ensure a clean boot using `docker logs -f oxidus`. Keep it going to
+persist watching driver output, or Ctrl-C to return to the operating system
+prompt.
+
+**Upgrade** to a newer published image:
+
+```bash
+docker pull ghcr.io/gesslar/oxidus:latest   # fetch the newest image
+docker rm -f oxidus                          # remove the old container
+# then re-run the `docker run` command above to recreate it on the new image
+```
+
+**Reset to a brand-new MUD** (wipes the world — new accounts, and the first
+login becomes Oxidus's owner again):
+
+```bash
+docker rm -f oxidus
+docker volume rm oxidus-state
+# then re-run the `docker run` command above
+```
+
+## Editing the lib (heads-up: changes are temporary)
+
+The mudlib code is **baked into the image**, not the volume — so every
+`docker pull` gives you a clean, current Oxidus. The trade-off: **any edit to
+the shipped lib is wiped when you recreate the container on a newer image.**
+That's intended — you always land on fresh, stock Oxidus. Only *state* survives
+an update: players, data, logs, and your wizard home directory (`/home/...`).
+So tinker freely; a refresh just resets the lib.
+
+**From inside the game:** log in as a wizard, edit with the in-game tools, and
+`update <path>` to reload.
+
+**From a shell:** the image ships `nano`, `nvim`, and `rg` (ripgrep), so hop in
+and edit directly:
+
+```bash
+docker exec -it oxidus bash
+#  nano /oxidus/std/file.c       # /oxidus is the mudlib root
+#  rg "some_function" /oxidus    # search the lib
+#  then, in the game: update /std/file
+```
+
+Prefer your own editor on the host? Copy out, edit, copy back:
+
+```bash
+docker cp oxidus:/oxidus/std/file.c ./file.c
+docker cp ./file.c oxidus:/oxidus/std/file.c
+```
+
+**Want edits that stick** (real development)? Use Option 2 (clone + build) so the
+lib is yours, or bind-mount a host folder over a lib path
+(`-v "$PWD/d:/oxidus/d"`).
+
+## Option 2 — Build it yourself (clone, then Docker)
+
+Clone the repo and build the image locally with Compose. This compiles the
+driver from source, so a rebuild always picks up the latest FluffOS:
+
+```bash
+git clone https://github.com/gesslar/oxidus-mudlib.git
+cd oxidus-mudlib/adm/dist/docker
+docker compose up -d --build      # build the driver + start the MUD
+docker compose logs -f            # watch it boot ("Accepting telnet connections...")
+```
+
+Connect (first login becomes Oxidus's owner, as above):
+
+```bash
+telnet localhost 1336
+```
+
+Manage and upgrade:
+
+```bash
+docker compose down               # stop (world kept)
+docker compose up -d              # start
+docker compose build --no-cache   # rebuild against latest source, then `up -d`
+```
+
+**Reset to a brand-new MUD:**
+
+```bash
+docker compose down -v            # -v also drops the oxidus-state volume
+docker compose up -d
+```
+
+## What's actually happening
+
+- **The image is built in two stages.** The first stage clones a *pristine*
+  copy of this repository over HTTPS and compiles the driver using the canonical
+  [`adm/dist/rebuild`](adm/dist/rebuild) script (which also pins the mudlib paths
+  in `config.mud`). The second, slim runtime stage ships only the built tree.
+  (With Option 1 this has already been done for you on the published image.)
+- **Code is baked into the image; game state lives in a volume.** On first boot
+  the container's entrypoint moves every runtime-mutable path
+  (`data/`, `home/`, `log/`, `open/`, `tmp/`, `adm/etc/certs/`,
+  `adm/etc/secret/`, `adm/etc/alarms/`, and the `first_user` / `config.lpml` /
+  `mssp.lpml` files) into the `oxidus-state` volume and symlinks them back in.
+  This keeps the mudlib code pristine while your players, data and logs survive
+  restarts **and** image upgrades. Resetting the MUD is simply removing that
+  volume.
+- **The driver runs in a reboot loop**, mirroring `adm/dist/run`: an in-game
+  reboot restarts it automatically, while a real shutdown stops the container.
+
+## Running vs. rebuilding (stable at run, fresh at build)
+
+There are two clocks here, and they behave differently on purpose:
+
+- **Running is deterministic.** A built image is a frozen snapshot — a fixed
+  driver binary with the mudlib baked in. `docker run` / `docker start` /
+  `docker compose up` on the same image always behaves identically; all your
+  changing state lives in the `oxidus-state` volume, not the image.
+- **Rebuilding is when you pull the latest.** A rebuild re-clones the mudlib and,
+  via `adm/dist/rebuild`, checks out and compiles the **current** FluffOS
+  `master`. So the way to pick up a newer driver (or newer base packages) is to
+  rebuild — not to restart a container you already have.
+
+One gotcha for **local** builds: Docker's layer cache will happily reuse the
+clone/compile layers, so a plain `docker compose build` can hand you a *stale*
+rebuild (old FluffOS, old packages). To actually pull the latest, force a clean
+build:
+
+```bash
+docker compose build --no-cache && docker compose up -d
+```
+
+(CI doesn't have this problem: each push builds at its exact commit, which busts
+the cache and always recompiles against the latest FluffOS.)
+
+For TLS, build args, and the full option list, see
+[`adm/dist/docker/README.md`](adm/dist/docker/README.md).

--- a/README.md
+++ b/README.md
@@ -1,205 +1,69 @@
 # Oxidus
 
+> **If you're looking to run it in a Docker container, please see
+> [DOCKER.md](DOCKER.md)** — one command, no build toolchain required.
+
 ## Setting up and documentation
 
 Information on setting up and further documentation of the systems and
 functions of Oxidus can be found on the [Oxidus documentation site](https://oxidus.online/).
 
-## Running with Docker
+## Installing and running
 
-A fresh, self-contained Oxidus MUD runs entirely in Docker. The image bundles
-the mudlib **and** a freshly-compiled FluffOS driver, so the only thing you need
-on the host is Docker.
+Oxidus runs on the [FluffOS](https://github.com/fluffos/fluffos) driver, which
+it builds from source. The whole build-and-run pipeline lives in `adm/dist/`.
 
-There are two ways in: just run the published image (no clone), or build it
-yourself from a clone of this repo.
-
-### Option 1 — Run the published image (lowest friction, no clone)
-
-You need nothing but Docker. The image is pulled automatically on first run:
-
-```bash
-docker run -d --name oxidus --init \
-  -p 1336:1336 \
-  -v oxidus-state:/oxidus/state \
-  ghcr.io/gesslar/oxidus:latest
-```
-
-- `--init` — clean signal handling, so `docker stop` shuts the driver down promptly
-- `-p 1336:1336` — exposes the telnet port on the host
-- `-v oxidus-state:/oxidus/state` — named volume holding all game state
-
-That `docker run -d` command **has already started the MUD** — it boots in the
-background the moment the command returns. You see no output because `-d`
-(detached) runs it silently and hands your prompt straight back.
-
-To *watch* it, attach to the logs. `docker logs` replays everything the
-container has printed since it started, and `-f` then follows live output —
-so you'll see the whole boot scroll past, ending at `Initializations complete.`
-once it's listening:
-
-```bash
-docker logs -f oxidus    # a viewer onto recorded + live output
-                         # Ctrl-C detaches the viewer; the MUD keeps running
-```
-
-You can run the above `docker logs` statement at any time to be re-plugged into
-the currently running docker to see any debug messages that the game has
-output. Doing so right after a boot is useful for checking for any issues with
-the boot process.
-
-`Ctrl+C` will exit you from tailing the driver output, but will not stop the
-game or the container.
-
-Connect and create a character — **the first character to log in becomes
-Oxidus's owner with the highest privileges**:
-
-```bash
-telnet localhost 1336
-```
-
-**Start / stop the MUD.** These control the container's lifecycle — whether the
-driver is actually running. Your world is preserved in the volume either way:
-
-```bash
-docker stop oxidus       # halt the running container
-docker start oxidus      # boot it back up (in the background again)
-docker restart oxidus    # stop + start in one step
-```
-
-Again, after starting or restarting Oxidus, you may opt to review the driver
-output to ensure a clean boot using `docker logs -f oxidus`. Keep it going to
-persist watching driver output, or Ctrl-C to return to the operating system
-prompt.
-
-**Upgrade** to a newer published image:
-
-```bash
-docker pull ghcr.io/gesslar/oxidus:latest   # fetch the newest image
-docker rm -f oxidus                          # remove the old container
-# then re-run the `docker run` command above to recreate it on the new image
-```
-
-**Reset to a brand-new MUD** (wipes the world — new accounts, and the first
-login becomes Oxidus's owner again):
-
-```bash
-docker rm -f oxidus
-docker volume rm oxidus-state
-# then re-run the `docker run` command above
-```
-
-### Editing the lib (heads-up: changes are temporary)
-
-The mudlib code is **baked into the image**, not the volume — so every
-`docker pull` gives you a clean, current Oxidus. The trade-off: **any edit to
-the shipped lib is wiped when you recreate the container on a newer image.**
-That's intended — you always land on fresh, stock Oxidus. Only *state* survives
-an update: players, data, logs, and your wizard home directory (`/home/...`).
-So tinker freely; a refresh just resets the lib.
-
-**From inside the game:** log in as a wizard, edit with the in-game tools, and
-`update <path>` to reload.
-
-**From a shell:** the image ships `nano`, `nvim`, and `rg` (ripgrep), so hop in
-and edit directly:
-
-```bash
-docker exec -it oxidus bash
-#  nano /oxidus/std/file.c       # /oxidus is the mudlib root
-#  rg "some_function" /oxidus    # search the lib
-#  then, in the game: update /std/file
-```
-
-Prefer your own editor on the host? Copy out, edit, copy back:
-
-```bash
-docker cp oxidus:/oxidus/std/file.c ./file.c
-docker cp ./file.c oxidus:/oxidus/std/file.c
-```
-
-**Want edits that stick** (real development)? Use Option 2 (clone + build) so the
-lib is yours, or bind-mount a host folder over a lib path
-(`-v "$PWD/d:/oxidus/d"`).
-
-### Option 2 — Build it yourself (clone, then Docker)
-
-Clone the repo and build the image locally with Compose. This compiles the
-driver from source, so a rebuild always picks up the latest FluffOS:
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/gesslar/oxidus-mudlib.git
-cd oxidus-mudlib/adm/dist/docker
-docker compose up -d --build      # build the driver + start the MUD
-docker compose logs -f            # watch it boot ("Accepting telnet connections...")
+cd oxidus-mudlib
 ```
 
-Connect (first login becomes Oxidus's owner, as above):
+### 2. Install the build dependencies
+
+The driver needs a C/C++ toolchain plus a handful of development libraries. On
+Debian / Ubuntu:
+
+```bash
+sudo apt-get install build-essential bison cmake git \
+  libssl-dev libz-dev libpcre3-dev libsqlite3-dev libpq-dev \
+  libjemalloc-dev libicu-dev default-libmysqlclient-dev
+```
+
+On other distributions, install the equivalents: a compiler, `bison`, `cmake`,
+`git`, and the OpenSSL, zlib, PCRE, SQLite, PostgreSQL, jemalloc, ICU, and MySQL
+client development headers.
+
+### 3. Build the driver
+
+```bash
+adm/dist/rebuild
+```
+
+This initialises the bundled FluffOS submodule, compiles the driver against the
+current FluffOS `master`, installs the binaries into `adm/dist/bin/`, and
+rewrites `adm/dist/config.mud` with the absolute paths for your checkout.
+
+### 4. Start the MUD
+
+```bash
+adm/dist/run            # run in the foreground (auto-restarts on an in-game reboot)
+```
+
+`adm/dist/run` also accepts:
+
+- `adm/dist/run bg` — start in the background
+- `adm/dist/run stop` — stop a running instance
+
+### 5. Connect
 
 ```bash
 telnet localhost 1336
 ```
 
-Manage and upgrade:
-
-```bash
-docker compose down               # stop (world kept)
-docker compose up -d              # start
-docker compose build --no-cache   # rebuild against latest source, then `up -d`
-```
-
-**Reset to a brand-new MUD:**
-
-```bash
-docker compose down -v            # -v also drops the oxidus-state volume
-docker compose up -d
-```
-
-### What's actually happening
-
-- **The image is built in two stages.** The first stage clones a *pristine*
-  copy of this repository over HTTPS and compiles the driver using the canonical
-  [`adm/dist/rebuild`](adm/dist/rebuild) script (which also pins the mudlib paths
-  in `config.mud`). The second, slim runtime stage ships only the built tree.
-  (With Option 1 this has already been done for you on the published image.)
-- **Code is baked into the image; game state lives in a volume.** On first boot
-  the container's entrypoint moves every runtime-mutable path
-  (`data/`, `home/`, `log/`, `open/`, `tmp/`, `adm/etc/certs/`,
-  `adm/etc/secret/`, `adm/etc/alarms/`, and the `first_user` / `config.lpml` /
-  `mssp.lpml` files) into the `oxidus-state` volume and symlinks them back in.
-  This keeps the mudlib code pristine while your players, data and logs survive
-  restarts **and** image upgrades. Resetting the MUD is simply removing that
-  volume.
-- **The driver runs in a reboot loop**, mirroring `adm/dist/run`: an in-game
-  reboot restarts it automatically, while a real shutdown stops the container.
-
-### Running vs. rebuilding (stable at run, fresh at build)
-
-There are two clocks here, and they behave differently on purpose:
-
-- **Running is deterministic.** A built image is a frozen snapshot — a fixed
-  driver binary with the mudlib baked in. `docker run` / `docker start` /
-  `docker compose up` on the same image always behaves identically; all your
-  changing state lives in the `oxidus-state` volume, not the image.
-- **Rebuilding is when you pull the latest.** A rebuild re-clones the mudlib and,
-  via `adm/dist/rebuild`, checks out and compiles the **current** FluffOS
-  `master`. So the way to pick up a newer driver (or newer base packages) is to
-  rebuild — not to restart a container you already have.
-
-One gotcha for **local** builds: Docker's layer cache will happily reuse the
-clone/compile layers, so a plain `docker compose build` can hand you a *stale*
-rebuild (old FluffOS, old packages). To actually pull the latest, force a clean
-build:
-
-```bash
-docker compose build --no-cache && docker compose up -d
-```
-
-(CI doesn't have this problem: each push builds at its exact commit, which busts
-the cache and always recompiles against the latest FluffOS.)
-
-For TLS, build args, and the full option list, see
-[`adm/dist/docker/README.md`](adm/dist/docker/README.md).
+The first character to log in becomes Oxidus's owner with the highest
+privileges.
 
 ## AI Assistant Guidelines
 

--- a/adm/simul_efun/array.c
+++ b/adm/simul_efun/array.c
@@ -945,6 +945,7 @@ varargs void each(mixed src, function fun, mixed extra...) {
     int i, sz;
 
     for(i = 0, sz = sizeof(src); i < sz; i++)
+      // @lpc-expect-error: LSP doesn't know how to reach fun() here
       fun(src[i], i, src, extra...);
   }
 


### PR DESCRIPTION
The Docker documentation has been extracted from `README.md` into a dedicated `DOCKER.md` file, and `README.md` has been updated to point readers there and replaced with a concise native build-and-run guide covering cloning, installing dependencies, building the driver via `adm/dist/rebuild`, starting with `adm/dist/run`, and connecting via telnet.

Additionally, a `// @lpc-expect-error` comment has been added in `adm/simul_efun/array.c` to suppress a false LSP diagnostic on the `fun()` call inside `each()`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorganizes documentation and adds a minor LSP-suppression comment. The Docker documentation is extracted from `README.md` into a dedicated `DOCKER.md`, and `README.md` is updated with a concise native build-and-run guide plus a callout pointing Docker users to the new file.

- `DOCKER.md` is a faithful, complete extraction of the Docker content previously in `README.md`; both Option 1 (pull published image) and Option 2 (clone + build) workflows are preserved.
- `README.md` now covers clone → install dependencies → `adm/dist/rebuild` → `adm/dist/run` → telnet, with a top-of-file callout for Docker users.
- `adm/simul_efun/array.c` gains a single `// @lpc-expect-error` comment above the array-branch `fun()` call inside `each()`, but the identical `fun()` call in the mapping branch is not suppressed similarly.

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are purely documentation plus a one-line comment in LPC source; no runtime logic is altered.

The documentation reorganization is clean and complete. The only code-touching change is the @lpc-expect-error suppressor in array.c, which only covers the array iteration branch of each() while the mapping branch's identical fun() call remains unsuppressed — a minor inconsistency that may leave a false LSP diagnostic in place.

adm/simul_efun/array.c — check whether the @lpc-expect-error should also be added above the fun() call in the foreach branch.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aadm%2Fsimul_efun%2Farray.c%3A948-949%0A**Missing%20suppression%20on%20mapping%20branch**%0A%0AThe%20%60%2F%2F%20%40lpc-expect-error%60%20is%20placed%20only%20above%20the%20array-branch%20%60fun%28%29%60%20call%2C%20but%20the%20mapping%20branch%20at%20line%20956%20makes%20an%20identical%20%60fun%28key%2C%20val%2C%20src%2C%20extra...%29%60%20call%20without%20the%20same%20suppressor.%20If%20the%20LSP%20diagnostic%20fires%20because%20of%20the%20%60fun%28%29%60%20invocation%20pattern%20itself%20%28rather%20than%20something%20specific%20to%20the%20for-loop%20syntax%29%2C%20the%20false%20positive%20will%20still%20appear%20on%20the%20mapping%20branch.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=215&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs update, plus an inline LSP fix"](https://github.com/gesslar/oxidus-mudlib/commit/c01dd7f339816f3f69e43761c6ca85deef2c8796) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36118265)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->