### PR TITLE
feat: help system rewrite

### DIFF
--- a/adm/daemons/help.c
+++ b/adm/daemons/help.c
@@ -1,0 +1,126 @@
+/**
+ * @file /adm/daemons/help.c
+ *
+ * Help! Daemon!
+ *
+ * @created 2026-06-07 - Gesslar
+ * @last_modified 2026-06-07 - Gesslar
+ *
+ * @history
+ * 2026-06-07 - Gesslar - Created
+ */
+
+inherit STD_DAEMON;
+
+#include <pcre_flags.h>
+
+public void rehash();
+private void rehash_directory(mapping directory);
+
+private nosave string  __help_root;
+private nosave string *__excludes; // wired, not yet filtered on — intentional
+private nosave mapping __cache = ([]);
+
+void setup() {
+  set_no_clean();
+
+  __help_root = mud_config("DOC.ROOT") + mud_config("DOC.HELP.ROOT");
+  __excludes = map(
+    mud_config("DOC.HELP.EXCLUDE") ?? ({}),
+    (: __help_root + $1 :)
+  );
+
+  rehash();
+}
+
+public void rehash() {
+  __cache = ([]);
+
+  mapping fd = read_directory(__help_root);
+
+  int sz = sizeof(fd["directories"]);
+
+  while(sz--)
+    call_out_walltime((: rehash_directory, fd["directories"][sz] :), sz * 0.1);
+}
+
+private void rehash_directory(mapping directory) {
+  if(file_size(directory["path"]) != -2)
+    return;
+
+  mapping fd = read_directory(directory["path"], "*.help");
+  mapping *files = fd["files"];
+  mapping help = ([]);
+
+  if(!sizeof(files))
+    return;
+
+  foreach(mapping file in files) {
+    mapping front_matter;
+    string front_matter_text;
+    string content = read_file(file["path"]);
+
+    if(falsy(content))
+      continue;
+
+    // Do we have front matter?
+    string *matches =
+    pcre_extract(
+      content,
+      "^---$([\\s\\S]+?)^---$([\\s\\S]+)",
+      // @lpc-expect-error: the LSP doesn't know about these arguments
+      0,
+      PCRE_M
+    );
+
+    if(sizeof(matches) == 2) {
+      content = matches[1];
+      front_matter_text = matches[0];
+    }
+
+    if(truthy(front_matter_text)) {
+      string e = catch(front_matter = lpml_decode(front_matter_text));
+
+      if(e) {
+        front_matter = ([
+          "title": all_caps(file["base"]),
+        ]);
+      }
+    } else {
+      front_matter = ([
+        "title": all_caps(file["base"])
+      ]);
+    }
+
+    front_matter += ([ "topic" : file["base"] ]);
+
+    help[file["base"]] = front_matter + ([ "content": content ]);
+  }
+
+  __cache[directory["name"]] = help;
+}
+
+mapping *query_help(string topic, object who) {
+  who ??= this_body();
+
+  string name = who
+    ? query_privs(who)
+    : NONAME;
+
+  string *groups = master()->query_group_names();
+  mapping *result = ({});
+
+  foreach(string cat, mapping helps in __cache) {
+    if(cat == "all" || !includes(groups, cat)) {
+      if(helps[topic]) {
+        push(ref result, ({ cat, helps[topic] }));
+      }
+    } else {
+      if(helps[topic] && is_member(name, cat)) {
+        push(ref result, ({ cat, helps[topic] }));
+      }
+    }
+  }
+
+  return result;
+}

--- a/adm/etc/default.lpml
+++ b/adm/etc/default.lpml
@@ -151,4 +151,11 @@
     GLOBAL_SPAWN_CHANCE: 5.5,
     GLOBAL_SPAWN_FREQUENCY: 18000
   },
+  DOC: {
+    ROOT: "/doc/",
+    HELP: {
+      ROOT: "help/",
+      EXCLUDE: [],
+    }
+  }
 }

