### PR TITLE
refactor: rename query_path to get_path

### DIFF
--- a/cmds/ghost/help.c
+++ b/cmds/ghost/help.c
@@ -35,7 +35,7 @@ mixed main(/** @type {STD_PLAYER} */ object caller, string str) {
   if(!str)
     str = "help";
 
-  path = caller->query_path();
+  path = caller->get_path();
 
   for(int i = 0; i < sizeof(path); i++) {
     if(file_exists(path[i] + str + ".c")) {

--- a/cmds/std/help.c
+++ b/cmds/std/help.c
@@ -27,7 +27,7 @@ mixed main(/** @type {STD_PLAYER} */ object tp, string str) {
   if(!str)
     str = "help";
 
-  path = tp->query_path();
+  path = tp->get_path();
 
   for(i = 0; i < sizeof(path); i++) {
     if(file_exists(path[i] + str + ".c")) {

--- a/cmds/wiz/path.c
+++ b/cmds/wiz/path.c
@@ -13,7 +13,7 @@ mixed main(object caller, string str) {
   ret = "";
 
   if(!str || !sscanf(str, "-%s %s", action, arg)) {
-    path = this_body()->query_path();
+    path = this_body()->get_path();
     for(i = 0; i < sizeof(path); i++) {
       ret += path[i][0..<2] + ":";
     }
@@ -40,7 +40,7 @@ mixed main(object caller, string str) {
       break;
   }
 
-  path = this_body()->query_path();
+  path = this_body()->get_path();
 
   for(i = 0; i < sizeof(path); i++) {
     ret += path[i][0..<2] + ":";

--- a/cmds/wiz/which.c
+++ b/cmds/wiz/which.c
@@ -12,7 +12,7 @@ mixed main(
   /** @type {STD_PLAYER} */ object caller,
   string args
 ) {
-  string *command_path = caller->query_path();
+  string *command_path = caller->get_path();
   mixed *actions = previous_object()->query_commands();
   int i, is_located = 0;
 

--- a/std/object/command.c
+++ b/std/object/command.c
@@ -184,7 +184,7 @@ string process_input(string arg) {
  *
  * @returns {string*} Copy of the command paths array
  */
-public string *query_path() {
+public string *get_path() {
   return copy(__cmdPaths);
 }
 
@@ -265,7 +265,7 @@ public void add_wizard_path() {
  * paths only.
  */
 public void remove_wizard_paths() {
-  filter(query_path(), (: rem_path :));
+  filter(get_path(), (: rem_path :));
 
   add_standard_paths();
 }
@@ -434,7 +434,7 @@ public int command_hook(string arg) {
  *          file without extension, or undefined if not found
  */
 public string find_command_path(string verb) {
-  string *paths = query_path();
+  string *paths = get_path();
   string path;
 
   foreach(string p in paths) {

--- a/std/object/include/command.h
+++ b/std/object/include/command.h
@@ -14,7 +14,7 @@ public mixed evaluate_command(object tp, string command,
   string arg);
 
 // Path functions
-public string *query_path();
+public string *get_path();
 public int add_path(string str);
 public void set_path(mixed path);
 public int rem_path(string str);


### PR DESCRIPTION
Mechanical rename of the command-path accessor `query_path()` → `get_path()` across the definition (`std/object/command.c`), its header, and all callers (`cmds/std/help.c`, `cmds/ghost/help.c`, `cmds/wiz/path.c`, `cmds/wiz/which.c`).

Foundation of a 4-PR stack splitting out the old #216/#217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs a clean mechanical rename of the command-path accessor from `query_path()` to `get_path()` across the function definition (`std/object/command.c`), its header declaration (`std/object/include/command.h`), and all five call sites in the command files.

- The definition in `std/object/command.c` is updated, along with the two internal callers (`remove_wizard_paths` and `find_command_path`) within the same file.
- All external callers (`cmds/ghost/help.c`, `cmds/std/help.c`, `cmds/wiz/path.c`, `cmds/wiz/which.c`) are updated; a grep across the full repository confirms no stale `query_path` references remain.

<h3>Confidence Score: 5/5</h3>

The rename is applied uniformly — definition, header, and every call site — with no leftover references in the codebase.

Every occurrence of `query_path` has been updated to `get_path`, including internal self-calls inside `command.c`. A full-repo search returns zero remaining hits, so no callers are left behind.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["refactor: rename query\_path to get\_path"](https://github.com/gesslar/oxidus-mudlib/commit/a1425d8757edc11a860b223ccf1020117b709bd6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36352474)</sub>

<!-- /greptile_comment -->