--- a/cmds/action/close.c
+++ b/cmds/action/close.c
@@ -79,3 +79,12 @@ mixed main(/** @type {STD_BODY} */ object tp, string args) {
 
   return 1;
 }
+
+string query_help(object _caller) {
+  return
+    "SYNTAX: close <object> [here]\n\n"
+    "This command will allow you to close a container or a door in your "
+    "environment. If you have a container in your inventory and another of "
+    "the same name in the room, append 'here' to close the one in the room.\n\n"
+    "See also: open";
+}

--- a/cmds/action/dispose.c
+++ b/cmds/action/dispose.c
@@ -36,3 +36,10 @@ mixed main(object tp, string str) {
 
   return 1;
 }
+
+string query_help(object _caller) {
+  return
+    "SYNTAX: dispose <corpse>\n\n"
+    "This command will allow you to dispose of a corpse in your environment. "
+    "Only corpses may be disposed of in this manner.";
+}

--- a/cmds/action/drink.c
+++ b/cmds/action/drink.c
@@ -38,3 +38,11 @@ mixed main(object tp, string str) {
 
   return 1;
 }
+
+string query_help(object _caller) {
+  return
+    "SYNTAX: drink <object>\n\n"
+    "This command will allow you to drink from a beverage you are holding. "
+    "Drinking consumes the beverage more quickly than sipping it.\n\n"
+    "See also: sip, eat";
+}

--- a/cmds/action/duel.c
+++ b/cmds/action/duel.c
@@ -43,3 +43,11 @@ mixed main(/** @type {STD_BODY} */ object tp, string arg) {
 
   return 1;
 }
+
+string query_help(object _caller) {
+  return
+    "SYNTAX: duel <living>\n\n"
+    "This command will allow you to engage another living being in your "
+    "environment in combat. You cannot duel while dead or a ghost, nor may "
+    "you duel someone who is dead or a ghost.";
+}

--- a/cmds/action/eat.c
+++ b/cmds/action/eat.c
@@ -38,3 +38,11 @@ mixed main(object tp, string str) {
 
   return 1;
 }
+
+string query_help(object _caller) {
+  return
+    "SYNTAX: eat <object>\n\n"
+    "This command will allow you to eat food you are holding. Eating consumes "
+    "the food more quickly than nibbling at it.\n\n"
+    "See also: nibble, drink";
+}

--- a/cmds/action/eq.c
+++ b/cmds/action/eq.c
@@ -39,3 +39,12 @@ mixed main(/** @type {STD_BODY} */ object tp,
 
   return out;
 }
+
+string query_help(object _caller) {
+  return
+    "SYNTAX: eq\n\n"
+    "This command will list all the items you currently have equipped, "
+    "including the clothing and armour you are wearing and the weapons you "
+    "are wielding, organised by the slot each occupies.\n\n"
+    "See also: wear, wield";
+}

--- a/cmds/action/get.c
+++ b/cmds/action/get.c
@@ -31,7 +31,10 @@ void setup() {
 "See also: drop, put\n";
 }
 
-mixed main(object tp, string arg) {
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string arg
+) {
   object ob;
   object room = environment(tp);
   object source = room;

--- a/cmds/action/go.c
+++ b/cmds/action/go.c
@@ -52,3 +52,14 @@ mixed main(/** @type {STD_BODY} */ object tp, string arg) {
 
     return 1;
 }
+
+string query_help(object _caller) {
+  return
+    "SYNTAX: go <direction>\n\n"
+    "This command will allow you to move in a given direction, provided there "
+    "is an exit leading that way. Moving costs movement points, and distant "
+    "exits may be too far to reach when you are low on them.\n\n"
+    "Global aliases let you move with less typing: 'n', 's', 'e', 'w', 'ne', "
+    "'nw', 'se', 'sw', 'u' and 'd' expand to 'go north', 'go south', and so "
+    "on.";
+}

--- a/cmds/action/nibble.c
+++ b/cmds/action/nibble.c
@@ -32,3 +32,11 @@ mixed main(object tp, string str) {
 
   return 1;
 }
+
+string query_help(object _caller) {
+  return
+    "SYNTAX: nibble <object>\n\n"
+    "This command will allow you to nibble at food you are holding. Nibbling "
+    "consumes the food more slowly than eating it.\n\n"
+    "See also: eat, drink";
+}

--- a/cmds/action/open.c
+++ b/cmds/action/open.c
@@ -79,3 +79,12 @@ mixed main(/** @type {STD_BODY} */ object tp, string args) {
 
   return 1;
 }
+
+string query_help(object _caller) {
+  return
+    "SYNTAX: open <object> [here]\n\n"
+    "This command will allow you to open a container or a door in your "
+    "environment. If you have a container in your inventory and another of "
+    "the same name in the room, append 'here' to open the one in the room.\n\n"
+    "See also: close";
+}

--- a/cmds/action/sip.c
+++ b/cmds/action/sip.c
@@ -32,3 +32,11 @@ mixed main(object tp, string str) {
 
   return 1;
 }
+
+string query_help(object _caller) {
+  return
+    "SYNTAX: sip <object>\n\n"
+    "This command will allow you to sip from a beverage you are holding. "
+    "Sipping consumes the beverage more slowly than drinking it.\n\n"
+    "See also: drink, eat";
+}

--- a/cmds/action/use.c
+++ b/cmds/action/use.c
@@ -33,3 +33,11 @@ mixed use(/** @type {STD_BODY} */ object tp, string str) {
 
   return result;
 }
+
+string query_help(object _caller) {
+  return
+    "SYNTAX: use <object>\n\n"
+    "This command will allow you to use an object you are carrying or one "
+    "that is present in your environment, provided it is something that can "
+    "be used. The effect depends on the object.";
+}

--- a/cmds/adm/master.c
+++ b/cmds/adm/master.c
@@ -22,6 +22,7 @@ void setup() {
     ({"Load master/valid",(: load_object("/adm/obj/master/valid") :)}),
     ({"Load master object",(: load_object("/adm/obj/master") :)}),
     ({"Rehash system configuration",(: CONFIG_D->rehash_config() :)}),
+    ({"Rehash help system",(: HELP_D->rehash() :)}),
   });
 }
 

--- a/cmds/std/help.c
+++ b/cmds/std/help.c
@@ -1,83 +1,88 @@
 /**
  * @file /cmds/std/help.c
  *
- * Command to access the help system for topics and commands.
+ * Help command for all things helpful.
  *
- * @created 2005-10-08 - Tacitus @ LPUniversity
- * @last_modified 2006-10-06 - Tacitus
+ * @created 2026-06-07 - Gesslar
+ * @last_modified 2026-06-07 - Gesslar
  *
  * @history
- * 2005-10-08 - Tacitus - Created
- * 2006-10-06 - Tacitus - Last edited
+ * 2026-06-07 - Gesslar - Created
  */
 
 inherit STD_CMD;
 
-private nosave string* HELP_PATH = ({ "/doc/general/", "/doc/game/" });
-private nosave string* DEV_PATH = ({ "/doc/wiz/", "/doc/driver/efun/", "/doc/driver/apply/" });
-private nosave string* ADMIN_PATH = ({ "/doc/admin/" });
+private mixed get_command_help(object tp, string topic);
+private mixed get_file_help(object tp, string topic);
 
-#include <logs.h>
+mixed main(
+  /** @type {STD_PLAYER} */ object tp,
+  string topic
+) {
 
-mixed main(/** @type {STD_PLAYER} */ object tp, string str) {
-  /** @type {STD_CMD} */ object cmd;
-  string file, *path, err, output = "";
-  int i;
+  if(!topic)
+    return _info("help <topic>");
 
-  if(!str)
-    str = "help";
+  function valid_result = (:
+       (stringp($1) && truthy($1))
+    || (pointerp($1) && uniformp($1, T_STRING) && sizeof(filter($1, (: truthy :))))
+  :);
 
-  path = tp->get_path();
+  mixed result;
 
-  for(i = 0; i < sizeof(path); i++) {
-    if(file_exists(path[i] + str + ".c")) {
-      err = catch(cmd = load_object(path[i] + str));
-      if(!err)
-        file = cmd->query_help(tp);
+  result = get_command_help(tp, topic);
+  if(valid_result(result))
+    return result;
 
-      if(err)
-        return _error("This is a problem with '%s'. Please inform an admin.",
-          str);
+  result = get_file_help(tp, topic);
+  if(valid_result(result))
+    return result;
 
-      if(!file)
-        return _error("The command '%s' exists but there is no help file for "
-          "it. Please inform an admin.", str);
-
-      tp->page(output);
-
-      return 1;
-    }
-  }
-
-  path = HELP_PATH;
-
-  if(devp(tp))
-    path += DEV_PATH;
-
-  if(adminp(tp))
-    path += ADMIN_PATH;
-
-  for(i = 0; i < sizeof(path); i++) {
-    if(file_exists(path[i] + str)) {
-      file = read_file(path[i] + str);
-
-      output += (file + "\n");
-
-      tp->page(output);
-      return 1;
-    }
-  }
-
-  log_file(LOG_HELP, "Not found: " + str + "\n");
-
-  return _error("Unable to find help file for: " + str);
+  return result || "No help found for the topic '"+topic+"'.";
 }
 
-string query_help(object _caller) {
-  return
-    "Syntax: help <topic>\n\n"
-    "Whenever you need help or information regarding something in the mud, this "
-    "is the place to come. This command gives you instant access to a wealth of "
-    "information that will be vital to your stay here on " + mud_name() + ". "
-    "Help that you want not written yet? Let us know and we'll get right on it!";
+private mixed get_command_help(
+  /** @type {STD_PLAYER} */ object tp,
+  string topic
+) {
+  string *path = map(tp->get_path(), (: sprintf("%s%s.c", append($1, "/"), $(topic)) :));
+  string *exists = filter(path, (: file_size($1) > -1 :));
+
+  int sz = sizeof(exists);
+
+  if(sz > 1)
+    return "Too many command matches for '"+topic+"'.";
+
+  if(sz < 1)
+    return undefined;
+
+  /** @type {STD_CMD} */ object cmd;
+  string e = catch(cmd = load_object(exists[0]));
+
+  if(e)
+    return "There was a problem loading the help for '"+topic+"'.";
+
+  return cmd->query_help(tp);
+}
+
+private mixed get_file_help(
+  /** @type {STD_PLAYER} */ object tp,
+  string topic
+) {
+  mapping *helps = HELP_D->query_help(topic, tp);
+  string result;
+
+  if(!sizeof(helps))
+    return undefined;
+
+  // single-match render only for now; multi-match handling intentionally TODO
+  mapping help = helps[0];
+
+  result = sprintf(
+    "%s\n%s",
+    help[1]["title"],
+    help[1]["content"]
+  );
+
+  return result;
 }

--- a/doc/help/developer/time format.help
+++ b/doc/help/developer/time format.help
@@ -1,0 +1,59 @@
+---
+{
+  title: "Time Format"
+}
+---
+{{re1}}Miscellaneous{{res}}
+    %%          The % character {{bl1}}[%]{{res}}
+    %c          The preferred date and time representation (similar to ctime())
+                {{bl1}}[Sun Sep  1 01:03:52 1973]{{res}}
+    %n          A newline character {{bl1}}[\n]{{res}}
+    %t          A tab character {{bl1}}[\t]{{res}}
+
+{{re1}}Date{{res}}
+    %D          The date as %m/%d/%y {{bl1}}[01/01/00,12/31/99]{{res}}
+    %F          The date as %Y-%m-%d {{bl1}}[2000-01-01,1999-12-31]{{res}}
+    %x          The preferred date representation (no time) {{bl1}}[01/01/00,12/31/99]{{res}}
+
+{{re1}}Weekday{{res}}
+    %a          The abbreviated weekday name {{bl1}}[Sun, Sat]{{res}}
+    %A          The full weekday name {{bl1}}[Sunday, Saturday]{{res}}
+    %w          Weekday as a decimal number {{bl1}}[0(Sunday),6]{{res}}
+
+{{re1}}Century{{res}}
+    %C          The century number {{bl1}}[00,99]{{res}}
+
+{{re1}}Year{{res}}
+    %y          Year without century as a decimal number {{bl1}}[00,99]{{res}}
+    %Y          Year with century as a decimal number {{bl1}}[0000,9999]{{res}}
+
+{{re1}}Month{{res}}
+    %b, %h      The abbreviated month name {{bl1}}[Jan,Dec]{{res}}
+    %B          The full month name {{bl1}}[January, December]{{res}}
+    %m          Month as a decimal number {{bl1}}[01,12]{{res}}
+
+{{re1}}Day{{res}}
+    %d          Day of the month as a decimal number {{bl1}}[01,31]{{res}}
+    %e          Day of the month as a decimal number {{bl1}}[ 1,31]{{res}}
+    %j          Day of the year as a decimal number {{bl1}}[001,366]{{res}}
+
+{{re1}}Week{{res}}
+    %U          Week number of the year (Sunday as the first day of the week)
+                as a decimal number {{bl1}}[00,53]{{res}}
+
+{{re1}}Time{{res}}
+    %R          The time as %H:%M {{bl1}}[00:00,23:59]{{res}}
+    %r          The time as %I:%M:%S %p {{bl1}}[12:00:00 AM, 11:59:59 PM]{{res}}
+    %T          The time as %H:%M:%S {{bl1}}[00:00:00,23:59:59]{{res}}
+    %X          The preferred time representation (no date) {{bl1}}[00:00:00,23:59:59]{{res}}
+    %p          The locale's equivalent of AM or PM {{bl1}}[AM, PM]{{res}}
+
+{{re1}}Hour{{res}}
+    %H          Hour (24-hour clock) as a decimal number {{bl1}}[00,23]{{res}}
+    %I          Hour (12-hour clock) as a decimal number {{bl1}}[01,12]{{res}}
+
+{{re1}}Minute{{res}}
+    %M          Minute as a decimal number {{bl1}}[00,59]{{res}}
+
+{{re1}}Second{{res}}
+    %S          Second as a decimal number {{bl1}}[00,61]{{res}}

--- a/include/daemons.h
+++ b/include/daemons.h
@@ -23,6 +23,7 @@
 #define GH_ISSUES_D     DIR_DAEMONS "github_issues"
 #define GMCP_D          DIR_DAEMONS "gmcp"
 #define GRAPEVINE_D     DIR_DAEMONS "grapevine"
+#define HELP_D          DIR_DAEMONS "help"
 #define HTTPC_D         DIR_DAEMONS "httpc"
 #define LINES_D         DIR_DAEMONS "lines"
 #define LOCKDOWN_D      DIR_DAEMONS "lockdown_d"

--- a/std/cmd/cmd.c
+++ b/std/cmd/cmd.c
@@ -37,8 +37,9 @@ private void create() {
  * @returns {string | undefined} The help text
  */
 string query_help(object _caller) {
-
+  return "";
 }
+
 #if 0
 string query_help(object caller) {
   string result;


### PR DESCRIPTION
Adds `HELP_D` (`adm/daemons/help.c`) which indexes `.help` files under `/doc/help/<category>/`, parsing optional LPML front matter. Rewrites the help command to try command help first, then fall through to file-based help via `HELP_D`. Adds per-command `query_help` text to the action commands, a `query_help` base stub on `STD_CMD`, the `HELP_D` define, the `DOC:` config block, and an initial developer help file.

Stacked on #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces `HELP_D` (`adm/daemons/help.c`), a new daemon that indexes `.help` files under `/doc/help/<category>/`, parses optional LPML front matter, and gates category visibility on group membership. The std `help` command is rewritten to cascade: it first tries loading the matching command object and calling `query_help`, then falls back to `HELP_D`; per-command `query_help` text is added to the action commands and a base stub (returning `""`) is installed on `STD_CMD`.

- `adm/daemons/help.c` — new daemon with staggered async rehash, front-matter parsing, and group-gated topic lookup; `__excludes` is populated but intentionally not yet applied to filtering.
- `cmds/std/help.c` — rewritten cascade help command; the old `query_help` override was removed, leaving `help help` with no response, and the `sz > 1` branch returns an error instead of deferring to the highest-priority path entry.
- `std/cmd/cmd.c` — base `query_help` stub now returns `""` so callers can test falsiness and fall through to file-based help.

<h3>Confidence Score: 4/5</h3>

Safe to merge with two minor rough edges in the help command's query path.

The daemon itself is well-structured and the group-gated access control is correctly wired to the existing group system. The two issues are in cmds/std/help.c: `help help` now returns "No help found" because the override was dropped and no `help.help` file exists yet, and the multiple-match branch errors rather than taking the first priority match. Neither issue touches game-critical paths, but both produce unexpected player-visible output.

cmds/std/help.c — the removed `query_help` override and the multiple-match error branch.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acmds%2Fstd%2Fhelp.c%3A65%0A**%60help%20help%60%20now%20returns%20%22No%20help%20found%22**%0A%0AThe%20old%20%60cmds%2Fstd%2Fhelp.c%60%20had%20its%20own%20%60query_help%60%20override%20that%20returned%20a%20meaningful%20description.%20The%20new%20file%20inherits%20the%20%60STD_CMD%60%20base%20stub%20which%20returns%20%60%22%22%60%20%28falsy%29%2C%20so%20%60get_command_help%60%20falls%20through%3B%20no%20%60help.help%60%20file%20exists%20in%20the%20daemon%20cache%20yet%2C%20so%20%60get_file_help%60%20also%20comes%20up%20empty.%20A%20player%20typing%20%60help%20help%60%20now%20sees%20%22No%20help%20found%20for%20the%20topic%20'help'.%22%20instead%20of%20the%20former%20instructional%20text.%0A%0A%23%23%23%20Issue%202%20of%202%0Acmds%2Fstd%2Fhelp.c%3A53-54%0A**Multiple-match%20path%20returns%20an%20error%20instead%20of%20using%20priority%20order**%0A%0ACommand%20paths%20returned%20by%20%60get_path%28%29%60%20are%20already%20sorted%20by%20priority.%20When%20two%20directories%20both%20contain%20a%20file%20for%20the%20given%20topic%20%28e.g.%2C%20a%20custom%20command%20shadowing%20a%20std%20one%29%2C%20the%20conventional%20behavior%20is%20to%20take%20the%20first%20%28highest-priority%29%20match.%20Returning%20%60%22Too%20many%20command%20matches%20for%20'%22%2Btopic%2B%22'.%22%60%20here%20is%20unexpected%3A%20%60valid_result%60%20will%20flag%20this%20non-empty%20string%20as%20a%20hit%2C%20and%20the%20player%20receives%20an%20error%20rather%20than%20help%20from%20the%20best-match%20command.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=219&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["feat: help system rewrite"](https://github.com/gesslar/oxidus-mudlib/commit/967ac367ec6fce441395a96938d970a5a2ec6e9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36352478)</sub>

<!-- /greptile_comment -->