### PR TITLE
docs and things

### DIFF
--- a/adm/bash/sefuns
+++ b/adm/bash/sefuns
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Regenerate the simul_efun help files in /doc/sefun from the LPCDoc comment
+# blocks in /adm/simul_efun, using BeDoc (https://github.com/gesslar/BeDoc).
+#
+# The parser, formatter and per-function writer hook live under /doc/bedoc; the
+# config that ties them together is /doc/bedoc/sefun.json5. Any extra arguments
+# are passed straight through to bedoc (e.g. --terse).
+
+CURR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+LIB="$CURR/../.."        # adm/bash -> lib root
+
+cd "$LIB" || exit 1
+
+# Clean rebuild: clear out the generated help files (and the scratch module
+# output) first so renamed or removed sefuns don't leave orphans behind.
+rm -f doc/sefun/*.help doc/bedoc/.cache/*.help
+
+npx -y @gesslar/bedoc --config doc/bedoc/sefun.json5 "$@"

--- a/adm/bash/sefuns
+++ b/adm/bash/sefuns
@@ -14,6 +14,6 @@ cd "$LIB" || exit 1
 
 # Clean rebuild: clear out the generated help files (and the scratch module
 # output) first so renamed or removed sefuns don't leave orphans behind.
-rm -f doc/sefun/*.help doc/bedoc/.cache/*.help
+rm -f doc/sefun/*.help tmp/bedoc/*
 
 npx -y @gesslar/bedoc --config doc/bedoc/sefun.json5 "$@"

--- a/doc/bedoc/actions/bedoc-help-formatter.js
+++ b/doc/bedoc/actions/bedoc-help-formatter.js
@@ -2,15 +2,15 @@
  * @file Help formatter for the gLPU simul_efun help generator.
  *
  * Turns each parsed function into a standalone `.help` document: an LPML
- * frontmatter block carrying the function name as the title, followed by a body
- * laid out like the driver efun docs under `/doc/driver/efun` — `### NAME`,
+ * frontmatter block carrying the function name as the title, followed by a
+ * body laid out like the driver efun docs under `/doc/driver/efun` — `### NAME`,
  * `### SYNOPSIS`, `### DESCRIPTION`, `### PARAMETERS`, `### RETURN VALUES`,
  * `### ERRORS`, and `### EXAMPLE` sections with four-space indented bodies.
  *
  * The complete per-function document is stashed on `ctx.formatted`; the
- * companion Format hook (doc/bedoc/hooks/sefun-help-hooks.js) writes each one to
- * its own file. The pipeline result itself is empty — this formatter emits no
- * combined output.
+ * companion Format hook (doc/bedoc/hooks/sefun-help-hooks.js) writes each one
+ * to its own file. The pipeline result itself is empty — this formatter emits
+ * no combined output.
  *
  * @author gesslar
  */
@@ -61,7 +61,8 @@ export default class HelpFormatter {
     return lines.join("\n")
   }
 
-  // Collapse an array of raw comment lines into paragraphs, splitting on blanks.
+  // Collapse an array of raw comment lines into paragraphs, splitting on
+  // blanks.
   #paragraphs = lines => {
     const paras = []
     let curr = []
@@ -233,14 +234,15 @@ export default class HelpFormatter {
     const frontmatter = `---\n{\n  title: ${JSON.stringify(ctx.name)}\n}\n---`
     const formatted = `${frontmatter}\n${sections.join("\n\n")}\n`
 
-    // Mutate in place so the Format hook's after$formatFunction sees `formatted`
-    // on the same context object.
+    // Mutate in place so the Format hook's after$formatFunction sees
+    // `formatted` on the same context object.
     return Object.assign(ctx, {formatted})
   }
 
   // The per-function `.help` files are written by the Format hook. BeDoc still
   // writes one file per source module from this return value, so we hand back
-  // the concatenated documents — the config routes that to a scratch directory.
+  // the concatenated documents — the config routes that to a scratch
+  // directory.
   #finalize = ctx =>
     Array.isArray(ctx)
       ? ctx.map(fn => fn.formatted).filter(Boolean).join("\n\n")

--- a/doc/bedoc/actions/bedoc-help-formatter.js
+++ b/doc/bedoc/actions/bedoc-help-formatter.js
@@ -1,0 +1,248 @@
+/**
+ * @file Help formatter for the gLPU simul_efun help generator.
+ *
+ * Turns each parsed function into a standalone `.help` document: an LPML
+ * frontmatter block carrying the function name as the title, followed by a body
+ * laid out like the driver efun docs under `/doc/driver/efun` — `### NAME`,
+ * `### SYNOPSIS`, `### DESCRIPTION`, `### PARAMETERS`, `### RETURN VALUES`,
+ * `### ERRORS`, and `### EXAMPLE` sections with four-space indented bodies.
+ *
+ * The complete per-function document is stashed on `ctx.formatted`; the
+ * companion Format hook (doc/bedoc/hooks/sefun-help-hooks.js) writes each one to
+ * its own file. The pipeline result itself is empty — this formatter emits no
+ * combined output.
+ *
+ * @author gesslar
+ */
+
+import {ActionBuilder, ACTIVITY} from "@gesslar/actioneer"
+
+const WIDTH = 76
+const INDENT = 4
+
+export default class HelpFormatter {
+  static meta = Object.freeze({
+    kind: "formatter",
+    format: "help",
+    extension: "help",
+    terms: "ref://./bedoc-help-formatter.yaml"
+  })
+
+  setup = builder => builder
+    .do("Format functions", ACTIVITY.SPLIT,
+      ctx => ctx, // splitter
+      ctx => ctx, // rejoiner — nothing to recombine; the hook writes each file
+      new ActionBuilder()
+        .do("Format function", this.#formatFunction)
+    )
+    .do("Finalize", this.#finalize)
+
+  // -- Text helpers ---------------------------------------------------------
+
+  // Word-wrap a single run of text to WIDTH columns, indenting every line.
+  #wrap = (text, width, indent) => {
+    const pad = " ".repeat(indent)
+    const words = String(text).split(/\s+/).filter(Boolean)
+    const lines = []
+    let line = ""
+
+    for(const word of words) {
+      if(line && (pad + line + " " + word).length > width) {
+        lines.push(pad + line)
+        line = word
+      } else {
+        line = line ? line + " " + word : word
+      }
+    }
+
+    if(line)
+      lines.push(pad + line)
+
+    return lines.join("\n")
+  }
+
+  // Collapse an array of raw comment lines into paragraphs, splitting on blanks.
+  #paragraphs = lines => {
+    const paras = []
+    let curr = []
+
+    for(const line of (lines ?? [])) {
+      if(line.trim() === "") {
+        if(curr.length) {
+          paras.push(curr.join(" "))
+          curr = []
+        }
+      } else {
+        curr.push(line.trim())
+      }
+    }
+
+    if(curr.length)
+      paras.push(curr.join(" "))
+
+    return paras
+  }
+
+  #section = (heading, body) => `### ${heading}\n\n${body}`
+
+  // -- Section builders -----------------------------------------------------
+
+  #synopsis = signature => {
+    const s = signature ?? {}
+    const head = [s.access, s.modifier1, s.modifier2].filter(Boolean).join(" ")
+    const params = s.parameters ?? []
+
+    let sig = head ? head + " " : ""
+    sig += s.type ?? "mixed"
+    sig += s.array ? " *" : " "
+    sig += s.name
+    sig += params.length ? `( ${params.join(", ")} )` : "( void )"
+    sig += ";"
+
+    return sig
+  }
+
+  #parameters = params => {
+    const rows = params.map(p => {
+      let name = p.name
+      let optional = false
+      let defaultValue = null
+
+      const optMatch = name.match(/^\[(.*)\]$/)
+      if(optMatch) {
+        optional = true
+        name = optMatch[1]
+      }
+
+      const defMatch = name.match(/^([^=]*)=(.*)$/)
+      if(defMatch) {
+        name = defMatch[1]
+        defaultValue = defMatch[2]
+      }
+
+      name = name.replace(/\.{3}/, "").trim()
+
+      const type = Array.isArray(p.type) ? p.type.join("|") : p.type
+      const bits = [type]
+      if(optional)
+        bits.push("optional")
+      if(defaultValue != null && defaultValue !== "")
+        bits.push(`default: ${defaultValue}`)
+
+      const content = (p.content ?? [])
+        .map(c => c.trim())
+        .filter(Boolean)
+        .join(" ")
+
+      return {name, meta: `(${bits.join(", ")})`, content}
+    })
+
+    const col = Math.max(...rows.map(r => r.name.length), 1)
+    const lines = []
+
+    for(const row of rows) {
+      lines.push(`${" ".repeat(INDENT)}${row.name.padEnd(col)}  ${row.meta}`)
+      if(row.content)
+        lines.push(this.#wrap(row.content, WIDTH, INDENT + col + 2))
+      lines.push("")
+    }
+
+    while(lines.length && lines.at(-1) === "")
+      lines.pop()
+
+    return lines.join("\n")
+  }
+
+  #example = lines => {
+    // Drop markdown code fences (``` / ```lang) — meaningless in a MUD help
+    // display — and keep the code as-is.
+    const body = [...(lines ?? [])].filter(line => !/^\s*```/.test(line))
+
+    while(body.length && body.at(0).trim() === "")
+      body.shift()
+    while(body.length && body.at(-1).trim() === "")
+      body.pop()
+
+    const rendered = body.map(line =>
+      line.trim() === "" ? "" : " ".repeat(INDENT) + line)
+
+    // Dim the example code with {{di1}}…{{di0}} so it reads as de-emphasized.
+    const first = rendered.findIndex(line => line !== "")
+    if(first < 0)
+      return ""
+
+    let last = rendered.length - 1
+    while(last > first && rendered[last] === "")
+      last--
+
+    rendered[first] = rendered[first].replace(/^( {4})/, "$1{{di1}}")
+    rendered[last] += "{{di0}}"
+
+    return rendered.join("\n")
+  }
+
+  // -- Pipeline -------------------------------------------------------------
+
+  #formatFunction = ctx => {
+    const sections = []
+    const paragraphs = this.#paragraphs(ctx.description)
+    const tagline = paragraphs[0] ?? ""
+
+    // NAME
+    const nameLine = `${ctx.name}()${tagline ? ` - ${tagline}` : ""}`
+    sections.push(this.#section("NAME", this.#wrap(nameLine, WIDTH, INDENT)))
+
+    // SYNOPSIS
+    sections.push(this.#section("SYNOPSIS",
+      `${" ".repeat(INDENT)}${this.#synopsis(ctx.signature)}`))
+
+    // DESCRIPTION
+    if(paragraphs.length) {
+      const body = paragraphs.map(p => this.#wrap(p, WIDTH, INDENT)).join("\n\n")
+      sections.push(this.#section("DESCRIPTION", body))
+    }
+
+    // PARAMETERS
+    if(ctx.param?.length)
+      sections.push(this.#section("PARAMETERS", this.#parameters(ctx.param)))
+
+    // RETURN VALUES
+    if(ctx.return && ctx.return.type !== "void") {
+      const type = Array.isArray(ctx.return.type)
+        ? ctx.return.type.join("|")
+        : ctx.return.type
+      const content = (ctx.return.content ?? []).map(c => c.trim()).filter(Boolean).join(" ")
+      const body = this.#wrap(`(${type})${content ? ` ${content}` : ""}`, WIDTH, INDENT)
+      sections.push(this.#section("RETURN VALUES", body))
+    }
+
+    // ERRORS
+    if(ctx.errors?.length) {
+      const text = ctx.errors.map(e => e.trim()).filter(Boolean).join(" ")
+      if(text)
+        sections.push(this.#section("ERRORS", this.#wrap(text, WIDTH, INDENT)))
+    }
+
+    // EXAMPLE
+    if(ctx.example?.length) {
+      const body = this.#example(ctx.example)
+      if(body)
+        sections.push(this.#section("EXAMPLE", body))
+    }
+
+    const frontmatter = `---\n{\n  title: ${JSON.stringify(ctx.name)}\n}\n---`
+    const formatted = `${frontmatter}\n${sections.join("\n\n")}\n`
+
+    // Mutate in place so the Format hook's after$formatFunction sees `formatted`
+    // on the same context object.
+    return Object.assign(ctx, {formatted})
+  }
+
+  // The per-function `.help` files are written by the Format hook. BeDoc still
+  // writes one file per source module from this return value, so we hand back
+  // the concatenated documents — the config routes that to a scratch directory.
+  #finalize = ctx =>
+    Array.isArray(ctx)
+      ? ctx.map(fn => fn.formatted).filter(Boolean).join("\n\n")
+      : ""
+}

--- a/doc/bedoc/actions/bedoc-help-formatter.yaml
+++ b/doc/bedoc/actions/bedoc-help-formatter.yaml
@@ -1,0 +1,89 @@
+# yaml-language-server: $schema=https://schema.gesslar.dev/bedoc/v1/bedoc-action.json
+
+$schema: https://schema.gesslar.dev/bedoc/v1/bedoc-action.json
+accepts:
+  type: object
+  required:
+    - functions
+  properties:
+    functions:
+      type: array
+      items:
+        type: object
+        required:
+          - name
+          - signature
+        properties:
+          name:
+            type: string
+          signature:
+            type: object
+            required:
+              - name
+            properties:
+              access:
+                type: string
+                enum: [protected, public, private]
+              modifier1:
+                type: string
+                enum: [nomask, varargs]
+              modifier2:
+                type: string
+                enum: [nomask, varargs]
+              type:
+                type: string
+              array:
+                type: boolean
+              name:
+                type: string
+              parameters:
+                type: array
+                items:
+                  type: string
+          description:
+            type: array
+            items:
+              type: string
+          param:
+            type: array
+            items:
+              type: object
+              required:
+                - type
+                - name
+              properties:
+                type:
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+                name:
+                  type: string
+                content:
+                  type: array
+                  items:
+                    type: string
+          return:
+            type: object
+            required:
+              - type
+            properties:
+              type:
+                oneOf:
+                  - type: string
+                  - type: array
+                    items:
+                      type: string
+              content:
+                type: array
+                items:
+                  type: string
+          errors:
+            type: array
+            items:
+              type: string
+          example:
+            type: array
+            items:
+              type: string

--- a/doc/bedoc/actions/bedoc-lpc-parser.js
+++ b/doc/bedoc/actions/bedoc-lpc-parser.js
@@ -5,7 +5,8 @@
  * from LPC source files, producing the structured `functions` payload consumed
  * by the help formatter.
  *
- * This is adapted from the BeDoc sample LPC parser with gLPU-specific changes:
+ * This is adapted from the BeDoc sample LPC parser with Oxidus-specific
+ * changes:
  *   - the signature regex captures the array `*` return marker,
  *   - blocks that are not attached to a function (file headers, documented
  *     variables) are dropped instead of crashing the run,
@@ -52,8 +53,8 @@ export default class LpcParser {
 
       const startIndex = lines.findIndex(line => this.#regexes.get("block-start").exec(line))
       // The closing `*/` must come after this block's opening — otherwise a
-      // plain `/* ... */` header comment earlier in the file would steal it and
-      // abort the whole file.
+      // plain `/* ... */` header comment earlier in the file would steal it
+      // and abort the whole file.
       const endIndex = lines.findIndex((line, i) =>
         i > startIndex && this.#regexes.get("block-stop").exec(line))
 

--- a/doc/bedoc/actions/bedoc-lpc-parser.js
+++ b/doc/bedoc/actions/bedoc-lpc-parser.js
@@ -1,0 +1,269 @@
+/**
+ * @file LPC parser for the gLPU simul_efun help generator.
+ *
+ * Extracts LPCDoc comment blocks and the function signatures that follow them
+ * from LPC source files, producing the structured `functions` payload consumed
+ * by the help formatter.
+ *
+ * This is adapted from the BeDoc sample LPC parser with gLPU-specific changes:
+ *   - the signature regex captures the array `*` return marker,
+ *   - blocks that are not attached to a function (file headers, documented
+ *     variables) are dropped instead of crashing the run,
+ *   - `private` functions are excluded (not part of the public API),
+ *   - free-form `@errors` / `@throws` tags are captured.
+ *
+ * @author gesslar
+ */
+
+import {ActionBuilder, ACTIVITY} from "@gesslar/actioneer"
+import {Collection, Data, Util} from "@gesslar/toolkit"
+
+const {WHILE} = ACTIVITY
+
+export default class LpcParser {
+  static meta = Object.freeze({
+    kind: "parser",
+    input: "lpc",
+    terms: "ref://./bedoc-lpc-parser.yaml"
+  })
+
+  setup = builder => builder
+    .do("Extract blocks", this.#extractBlocks)
+    .do("Process functions", ACTIVITY.SPLIT,
+      ctx => ctx, // splitter
+      ctx => ctx, // rejoiner
+      new ActionBuilder()
+        .do("Extract signature", this.#johnHandcock)
+        .do("Extract description", this.#extractDescription)
+        .do("Extract tags", WHILE, ctx => {
+          return ctx.lines.length > 0
+        }, this.#extractTag)
+    )
+    .done(this.#finally)
+
+  async #extractBlocks(ctx) {
+    ctx = Data.append(ctx, "\n")
+
+    const result = []
+    const lines = ctx.split("\n")
+
+    while(lines.length) {
+      const block = {}
+
+      const startIndex = lines.findIndex(line => this.#regexes.get("block-start").exec(line))
+      // The closing `*/` must come after this block's opening — otherwise a
+      // plain `/* ... */` header comment earlier in the file would steal it and
+      // abort the whole file.
+      const endIndex = lines.findIndex((line, i) =>
+        i > startIndex && this.#regexes.get("block-stop").exec(line))
+
+      if(startIndex < 0 || endIndex <= startIndex)
+        break
+
+      block.lines = lines.slice(startIndex+1, endIndex)
+
+      lines.splice(0, endIndex+1)
+
+      const idIndex = lines.findIndex(line => this.#regexes.get("function").test(line))
+      const nextBlockIndex = lines.findIndex(line => this.#regexes.get("block-start").test(line))
+
+      if(idIndex > -1) {
+        if(nextBlockIndex !== -1 && idIndex > nextBlockIndex) {
+          // The next thing is another doc block, not a function — this block
+          // documents a file header or a variable. Leave block.function unset;
+          // #finally drops it.
+          lines.splice(0, nextBlockIndex)
+        } else {
+          const func = this.#regexes.get("function").exec(lines[idIndex])
+          block.function = func
+
+          lines.splice(0, 1)
+        }
+      }
+
+      result.push(block)
+    }
+
+    return result
+  }
+
+  #gimme = ob =>
+    Object.fromEntries(Object.entries(ob).filter(([_, v]) => v != null))
+
+  #johnHandcock = ctx => {
+    const {function: func} = ctx
+    const signature = this.#gimme(func?.groups ?? {})
+
+    signature.array = signature.array ? true : false
+
+    signature.parameters = signature.parms
+      ? signature.parms.split(",").map(p => p.trim()).filter(Boolean)
+      : []
+    delete signature.parms
+
+    return Object.assign(ctx, {signature})
+  }
+
+  #extractDescription = ctx => {
+    const {lines} = ctx
+
+    const comment = this.#regexes.get("comment-line")
+    const tagId = this.#regexes.get("tag-id")
+
+    const description = []
+    Object.assign(ctx, {description})
+
+    if(!(comment.test(lines.join("\n"))))
+      return ctx
+
+    while(lines.length > 0) {
+      const line = lines.shift()
+
+      if(!comment.test(line))
+        continue
+
+      if(tagId.test(line)) {
+        lines.unshift(line)
+        break
+      }
+
+      const {content} = comment.exec(line)?.groups ?? {}
+      description.push(content ?? "")
+    }
+
+    return ctx
+  }
+
+  #extractTag = async ctx => {
+    const {lines, tag: extractedTags = {}} = ctx
+
+    const comment = this.#regexes.get("comment-line")
+    const tagId = this.#regexes.get("tag-id")
+    // narrower to broader
+    const patterns = ["return", "example", "simple", "tag"].map(e => this.#regexes.get(e))
+
+    const line = lines.shift()
+
+    if(!comment.test(line))
+      return ctx
+
+    if(!tagId.test(line))
+      return ctx
+
+    const pattern = patterns.find(e => e.test(line))
+
+    if(!pattern)
+      return ctx
+
+    const {groups} = pattern.exec(line) ?? {}
+    if(!groups)
+      return ctx
+
+    const {tag} = groups
+    if(!tag)
+      return ctx
+
+    delete groups.tag
+    if(groups.content)
+      groups.content = [groups.content]
+    else
+      groups.content = []
+
+    while(lines.length > 0) {
+      const continued = lines.shift()
+
+      if(tagId.test(continued)) {
+        lines.unshift(continued)
+        break
+      }
+
+      const {content} = comment.exec(continued)?.groups ?? {}
+
+      groups.content.push(content ?? "")
+    }
+
+    const curr = extractedTags[tag] ?? []
+    curr.push(groups)
+
+    Object.assign(extractedTags, {[tag]: curr})
+
+    return Object.assign(ctx, {tag: extractedTags})
+  }
+
+  async #finally(ctx) {
+    // Keep only blocks attached to a non-private function. File headers and
+    // documented variables have no function; private functions are not part of
+    // the public API.
+    const documented = ctx.filter(block =>
+      block.function && block.signature?.access !== "private")
+
+    const functions = await Collection.asyncMap(documented, async func => {
+      const result = {
+        name: func.function.groups.name,
+        description: func.description,
+        signature: func.signature,
+      }
+
+      const tags = func.tag ?? {}
+
+      if(tags.param)
+        result.param = tags.param
+          .map(({type, name, content}) => ({type, name, content}))
+
+      if(tags.return || tags.returns) {
+        const ret = (tags.return ?? tags.returns)[0]
+        result.return = {type: ret.type, content: ret.content}
+      }
+
+      if(tags.errors || tags.throws) {
+        const errs = [...(tags.errors ?? []), ...(tags.throws ?? [])]
+        result.errors = errs.flatMap(({content}) => content)
+      }
+
+      if(tags.example || tags.examples) {
+        const examples = tags.example ?? tags.examples
+        result.example = examples.flatMap(({content}) => content)
+      }
+
+      return result
+    })
+
+    return {functions}
+  }
+
+  #regexes = new Map([
+    ["block-start", /^\s*\/\*\*.*$/],
+    ["block-stop", /^\s*\*\/\s*$/],
+    ["comment-line", /^\s\*((?:\s)(?<content>[\s\S]+))?/],
+    ["tag-id", /^\s\*\s@[a-zA-Z]/],
+    ["tag", Util.regexify(`
+      ^\\s*\\*(\\s
+      @(?<tag>\\w+)\\s*
+      \\{(?<type>\\w+(?:\\|\\w+)*(?:\\*)?)\\}\\s+
+      (?<name>(\\w+(\\.\\w?)*=?\\w*\\s*(?<rest>\\.{3})?|\\[\\w+=?.*]))(?:\\s+-)?\\s+|\\s)
+      (?<content>[\\s\\S]+?)
+      $
+    `
+    )],
+    ["simple", /^\s*\*\s*@(?<tag>errors|throws)\b\s*(?:-\s+)?(?<content>.*)$/],
+    ["return", /^\s*\*\s*@(?<tag>returns?)\s+\{(?<type>[^}]*)\}(?:\s+(?:-\s+)?(?<content>.*))?/],
+    ["example", /^\s\* @(?<tag>examples?)((?:\s)(?<content>[\s\S]+))?/],
+    ["function", Util.regexify(`
+      ^\\s*
+      (?<access>public|protected|private)?
+      \\s*
+      (?<modifier1>nomask|varargs)?
+      \\s*
+      (?<modifier2>nomask|varargs)?
+      \\s*
+      (?<type>(int|float|void|string|object|mixed|mapping|array|buffer|function))\\s*(?<array>\\*)?
+      \\s*
+      (?<name>[a-zA-Z_][a-zA-Z0-9_]*)
+      \\s*
+      \\((?<parms>.*)\\)
+      \\s*
+      \\{?.*
+      `
+    )]
+  ])
+}

--- a/doc/bedoc/actions/bedoc-lpc-parser.yaml
+++ b/doc/bedoc/actions/bedoc-lpc-parser.yaml
@@ -1,0 +1,94 @@
+# yaml-language-server: $schema=https://schema.gesslar.dev/bedoc/v1/bedoc-action.json
+
+$schema: https://schema.gesslar.dev/bedoc/v1/bedoc-action.json
+provides:
+  type: object
+  required:
+    - functions
+  properties:
+    functions:
+      type: array
+      items:
+        type: object
+        required:
+          - name
+          - signature
+        properties:
+          name:
+            type: string
+          signature:
+            type: object
+            required:
+              - name
+            properties:
+              access:
+                type: string
+                enum: [protected, public, private]
+              modifier1:
+                type: string
+                enum: [nomask, varargs]
+              modifier2:
+                type: string
+                enum: [nomask, varargs]
+              type:
+                type: string
+                enum:
+                  [
+                    array,
+                    buffer,
+                    float,
+                    function,
+                    int,
+                    mapping,
+                    mixed,
+                    object,
+                    string,
+                    void,
+                  ]
+              array:
+                type: boolean
+              name:
+                type: string
+              parameters:
+                type: array
+                items:
+                  type: string
+          description:
+            type: array
+            items:
+              type: string
+          param:
+            type: array
+            items:
+              type: object
+              required:
+                - type
+                - name
+              properties:
+                type:
+                  type: string
+                name:
+                  type: string
+                content:
+                  type: array
+                  items:
+                    type: string
+          return:
+            type: object
+            required:
+              - type
+            properties:
+              type:
+                type: string
+              content:
+                type: array
+                items:
+                  type: string
+          errors:
+            type: array
+            items:
+              type: string
+          example:
+            type: array
+            items:
+              type: string

--- a/doc/bedoc/hooks/sefun-help-hooks.js
+++ b/doc/bedoc/hooks/sefun-help-hooks.js
@@ -1,0 +1,37 @@
+/**
+ * @file Format hook for the gLPU simul_efun help generator.
+ *
+ * BeDoc writes one output file per input source file, but each simul_efun
+ * source holds many functions and we want one help file per function. This hook
+ * intercepts each formatted function and writes it to its own
+ * `<name>.help` file under `/doc/sefun`, all in a single flat directory (every
+ * sefun is uniquely named). The formatter itself returns no combined output, so
+ * these per-function writes are the only files produced.
+ *
+ * The output directory is resolved relative to this hook file, so it does not
+ * depend on the working directory BeDoc is launched from.
+ *
+ * @author gesslar
+ */
+
+import {mkdir, writeFile} from "node:fs/promises"
+import {dirname, join} from "node:path"
+import {fileURLToPath} from "node:url"
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const OUTPUT_DIR = join(HERE, "..", "..", "sefun")
+
+export class Format {
+  setup = async() => {
+    await mkdir(OUTPUT_DIR, {recursive: true})
+  }
+
+  after$formatFunction = async ctx => {
+    if(!ctx?.name || !ctx?.formatted)
+      return ctx
+
+    await writeFile(join(OUTPUT_DIR, `${ctx.name}.help`), ctx.formatted)
+
+    return ctx
+  }
+}

--- a/doc/bedoc/package.json
+++ b/doc/bedoc/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/doc/bedoc/sefun.json5
+++ b/doc/bedoc/sefun.json5
@@ -1,0 +1,28 @@
+// gLPU simul_efun help generator.
+//
+// Scrapes the LPCDoc comment blocks out of the simul_efuns and emits one help
+// file per public function into /doc/sefun. Run from the lib root:
+//
+//   npx @gesslar/bedoc --config doc/bedoc/sefun.json5
+//
+// The parser, formatter and per-function writer hook all live alongside this
+// config under /doc/bedoc.
+{
+  // Pinned parser + formatter (no discovery) — they are not published packages.
+  parser: "doc/bedoc/actions/bedoc-lpc-parser.js",
+  formatter: "doc/bedoc/actions/bedoc-help-formatter.js",
+
+  // Writes each formatted function to its own /doc/sefun/<name>.help file.
+  hooks: "doc/bedoc/hooks/sefun-help-hooks.js",
+
+  // Every simul_efun source file.
+  input: ["adm/simul_efun/*.c"],
+
+  // The hook writes the real per-function files to /tmp/bedoc. BeDoc still
+  // writes one file per source module from the formatter's return value; we
+  // send those throwaway module files to a gitignored scratch directory.
+  output: "tmp/bedoc",
+
+  // Don't show all the stages
+  terse: true,
+}

--- a/doc/bedoc/sefun.json5
+++ b/doc/bedoc/sefun.json5
@@ -18,7 +18,7 @@
   // Every simul_efun source file.
   input: ["adm/simul_efun/*.c"],
 
-  // The hook writes the real per-function files to /tmp/bedoc. BeDoc still
+  // The hook writes the real per-function files to /doc/sefun. BeDoc still
   // writes one file per source module from the formatter's return value; we
   // send those throwaway module files to a gitignored scratch directory.
   output: "tmp/bedoc",

--- a/doc/sefun/_debug.help
+++ b/doc/sefun/_debug.help
@@ -1,0 +1,43 @@
+---
+{
+  title: "_debug"
+}
+---
+### NAME
+
+    _debug() - Sends a message to a player using accessible notation to
+    indicate that it is a debug system message.
+
+### SYNOPSIS
+
+    varargs int _debug( mixed args... );
+
+### DESCRIPTION
+
+    Sends a message to a player using accessible notation to indicate that
+    it is a debug system message.
+
+    Provides a debug message, optionally formatted with arguments. If no
+    object is provided, the message will be sent to this_body(). If no
+    object is found, the message will be discarded.
+
+### PARAMETERS
+
+    tp    (STD_PLAYER)
+          The target object to receive the message.
+
+    str   (string)
+          The debug message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+    str   (string)
+          The debug message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+### RETURN VALUES
+
+    (int) Always returns 1, unless there is no body object.

--- a/doc/sefun/_error.help
+++ b/doc/sefun/_error.help
@@ -1,0 +1,43 @@
+---
+{
+  title: "_error"
+}
+---
+### NAME
+
+    _error() - Sends a message to a player using accessible notation to
+    indicate that it is an error/failure system message.
+
+### SYNOPSIS
+
+    varargs int _error( mixed args... );
+
+### DESCRIPTION
+
+    Sends a message to a player using accessible notation to indicate that
+    it is an error/failure system message.
+
+    Provides an error message, optionally formatted with arguments. If no
+    object is provided, the message will be sent to this_body(). If no
+    object is found, the message will be sent to the debug log.
+
+### PARAMETERS
+
+    tp    (STD_PLAYER)
+          The target object to receive the message.
+
+    str   (string)
+          The error message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+    str   (string)
+          The error message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+### RETURN VALUES
+
+    (int) Always returns 1, unless there is no previous object.

--- a/doc/sefun/_info.help
+++ b/doc/sefun/_info.help
@@ -1,0 +1,43 @@
+---
+{
+  title: "_info"
+}
+---
+### NAME
+
+    _info() - Sends a message to a player using accessible notation to
+    indicate that it is an informational system message.
+
+### SYNOPSIS
+
+    varargs int _info( mixed args... );
+
+### DESCRIPTION
+
+    Sends a message to a player using accessible notation to indicate that
+    it is an informational system message.
+
+    Provides an informational message, optionally formatted with arguments.
+    If no object is provided, the message will be sent to this_body(). If no
+    object is found, the message will be sent to the debug log.
+
+### PARAMETERS
+
+    tp    (STD_PLAYER)
+          The target object to receive the message.
+
+    str   (string)
+          The informational message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+    str   (string)
+          The informational message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+### RETURN VALUES
+
+    (int) Always returns 1, unless there is no previous object.

--- a/doc/sefun/_ok.help
+++ b/doc/sefun/_ok.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "_ok"
+}
+---
+### NAME
+
+    _ok()
+
+### SYNOPSIS
+
+    varargs int _ok( mixed args... );
+
+### PARAMETERS
+
+    tp    (STD_PLAYER)
+          The target object to receive the message.
+
+    str   (string)
+          The confirmation message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+    str   (string)
+          The confirmation message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+### RETURN VALUES
+
+    (int) Always returns 1, unless there is no previous object.

--- a/doc/sefun/_question.help
+++ b/doc/sefun/_question.help
@@ -1,0 +1,43 @@
+---
+{
+  title: "_question"
+}
+---
+### NAME
+
+    _question() - Sends a message to a player using accessible notation to
+    indicate that it is a question/query system message.
+
+### SYNOPSIS
+
+    varargs int _question( mixed args... );
+
+### DESCRIPTION
+
+    Sends a message to a player using accessible notation to indicate that
+    it is a question/query system message.
+
+    Provides a question message, optionally formatted with arguments. If no
+    object is provided, the message will be sent to this_body(). If no
+    object is found, the message will be discarded.
+
+### PARAMETERS
+
+    tp    (STD_PLAYER)
+          The target object to receive the message.
+
+    str   (string)
+          The question message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+    str   (string)
+          The question message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+### RETURN VALUES
+
+    (int) Always returns 1, unless there is no body object.

--- a/doc/sefun/_warn.help
+++ b/doc/sefun/_warn.help
@@ -1,0 +1,43 @@
+---
+{
+  title: "_warn"
+}
+---
+### NAME
+
+    _warn() - Sends a message to a player using accessible notation to
+    indicate that it is a warning system message.
+
+### SYNOPSIS
+
+    varargs int _warn( mixed args... );
+
+### DESCRIPTION
+
+    Sends a message to a player using accessible notation to indicate that
+    it is a warning system message.
+
+    Provides a warning message, optionally formatted with arguments. If no
+    object is provided, the message will be sent to this_body(). If no
+    object is found, the message will be sent to the debug log.
+
+### PARAMETERS
+
+    tp    (STD_PLAYER)
+          The target object to receive the message.
+
+    str   (string)
+          The warning message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+    str   (string)
+          The warning message.
+
+    args  (mixed, optional)
+          Optional arguments to format the message.
+
+### RETURN VALUES
+
+    (int) Always returns 1, unless there is no previous object.

--- a/doc/sefun/accessible_objects.help
+++ b/doc/sefun/accessible_objects.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "accessible_objects"
+}
+---
+### NAME
+
+    accessible_objects() - Retrieves a nested array of objects that can be
+    reached within a container.
+
+### SYNOPSIS
+
+    varargs mixed *accessible_objects( object container, object pov );
+
+### DESCRIPTION
+
+    Retrieves a nested array of objects that can be reached within a
+    container.
+
+    This function checks the accessibility of objects within a container
+    from the perspective of another object, including nested containers.
+
+### PARAMETERS
+
+    container  (STD_CONTAINER)
+               The container object we are checking
+
+    pov        (STD_ITEM, optional)
+               The perspective object doing the checking.
+
+### RETURN VALUES
+
+    (mixed*) A nested array of objects that can be reached in the container.

--- a/doc/sefun/accessible_objects_flat.help
+++ b/doc/sefun/accessible_objects_flat.help
@@ -1,0 +1,34 @@
+---
+{
+  title: "accessible_objects_flat"
+}
+---
+### NAME
+
+    accessible_objects_flat() - Retrieves a flat array of objects that can
+    be reached within a container.
+
+### SYNOPSIS
+
+    varargs object *accessible_objects_flat( object container, object pov );
+
+### DESCRIPTION
+
+    Retrieves a flat array of objects that can be reached within a
+    container.
+
+    This function checks the accessibility of objects within a container
+    from the perspective of another object, including nested containers, and
+    returns a flat array of all reachable objects.
+
+### PARAMETERS
+
+    container  (STD_CONTAINER)
+               The container object we are checking
+
+    pov        (STD_ITEM, optional)
+               The perspective object doing the checking.
+
+### RETURN VALUES
+
+    (STD_ITEM*) An array of objects that can be reached in the container.

--- a/doc/sefun/account_file.help
+++ b/doc/sefun/account_file.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "account_file"
+}
+---
+### NAME
+
+    account_file() - Returns the file path for the account file.
+
+### SYNOPSIS
+
+    string account_file( string name );
+
+### DESCRIPTION
+
+    Returns the file path for the account file.
+
+### PARAMETERS
+
+    name  (string)
+          The name of the account.
+
+### RETURN VALUES
+
+    (string) The file path for the account file, or 0 if the input is
+    invalid.

--- a/doc/sefun/account_path.help
+++ b/doc/sefun/account_path.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "account_path"
+}
+---
+### NAME
+
+    account_path() - Returns the path for the account file.
+
+### SYNOPSIS
+
+    string account_path( string name );
+
+### DESCRIPTION
+
+    Returns the path for the account file.
+
+### PARAMETERS
+
+    name  (string)
+          The name of the account.
+
+### RETURN VALUES
+
+    (string) The path for the account file, or 0 if the input is invalid.

--- a/doc/sefun/add_article.help
+++ b/doc/sefun/add_article.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "add_article"
+}
+---
+### NAME
+
+    add_article() - Adds appropriate article to start of string.
+
+### SYNOPSIS
+
+    varargs string add_article( string str, int definite );
+
+### DESCRIPTION
+
+    Adds appropriate article to start of string.
+
+### PARAMETERS
+
+    str       (string)
+              String to add article to
+
+    definite  (int, optional, default: 0)
+              Use "the" instead of "a/an"
+
+### RETURN VALUES
+
+    (string) String with article added
+
+### EXAMPLE
+
+    {{di1}}add_article("elephant");     // Returns "an elephant"
+    add_article("bear", 1);      // Returns "the bear"{{di0}}

--- a/doc/sefun/add_commas.help
+++ b/doc/sefun/add_commas.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "add_commas"
+}
+---
+### NAME
+
+    add_commas() - Returns a string with commas added to the number.
+
+### SYNOPSIS
+
+    string add_commas( mixed number );
+
+### DESCRIPTION
+
+    Returns a string with commas added to the number.
+
+### PARAMETERS
+
+    number  (mixed)
+            The number to add commas to.
+
+### RETURN VALUES
+
+    (string) The number with commas added as a string.

--- a/doc/sefun/admin_email.help
+++ b/doc/sefun/admin_email.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "admin_email"
+}
+---
+### NAME
+
+    admin_email() - Returns the admin email address for the MUD.
+
+### SYNOPSIS
+
+    string admin_email( void );
+
+### DESCRIPTION
+
+    Returns the admin email address for the MUD.
+
+### RETURN VALUES
+
+    (string) The admin email address.

--- a/doc/sefun/adminp.help
+++ b/doc/sefun/adminp.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "adminp"
+}
+---
+### NAME
+
+    adminp() - Checks if a user has admin privileges.
+
+### SYNOPSIS
+
+    int adminp( mixed user );
+
+### DESCRIPTION
+
+    Checks if a user has admin privileges.
+
+### PARAMETERS
+
+    user  (mixed)
+          The user to check, either as a username string or an object.
+          Defaults to the previous object.
+
+### RETURN VALUES
+
+    (int) 1 if the user has admin privileges, otherwise 0.

--- a/doc/sefun/all_environment.help
+++ b/doc/sefun/all_environment.help
@@ -1,0 +1,27 @@
+---
+{
+  title: "all_environment"
+}
+---
+### NAME
+
+    all_environment() - Retrieves all environments of the specified object,
+    traversing up through nested environments.
+
+### SYNOPSIS
+
+    varargs object *all_environment( object ob );
+
+### DESCRIPTION
+
+    Retrieves all environments of the specified object, traversing up
+    through nested environments.
+
+### PARAMETERS
+
+    ob  (object)
+        The object to get the environments of.
+
+### RETURN VALUES
+
+    (object*) An array of environments of the object.

--- a/doc/sefun/append.help
+++ b/doc/sefun/append.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "append"
+}
+---
+### NAME
+
+    append() - Appends a string to another string if it is not already
+    there. If the string is already present, the original string is
+    returned.
+
+### SYNOPSIS
+
+    string append( string source, string to_append );
+
+### DESCRIPTION
+
+    Appends a string to another string if it is not already there. If the
+    string is already present, the original string is returned.
+
+### PARAMETERS
+
+    source     (string)
+               The string to append to.
+
+    to_append  (string)
+               The string to append.
+
+### RETURN VALUES
+
+    (string) The original string with the appended string if it was not
+    already present.

--- a/doc/sefun/arch.help
+++ b/doc/sefun/arch.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "arch"
+}
+---
+### NAME
+
+    arch() - Returns the architecture of the system the MUD is running on.
+
+### SYNOPSIS
+
+    string arch( void );
+
+### DESCRIPTION
+
+    Returns the architecture of the system the MUD is running on.
+
+### RETURN VALUES
+
+    (string) The system architecture.

--- a/doc/sefun/array_columns.help
+++ b/doc/sefun/array_columns.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "array_columns"
+}
+---
+### NAME
+
+    array_columns() - Formats an array of strings into multiple columns for
+    display.
+
+### SYNOPSIS
+
+    varargs string array_columns( string *items, int col, int width );
+
+### DESCRIPTION
+
+    Formats an array of strings into multiple columns for display.
+
+### PARAMETERS
+
+    items  (string*)
+           Array of strings to display
+
+    col    (int, optional, default: 2)
+           Number of columns to display
+
+    width  (int, optional, default: 79)
+           Total width available for all columns
+
+### RETURN VALUES
+
+    (string) Text formatted into the requested number of columns

--- a/doc/sefun/article.help
+++ b/doc/sefun/article.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "article"
+}
+---
+### NAME
+
+    article() - Determines the appropriate article for a word.
+
+### SYNOPSIS
+
+    varargs string article( string str, int definite );
+
+### DESCRIPTION
+
+    Determines the appropriate article for a word.
+
+### PARAMETERS
+
+    str       (string)
+              Word to check
+
+    definite  (int, optional, default: 0)
+              Use "the" instead of "a/an"
+
+### RETURN VALUES
+
+    (string) Appropriate article (the/a/an)
+
+### EXAMPLE
+
+    {{di1}}article("elephant");     // Returns "an"
+    article("bear", 1);      // Returns "the"{{di0}}

--- a/doc/sefun/article_of.help
+++ b/doc/sefun/article_of.help
@@ -1,0 +1,38 @@
+---
+{
+  title: "article_of"
+}
+---
+### NAME
+
+    article_of() - Extracts the leading article from a string if present.
+
+### SYNOPSIS
+
+    string article_of( string str );
+
+### DESCRIPTION
+
+    Extracts the leading article from a string if present.
+
+    Identifies and returns any article ("the", "a", or "an") that appears at
+    the beginning of the provided string.
+
+### PARAMETERS
+
+    str  (string)
+         The string to extract an article from
+
+### RETURN VALUES
+
+    (string) The extracted article or empty string if none found
+
+### ERRORS
+
+    If str is not a string or is empty
+
+### EXAMPLE
+
+    {{di1}}article_of("the book");  // Returns "the"
+    article_of("an apple");  // Returns "an"
+    article_of("bear");      // Returns ""{{di0}}

--- a/doc/sefun/as_directory.help
+++ b/doc/sefun/as_directory.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "as_directory"
+}
+---
+### NAME
+
+    as_directory() - Builds a directory entry mapping for a single path.
+
+### SYNOPSIS
+
+    mapping as_directory( string str );
+
+### DESCRIPTION
+
+    Builds a directory entry mapping for a single path.
+
+    Splits the bare name into base and extension and pairs it with the full
+    path and access time pulled from get_dir(). Used by read_directory() to
+    describe subdirectories and by recursive_delete() to seed its walk.
+
+### PARAMETERS
+
+    str  (string)
+         Path to an existing directory
+
+### RETURN VALUES
+
+    (mapping) ([ "name", "base", "ext", "path", "directory" ]), or 0 if the
+    path cannot be read

--- a/doc/sefun/as_file.help
+++ b/doc/sefun/as_file.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "as_file"
+}
+---
+### NAME
+
+    as_file() - Builds a file entry mapping for a single path.
+
+### SYNOPSIS
+
+    mapping as_file( string str );
+
+### DESCRIPTION
+
+    Builds a file entry mapping for a single path.
+
+    Splits the bare name into base and extension and pairs it with the full
+    path, size, and access time pulled from get_dir(). Used by
+    read_directory() to describe files.
+
+### PARAMETERS
+
+    str  (string)
+         Path to an existing file
+
+### RETURN VALUES
+
+    (mapping) ([ "name", "base", "ext", "path", "file" ]), or 0 if the path
+    cannot be read

--- a/doc/sefun/assemble_call_back.help
+++ b/doc/sefun/assemble_call_back.help
@@ -1,0 +1,45 @@
+---
+{
+  title: "assemble_call_back"
+}
+---
+### NAME
+
+    assemble_call_back() - Creates a callback structure for delayed
+    execution.
+
+### SYNOPSIS
+
+    mixed *assemble_call_back( mixed arg... );
+
+### DESCRIPTION
+
+    Creates a callback structure for delayed execution.
+
+    Builds a standardized callback array that can be stored and executed
+    later. Supports both object methods and function pointers with
+    arguments.
+
+### PARAMETERS
+
+    ob      (object)
+            Target object to call a method on.
+
+    method  (string)
+            Method name to invoke on ob.
+
+    f       (function)
+            Function pointer to invoke.
+
+### RETURN VALUES
+
+    (mixed*) Assembled callback array.
+
+### ERRORS
+
+    If arguments are invalid or method doesn't exist.
+
+### EXAMPLE
+
+    {{di1}}mixed *cb = assemble_call_back(player, "move", "/room/square");
+    mixed *cb = assemble_call_back((: do_something :), arg1, arg2);{{di0}}

--- a/doc/sefun/assert.help
+++ b/doc/sefun/assert.help
@@ -1,0 +1,35 @@
+---
+{
+  title: "assert"
+}
+---
+### NAME
+
+    assert() - Verifies a condition, throwing an error if false.
+
+### SYNOPSIS
+
+    varargs void assert( mixed condition, string message );
+
+### DESCRIPTION
+
+    Verifies a condition, throwing an error if false.
+
+    Enhanced assertion checking with custom error messages and evaluation of
+    complex conditions.
+
+### PARAMETERS
+
+    condition  (mixed)
+               Condition to verify
+
+    message    (string, optional, default: "Assertion failed")
+               Error message if condition fails
+
+### ERRORS
+
+    If statement evaluates to false or null
+
+### EXAMPLE
+
+    {{di1}}assert(hp > 0, "Health cannot be negative");{{di0}}

--- a/doc/sefun/assert_arg.help
+++ b/doc/sefun/assert_arg.help
@@ -1,0 +1,38 @@
+---
+{
+  title: "assert_arg"
+}
+---
+### NAME
+
+    assert_arg() - Verifies a function argument condition.
+
+### SYNOPSIS
+
+    void assert_arg( mixed condition, int arg_num, string message );
+
+### DESCRIPTION
+
+    Verifies a function argument condition.
+
+    Specialized assertion for validating function parameters with numbered
+    argument reference.
+
+### PARAMETERS
+
+    condition  (mixed)
+               Condition to verify
+
+    arg_num    (int)
+               Parameter position number
+
+    message    (string)
+               Error message prefix
+
+### ERRORS
+
+    If condition is false, with formatted argument number
+
+### EXAMPLE
+
+    {{di1}}assert_arg(stringp(name), 1, "Expected string");{{di0}}

--- a/doc/sefun/assure_dir.help
+++ b/doc/sefun/assure_dir.help
@@ -1,0 +1,34 @@
+---
+{
+  title: "assure_dir"
+}
+---
+### NAME
+
+    assure_dir() - Creates a directory and all necessary parent directories.
+
+### SYNOPSIS
+
+    mixed assure_dir( string path );
+
+### DESCRIPTION
+
+    Creates a directory and all necessary parent directories.
+
+    Temporarily assumes privileges of the calling object while creating the
+    directory structure to ensure proper permissions.
+
+### PARAMETERS
+
+    path  (string)
+          Full directory path to create
+
+### RETURN VALUES
+
+    (int) 1 if directory exists/created, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}if(assure_dir("/d/players/" + name + "/letters")) {
+        tell_me("Created mail directory.\n");
+    }{{di0}}

--- a/doc/sefun/assure_file.help
+++ b/doc/sefun/assure_file.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "assure_file"
+}
+---
+### NAME
+
+    assure_file() - Ensures a file's parent directories exist.
+
+### SYNOPSIS
+
+    mixed assure_file( string file );
+
+### DESCRIPTION
+
+    Ensures a file's parent directories exist.
+
+    Creates any missing directories in the path to the specified file.
+
+### PARAMETERS
+
+    file  (string)
+          Path to the target file
+
+### RETURN VALUES
+
+    (int|string) 1 on success, error message on failure
+
+### EXAMPLE
+
+    {{di1}}assure_file("/log/system/startup.log");{{di0}}

--- a/doc/sefun/assure_object_data_dir.help
+++ b/doc/sefun/assure_object_data_dir.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "assure_object_data_dir"
+}
+---
+### NAME
+
+    assure_object_data_dir() - Ensures the data directory for the specified
+    object exists, creating it if necessary.
+
+### SYNOPSIS
+
+    string assure_object_data_dir( object ob );
+
+### DESCRIPTION
+
+    Ensures the data directory for the specified object exists, creating it
+    if necessary.
+
+### PARAMETERS
+
+    ob  (object)
+        The object to ensure the data directory for.
+
+### RETURN VALUES
+
+    (string) The data directory path for the object, or 0 if creation
+    failed.

--- a/doc/sefun/base64_decode.help
+++ b/doc/sefun/base64_decode.help
@@ -1,0 +1,38 @@
+---
+{
+  title: "base64_decode"
+}
+---
+### NAME
+
+    base64_decode() - Decodes a Base64 encoded string.
+
+### SYNOPSIS
+
+    string base64_decode( string source );
+
+### DESCRIPTION
+
+    Decodes a Base64 encoded string.
+
+    Converts a Base64 encoded string back to its original form. Handles
+    padding and whitespace in the input string. The result is decoded as
+    UTF-8.
+
+### PARAMETERS
+
+    source  (string)
+            Base64 encoded string to decode
+
+### RETURN VALUES
+
+    (string) Decoded string in UTF-8 encoding
+
+### ERRORS
+
+    If source is null/empty or contains invalid Base64 characters
+
+### EXAMPLE
+
+    {{di1}}string decoded = base64_decode("SGVsbG8gV29ybGQh");
+    // Returns: "Hello World!"{{di0}}

--- a/doc/sefun/base64_encode.help
+++ b/doc/sefun/base64_encode.help
@@ -1,0 +1,38 @@
+---
+{
+  title: "base64_encode"
+}
+---
+### NAME
+
+    base64_encode() - Encodes data into Base64 format.
+
+### SYNOPSIS
+
+    string base64_encode( mixed source_str );
+
+### DESCRIPTION
+
+    Encodes data into Base64 format.
+
+    Takes either a string or buffer input and converts it to a Base64
+    encoded string. When encoding strings, they are first converted to UTF-8
+    buffers.
+
+### PARAMETERS
+
+    source_str  (string|buffer)
+                Data to encode
+
+### RETURN VALUES
+
+    (string) Base64 encoded string
+
+### ERRORS
+
+    If source_str is invalid type or empty
+
+### EXAMPLE
+
+    {{di1}}string encoded = base64_encode("Hello World!");
+    // Returns: "SGVsbG8gV29ybGQh"{{di0}}

--- a/doc/sefun/baselib_name.help
+++ b/doc/sefun/baselib_name.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "baselib_name"
+}
+---
+### NAME
+
+    baselib_name() - Returns the name of the base library.
+
+### SYNOPSIS
+
+    string baselib_name( void );
+
+### DESCRIPTION
+
+    Returns the name of the base library.
+
+### RETURN VALUES
+
+    (string) The base library name.

--- a/doc/sefun/baselib_version.help
+++ b/doc/sefun/baselib_version.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "baselib_version"
+}
+---
+### NAME
+
+    baselib_version() - Returns the version of the base library.
+
+### SYNOPSIS
+
+    string baselib_version( void );
+
+### DESCRIPTION
+
+    Returns the version of the base library.
+
+### RETURN VALUES
+
+    (string) The base library version.

--- a/doc/sefun/between.help
+++ b/doc/sefun/between.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "between"
+}
+---
+### NAME
+
+    between() - Checks if a value is between a specified range, exclusive.
+
+### SYNOPSIS
+
+    int between( float val, float min, float max );
+
+### DESCRIPTION
+
+    Checks if a value is between a specified range, exclusive.
+
+### PARAMETERS
+
+    val  (float)
+         The value to check.
+
+    min  (float)
+         The minimum value (exclusive).
+
+    max  (float)
+         The maximum value (exclusive).
+
+### RETURN VALUES
+
+    (int) 1 if the value is between the range (exclusive), 0 otherwise.

--- a/doc/sefun/body_d.help
+++ b/doc/sefun/body_d.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "body_d"
+}
+---
+### NAME
+
+    body_d() - Returns the body daemon object, loading it if necessary.
+
+### SYNOPSIS
+
+    object body_d( ) { return load_object(BODY_D );
+
+### DESCRIPTION
+
+    Returns the body daemon object, loading it if necessary.
+
+### RETURN VALUES
+
+    (object) The body daemon object

--- a/doc/sefun/boot_number.help
+++ b/doc/sefun/boot_number.help
@@ -1,0 +1,22 @@
+---
+{
+  title: "boot_number"
+}
+---
+### NAME
+
+    boot_number() - Returns the boot number of the MUD. This is the number
+    of times the MUD has been booted.
+
+### SYNOPSIS
+
+    int boot_number( void );
+
+### DESCRIPTION
+
+    Returns the boot number of the MUD. This is the number of times the MUD
+    has been booted.
+
+### RETURN VALUES
+
+    (int) The current boot number.

--- a/doc/sefun/call_back.help
+++ b/doc/sefun/call_back.help
@@ -1,0 +1,37 @@
+---
+{
+  title: "call_back"
+}
+---
+### NAME
+
+    call_back() - Executes a previously assembled callback.
+
+### SYNOPSIS
+
+    mixed call_back( mixed cb, mixed new_arg... );
+
+### DESCRIPTION
+
+    Executes a previously assembled callback.
+
+    Takes a callback structure created by assemble_call_back() and executes
+    it, optionally with new arguments prepended to the stored ones.
+
+### PARAMETERS
+
+    cb  (mixed*)
+        Callback array from assemble_call_back()
+
+### RETURN VALUES
+
+    (mixed) Result from callback execution
+
+### ERRORS
+
+    If callback structure is invalid
+
+### EXAMPLE
+
+    {{di1}}mixed *cb = assemble_call_back(player, "tell", "Hello!");
+    call_back(cb);  // Calls player->tell("Hello!"){{di0}}

--- a/doc/sefun/call_if.help
+++ b/doc/sefun/call_if.help
@@ -1,0 +1,42 @@
+---
+{
+  title: "call_if"
+}
+---
+### NAME
+
+    call_if() - Safely calls a function on an object if it exists.
+
+### SYNOPSIS
+
+    varargs mixed call_if( mixed ob, string func, mixed arg... );
+
+### DESCRIPTION
+
+    Safely calls a function on an object if it exists.
+
+    Attempts to call the named function, returning null if function doesn't
+    exist instead of throwing an error.
+
+    IMPORTANT: function_exists() requires that the needle function have
+    public visibility.
+
+### PARAMETERS
+
+    ob    (object|string)
+          Target object or filename
+
+    func  (string)
+          Function name to call
+
+### RETURN VALUES
+
+    (mixed) Function result or null if function doesn't exist
+
+### ERRORS
+
+    If ob or func arguments are invalid types
+
+### EXAMPLE
+
+    {{di1}}call_if(user, "receive_message", "Hello");{{di0}}

--- a/doc/sefun/call_trace.help
+++ b/doc/sefun/call_trace.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "call_trace"
+}
+---
+### NAME
+
+    call_trace() - Generates a formatted call stack trace.
+
+### SYNOPSIS
+
+    varargs string call_trace( int colour );
+
+### DESCRIPTION
+
+    Generates a formatted call stack trace.
+
+    Creates a detailed stack trace with object paths, line numbers, and
+    function names. Each frame is color-coded when colors are enabled.
+
+### PARAMETERS
+
+    colour  (int, optional, default: 0)
+            Whether to include ANSI color codes
+
+### RETURN VALUES
+
+    (string) Formatted call stack trace
+
+### EXAMPLE
+
+    {{di1}}debug("Error occurred:\n" + call_trace(1));{{di0}}

--- a/doc/sefun/caller_is.help
+++ b/doc/sefun/caller_is.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "caller_is"
+}
+---
+### NAME
+
+    caller_is() - This simul_efun will return 1 if the caller of the current
+    operation is the specified object, or if the caller is the object with
+    the specified file name.
+
+### SYNOPSIS
+
+    int caller_is( mixed ob );
+
+### DESCRIPTION
+
+    This simul_efun will return 1 if the caller of the current operation is
+    the specified object, or if the caller is the object with the specified
+    file name.
+
+    *NOTE* This simul_efun will not succeed when called from other functions
+    in the simul_efun object, as previous_object() does not count the object
+    itself in its call list.
+
+### PARAMETERS
+
+    ob  (mixed)
+        The object or file name to compare the caller to.
+
+### RETURN VALUES
+
+    (int) 1 if the caller is the specified object, 0 otherwise.

--- a/doc/sefun/cap_significant_words.help
+++ b/doc/sefun/cap_significant_words.help
@@ -1,0 +1,38 @@
+---
+{
+  title: "cap_significant_words"
+}
+---
+### NAME
+
+    cap_significant_words() - Capitalizes significant words in a string,
+    treating it as a title.
+
+### SYNOPSIS
+
+    varargs string cap_significant_words( string str, int title );
+
+### DESCRIPTION
+
+    Capitalizes significant words in a string, treating it as a title.
+
+    Follows standard English title capitalization rules where major words
+    are capitalized but articles, conjunctions, and prepositions are not,
+    unless they start the title.
+
+### PARAMETERS
+
+    str    (string)
+           Text to capitalize
+
+    title  (int, optional, default: 0)
+           Whether to force capitalize first word
+
+### RETURN VALUES
+
+    (string) Text with appropriate words capitalized
+
+### EXAMPLE
+
+    {{di1}}cap_significant_words("the tale of two cities", 1);
+    // Returns "The Tale of Two Cities"{{di0}}

--- a/doc/sefun/cap_words.help
+++ b/doc/sefun/cap_words.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "cap_words"
+}
+---
+### NAME
+
+    cap_words() - Capitalizes the first letter of each word in a string.
+
+### SYNOPSIS
+
+    string cap_words( string str );
+
+### DESCRIPTION
+
+    Capitalizes the first letter of each word in a string.
+
+### PARAMETERS
+
+    str  (string)
+         Input string to capitalize
+
+### RETURN VALUES
+
+    (string) String with each word capitalized
+
+### EXAMPLE
+
+    {{di1}}cap_words("hello world");  // Returns "Hello World"{{di0}}

--- a/doc/sefun/cfile_exists.help
+++ b/doc/sefun/cfile_exists.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "cfile_exists"
+}
+---
+### NAME
+
+    cfile_exists() - Checks if a LPC source file exists.
+
+### SYNOPSIS
+
+    int cfile_exists( string file );
+
+### DESCRIPTION
+
+    Checks if a LPC source file exists.
+
+    Automatically appends ".c" to the filename before checking.
+
+### PARAMETERS
+
+    file  (string)
+          Base path of LPC file without .c extension
+
+### RETURN VALUES
+
+    (int) 1 if source file exists, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}if(cfile_exists("/cmds/wiz/update")) {
+        compile_object("/cmds/wiz/update");
+    }{{di0}}

--- a/doc/sefun/chop.help
+++ b/doc/sefun/chop.help
@@ -1,0 +1,35 @@
+---
+{
+  title: "chop"
+}
+---
+### NAME
+
+    chop() - Chops a substring off the end or beginning of another string if
+    it is present. If the substring is not present, the original string is
+    returned.
+
+### SYNOPSIS
+
+    varargs string chop( string str, string sub, int dir );
+
+### DESCRIPTION
+
+    Chops a substring off the end or beginning of another string if it is
+    present. If the substring is not present, the original string is
+    returned.
+
+### PARAMETERS
+
+    str  (string)
+         The string to chop from.
+
+    sub  (string)
+         The substring to chop.
+
+    dir  (int, optional, default: -1)
+         The direction to chop: 1 for left, -1 for right.
+
+### RETURN VALUES
+
+    (string) The string with the substring chopped off if it was present.

--- a/doc/sefun/clamp.help
+++ b/doc/sefun/clamp.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "clamp"
+}
+---
+### NAME
+
+    clamp() - Ensures a value is within a specified range.
+
+### SYNOPSIS
+
+    float clamp( float val, float min, float max );
+
+### DESCRIPTION
+
+    Ensures a value is within a specified range.
+
+### PARAMETERS
+
+    min  (float)
+         The minimum value.
+
+    max  (float)
+         The maximum value.
+
+    val  (float)
+         The value to check.
+
+### RETURN VALUES
+
+    (float) The value, constrained within the range of `min` to `max`.

--- a/doc/sefun/clamped.help
+++ b/doc/sefun/clamped.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "clamped"
+}
+---
+### NAME
+
+    clamped() - Checks if a value is within a specified range, inclusive.
+
+### SYNOPSIS
+
+    int clamped( float val, float min, float max );
+
+### DESCRIPTION
+
+    Checks if a value is within a specified range, inclusive.
+
+### PARAMETERS
+
+    val  (float)
+         The value to check.
+
+    min  (float)
+         The minimum value.
+
+    max  (float)
+         The maximum value.
+
+### RETURN VALUES
+
+    (int) 1 if the value is within the range (inclusive), 0 otherwise.

--- a/doc/sefun/clones.help
+++ b/doc/sefun/clones.help
@@ -1,0 +1,34 @@
+---
+{
+  title: "clones"
+}
+---
+### NAME
+
+    clones() - Retrieves all clones of the specified file in the game. If
+    the file is an object, it will retrieve all clones using the object's
+    base name. If env_only is set to 1, the simul_efun will only return
+    clones that have an environment.
+
+### SYNOPSIS
+
+    varargs object *clones( mixed file, int env_only );
+
+### DESCRIPTION
+
+    Retrieves all clones of the specified file in the game. If the file is
+    an object, it will retrieve all clones using the object's base name. If
+    env_only is set to 1, the simul_efun will only return clones that have
+    an environment.
+
+### PARAMETERS
+
+    file      (object|string)
+              The file or object to find clones of.
+
+    env_only  (int, optional)
+              Whether to only return clones that have an environment.
+
+### RETURN VALUES
+
+    (object*) An array of objects that are clones of the specified file.

--- a/doc/sefun/colour.help
+++ b/doc/sefun/colour.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "colour"
+}
+---
+### NAME
+
+    colour() - Resolves colour codes in a string to ANSI escape sequences.
+    Inverse of no_ansi(). Use when output bypasses the body messaging
+    pipeline (printf, debug_message, etc.).
+
+### SYNOPSIS
+
+    string colour( string str );
+
+### DESCRIPTION
+
+    Resolves colour codes in a string to ANSI escape sequences. Inverse of
+    no_ansi(). Use when output bypasses the body messaging pipeline (printf,
+    debug_message, etc.).
+
+### PARAMETERS
+
+    str  (string)
+         The string with colour codes.
+
+### RETURN VALUES
+
+    (string) The string with colour codes replaced by ANSI escapes.

--- a/doc/sefun/colourp.help
+++ b/doc/sefun/colourp.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "colourp"
+}
+---
+### NAME
+
+    colourp() - Returns 1 if the string contains colour codes, 0 if not.
+
+### SYNOPSIS
+
+    int colourp( string str );
+
+### DESCRIPTION
+
+    Returns 1 if the string contains colour codes, 0 if not.
+
+### PARAMETERS
+
+    str  (string)
+         The string to check.
+
+### RETURN VALUES
+
+    (int) 1 if the string contains colour codes, otherwise 0.

--- a/doc/sefun/consolidate.help
+++ b/doc/sefun/consolidate.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "consolidate"
+}
+---
+### NAME
+
+    consolidate() - Returns a consolidated string for a given quantity and
+    item description, handling pluralization and special cases.
+
+### SYNOPSIS
+
+    string consolidate( int x, string str );
+
+### DESCRIPTION
+
+    Returns a consolidated string for a given quantity and item description,
+    handling pluralization and special cases.
+
+### PARAMETERS
+
+    x    (int)
+         The quantity of items.
+
+    str  (string)
+         The description of the item(s).
+
+### RETURN VALUES
+
+    (string) The consolidated string.

--- a/doc/sefun/ctime.help
+++ b/doc/sefun/ctime.help
@@ -1,0 +1,21 @@
+---
+{
+  title: "ctime"
+}
+---
+### NAME
+
+    ctime()
+
+### SYNOPSIS
+
+    varargs string ctime( int x );
+
+### PARAMETERS
+
+    x  (int, optional)
+       The Unix timestamp to format; defaults to now
+
+### RETURN VALUES
+
+    (string) The formatted date-time string

--- a/doc/sefun/data_del.help
+++ b/doc/sefun/data_del.help
@@ -1,0 +1,37 @@
+---
+{
+  title: "data_del"
+}
+---
+### NAME
+
+    data_del() - Removes a key-value pair from a data file.
+
+### SYNOPSIS
+
+    int data_del( string file, string key );
+
+### DESCRIPTION
+
+    Removes a key-value pair from a data file.
+
+    Deletes the entire line containing the specified key. If the file
+    becomes empty after deletion, the file itself is removed.
+
+### PARAMETERS
+
+    file  (string)
+          Path to the data file
+
+    key   (string)
+          Key to remove
+
+### RETURN VALUES
+
+    (int) 1 if key was found and deleted, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}if(data_del("/save/player.dat", "temporary_buff")) {
+        tell_me("Buff removed.\n");
+    }{{di0}}

--- a/doc/sefun/data_inc.help
+++ b/doc/sefun/data_inc.help
@@ -1,0 +1,42 @@
+---
+{
+  title: "data_inc"
+}
+---
+### NAME
+
+    data_inc() - Increments a numeric value in a data file.
+
+### SYNOPSIS
+
+    varargs int data_inc( string file, string key, int inc );
+
+### DESCRIPTION
+
+    Increments a numeric value in a data file.
+
+    If the key doesn't exist, it's created with the increment value. If it
+    exists, its value is increased by the specified amount.
+
+    Defaults to 1 if inc is not supplied.
+
+### PARAMETERS
+
+    file  (string)
+          Path to the data file
+
+    key   (string)
+          Key of value to increment
+
+    inc   (int, optional, default: 1)
+          Amount to increment by
+
+### RETURN VALUES
+
+    (int) New value after incrementing
+
+### EXAMPLE
+
+    {{di1}}// Increment kill count
+    int kills = data_inc("/save/stats.dat", "monster_kills", 1);
+    printf("Total kills: %d\n", kills);{{di0}}

--- a/doc/sefun/data_value.help
+++ b/doc/sefun/data_value.help
@@ -1,0 +1,41 @@
+---
+{
+  title: "data_value"
+}
+---
+### NAME
+
+    data_value() - Retrieves a value from a data file by key.
+
+### SYNOPSIS
+
+    varargs mixed data_value( string file, string key, mixed def );
+
+### DESCRIPTION
+
+    Retrieves a value from a data file by key.
+
+    Reads the specified file and returns the value(s) associated with the
+    key. Multiple values are returned as an array.
+
+### PARAMETERS
+
+    file  (string)
+          Path to the data file
+
+    key   (string)
+          Key to look up
+
+    def   (mixed, optional)
+          Default value if key not found
+
+### RETURN VALUES
+
+    (mixed) Value(s) associated with key or default if not found
+
+### EXAMPLE
+
+    {{di1}}// Single value
+    string name = data_value("/save/player.dat", "name", "Unknown");
+    // Multiple values
+    mixed *stats = data_value("/save/player.dat", "stats", ({10, 10, 10}));{{di0}}

--- a/doc/sefun/data_write.help
+++ b/doc/sefun/data_write.help
@@ -1,0 +1,37 @@
+---
+{
+  title: "data_write"
+}
+---
+### NAME
+
+    data_write() - Writes one or more values to a data file under a key.
+
+### SYNOPSIS
+
+    varargs void data_write( string file, string key, mixed data... );
+
+### DESCRIPTION
+
+    Writes one or more values to a data file under a key.
+
+    If the key exists, its value is updated. If not, a new entry is created.
+    Multiple values are stored as a single entry.
+
+### PARAMETERS
+
+    file  (string)
+          Path to the data file
+
+    key   (string)
+          Key to write under
+
+    data  (mixed)
+          Value(s) to store
+
+### EXAMPLE
+
+    {{di1}}// Store single value
+    data_write("/save/player.dat", "name", "Bob");
+    // Store multiple values
+    data_write("/save/player.dat", "stats", 10, 12, 15);{{di0}}

--- a/doc/sefun/debug.help
+++ b/doc/sefun/debug.help
@@ -1,0 +1,27 @@
+---
+{
+  title: "debug"
+}
+---
+### NAME
+
+    debug() - Logs a debug message, optionally formatted with arguments.
+
+### SYNOPSIS
+
+    varargs void debug( mixed str, mixed args... );
+
+### DESCRIPTION
+
+    Logs a debug message, optionally formatted with arguments.
+
+    If the first argument is not a string, it will be printed using %O
+    notation using sprintf.
+
+    If the first argument is a string, it will be printed according to
+    sprintf, using any following additional arguments as substitutions.
+
+### PARAMETERS
+
+    str  (string)
+         The debug message.

--- a/doc/sefun/debug_message.help
+++ b/doc/sefun/debug_message.help
@@ -1,0 +1,17 @@
+---
+{
+  title: "debug_message"
+}
+---
+### NAME
+
+    debug_message()
+
+### SYNOPSIS
+
+    void debug_message( string str );
+
+### PARAMETERS
+
+    str  (string)
+         The debug message to output

--- a/doc/sefun/delay_act.help
+++ b/doc/sefun/delay_act.help
@@ -1,0 +1,38 @@
+---
+{
+  title: "delay_act"
+}
+---
+### NAME
+
+    delay_act() - Schedules an action with delayed execution.
+
+### SYNOPSIS
+
+    varargs int delay_act( string act, float delay, mixed *cb );
+
+### DESCRIPTION
+
+    Schedules an action with delayed execution.
+
+    Creates a delayed action on the current body object, with optional
+    callback on completion.
+
+### PARAMETERS
+
+    act    (string)
+           Action description
+
+    delay  (float)
+           Time to wait before execution
+
+    cb     (mixed*, optional)
+           Callback to execute after delay
+
+### RETURN VALUES
+
+    (int) Action ID or 0 if already acting
+
+### EXAMPLE
+
+    {{di1}}delay_act("casting", 3.0, assemble_call_back(this_object(), "cast_spell"));{{di0}}

--- a/doc/sefun/devp.help
+++ b/doc/sefun/devp.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "devp"
+}
+---
+### NAME
+
+    devp() - Checks if a user has developer privileges.
+
+### SYNOPSIS
+
+    varargs int devp( mixed user );
+
+### DESCRIPTION
+
+    Checks if a user has developer privileges.
+
+### PARAMETERS
+
+    user  (mixed)
+          The user to check, either as a username string or an object.
+          Defaults to the previous object.
+
+### RETURN VALUES
+
+    (int) 1 if the user has developer privileges, otherwise 0.

--- a/doc/sefun/dim_exponential_decay.help
+++ b/doc/sefun/dim_exponential_decay.help
@@ -1,0 +1,34 @@
+---
+{
+  title: "dim_exponential_decay"
+}
+---
+### NAME
+
+    dim_exponential_decay() - Exponential-decay diminishing return on `val`,
+    scaled by `scale`. Computes `scale * (1 - e^(-val/scale))`. Output
+    asymptotically approaches `scale` as `val` grows, and equals roughly
+    `0.632 * scale` (i.e. `1 - 1/e`) when `val == scale`.
+
+### SYNOPSIS
+
+    float dim_exponential_decay( mixed val, mixed scale );
+
+### DESCRIPTION
+
+    Exponential-decay diminishing return on `val`, scaled by `scale`.
+    Computes `scale * (1 - e^(-val/scale))`. Output asymptotically
+    approaches `scale` as `val` grows, and equals roughly `0.632 * scale`
+    (i.e. `1 - 1/e`) when `val == scale`.
+
+### PARAMETERS
+
+    val    (mixed)
+           The input value.
+
+    scale  (mixed)
+           The scale factor and asymptotic ceiling.
+
+### RETURN VALUES
+
+    (float) The diminished value, bounded by `scale`.

--- a/doc/sefun/dim_hyperbolic.help
+++ b/doc/sefun/dim_hyperbolic.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "dim_hyperbolic"
+}
+---
+### NAME
+
+    dim_hyperbolic() - Hyperbolic (Michaelis-Menten) diminishing return on
+    `val`, scaled by `scale`. Output asymptotically approaches `scale` as
+    `val` grows without bound, and equals `scale / 2` when `val == scale`.
+
+### SYNOPSIS
+
+    float dim_hyperbolic( mixed val, mixed scale );
+
+### DESCRIPTION
+
+    Hyperbolic (Michaelis-Menten) diminishing return on `val`, scaled by
+    `scale`. Output asymptotically approaches `scale` as `val` grows without
+    bound, and equals `scale / 2` when `val == scale`.
+
+### PARAMETERS
+
+    val    (mixed)
+           The input value.
+
+    scale  (mixed)
+           The scale factor and asymptotic ceiling.
+
+### RETURN VALUES
+
+    (float) The diminished value, bounded by `scale`.

--- a/doc/sefun/dim_logarithmic.help
+++ b/doc/sefun/dim_logarithmic.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "dim_logarithmic"
+}
+---
+### NAME
+
+    dim_logarithmic() - Logarithmic diminishing return on `val`, scaled by
+    `scale`. Computes `scale * ln(1 + val/scale)`. Output is 0 at `val == 0`
+    and grows ever more slowly as `val` increases. Unbounded above.
+
+### SYNOPSIS
+
+    float dim_logarithmic( mixed val, mixed scale );
+
+### DESCRIPTION
+
+    Logarithmic diminishing return on `val`, scaled by `scale`. Computes
+    `scale * ln(1 + val/scale)`. Output is 0 at `val == 0` and grows ever
+    more slowly as `val` increases. Unbounded above.
+
+### PARAMETERS
+
+    val    (mixed)
+           The input value.
+
+    scale  (mixed)
+           The scale factor.
+
+### RETURN VALUES
+
+    (float) The diminished value.

--- a/doc/sefun/dim_sigmoid.help
+++ b/doc/sefun/dim_sigmoid.help
@@ -1,0 +1,36 @@
+---
+{
+  title: "dim_sigmoid"
+}
+---
+### NAME
+
+    dim_sigmoid() - Sigmoid (zero-anchored logistic) diminishing return on
+    `val`, scaled by `scale`. Computes `scale * (2/(1 + e^-(val/scale)) -
+    1)`, producing an S-shaped curve that is 0 at `val == 0`, equals roughly
+    `0.462 * scale` when `val == scale`, and asymptotically approaches
+    `scale` as `val` grows.
+
+### SYNOPSIS
+
+    varargs float dim_sigmoid( mixed val, mixed scale, mixed k );
+
+### DESCRIPTION
+
+    Sigmoid (zero-anchored logistic) diminishing return on `val`, scaled by
+    `scale`. Computes `scale * (2/(1 + e^-(val/scale)) - 1)`, producing an
+    S-shaped curve that is 0 at `val == 0`, equals roughly `0.462 * scale`
+    when `val == scale`, and asymptotically approaches `scale` as `val`
+    grows.
+
+### PARAMETERS
+
+    val    (mixed)
+           The input value.
+
+    scale  (mixed)
+           The scale factor and asymptotic ceiling.
+
+### RETURN VALUES
+
+    (float) The diminished value, bounded by `scale`.

--- a/doc/sefun/dim_square_root.help
+++ b/doc/sefun/dim_square_root.help
@@ -1,0 +1,34 @@
+---
+{
+  title: "dim_square_root"
+}
+---
+### NAME
+
+    dim_square_root() - Square-root diminishing return on `val`, scaled by
+    `scale`. Output grows as the square root of the input ratio: doubling
+    `val` multiplies the output by sqrt(2). Output equals `scale` when `val
+    == scale`. Unbounded above.
+
+### SYNOPSIS
+
+    float dim_square_root( mixed val, mixed scale );
+
+### DESCRIPTION
+
+    Square-root diminishing return on `val`, scaled by `scale`. Output grows
+    as the square root of the input ratio: doubling `val` multiplies the
+    output by sqrt(2). Output equals `scale` when `val == scale`. Unbounded
+    above.
+
+### PARAMETERS
+
+    val    (mixed)
+           The input value.
+
+    scale  (mixed)
+           The scale factor.
+
+### RETURN VALUES
+
+    (float) The diminished value.

--- a/doc/sefun/dir_file.help
+++ b/doc/sefun/dir_file.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "dir_file"
+}
+---
+### NAME
+
+    dir_file() - Splits path into directory and filename components.
+
+### SYNOPSIS
+
+    string *dir_file( mixed path );
+
+### DESCRIPTION
+
+    Splits path into directory and filename components.
+
+### PARAMETERS
+
+    path  (string|object)
+          Path or object to analyze
+
+### RETURN VALUES
+
+    (({ string, string )
+
+### EXAMPLE
+
+    {{di1}}string *parts = dir_file("/d/town/square.c");
+    // Returns ({ "/d/town/", "square.c" }){{di0}}

--- a/doc/sefun/directory_exists.help
+++ b/doc/sefun/directory_exists.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "directory_exists"
+}
+---
+### NAME
+
+    directory_exists() - Checks if a directory exists in the filesystem.
+
+### SYNOPSIS
+
+    int directory_exists( string dirname );
+
+### DESCRIPTION
+
+    Checks if a directory exists in the filesystem.
+
+### PARAMETERS
+
+    dirname  (string)
+             Path of directory to check
+
+### RETURN VALUES
+
+    (int) 1 if directory exists, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}if(directory_exists("/d/wizards/" + name)) {
+        tell_me("Wizard directory exists.\n");
+    }{{di0}}

--- a/doc/sefun/distinct_array.help
+++ b/doc/sefun/distinct_array.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "distinct_array"
+}
+---
+### NAME
+
+    distinct_array() - Returns a new array containing the distinct elements
+    of the input array.
+
+### SYNOPSIS
+
+    varargs mixed *distinct_array( mixed *arr, int same_order );
+
+### DESCRIPTION
+
+    Returns a new array containing the distinct elements of the input array.
+
+### PARAMETERS
+
+    arr  (mixed*)
+         An array of mixed types.
+
+### RETURN VALUES
+
+    (mixed*) A new array with distinct elements from the input array.

--- a/doc/sefun/doc_dir.help
+++ b/doc/sefun/doc_dir.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "doc_dir"
+}
+---
+### NAME
+
+    doc_dir() - Returns the directory where documentation files are stored.
+
+### SYNOPSIS
+
+    string doc_dir( void );
+
+### DESCRIPTION
+
+    Returns the directory where documentation files are stored.
+
+### RETURN VALUES
+
+    (string) The documentation directory.

--- a/doc/sefun/dot_walk.help
+++ b/doc/sefun/dot_walk.help
@@ -1,0 +1,52 @@
+---
+{
+  title: "dot_walk"
+}
+---
+### NAME
+
+    dot_walk() - Walks a dotted path through nested mappings and returns the
+    value at the destination, or `undefined` if any intermediate hop is
+    missing or not a mapping.
+
+### SYNOPSIS
+
+    mixed dot_walk( mapping map, string path );
+
+### DESCRIPTION
+
+    Walks a dotted path through nested mappings and returns the value at the
+    destination, or `undefined` if any intermediate hop is missing or not a
+    mapping.
+
+    The path is split on `.`; each segment is looked up in the current
+    mapping. The final segment's value is returned as-is (it may itself be a
+    mapping). Intermediate non-mapping values abort the walk and yield
+    `undefined`.
+
+### PARAMETERS
+
+    map   (mapping)
+          The root mapping to walk.
+
+    path  (string)
+          Dot-separated path to follow (e.g. `"player.stats.hp"`).
+
+### RETURN VALUES
+
+    (mixed) The value at `path`, or `undefined` if the path can't be fully
+    resolved.
+
+### EXAMPLE
+
+    {{di1}}mapping data = ([
+      "player": ([
+        "name": "Alice",
+        "stats": ([ "hp": 100, "mp": 40 ]),
+      ]),
+    ]);
+
+    dot_walk(data, "player.name");      // "Alice"
+    dot_walk(data, "player.stats.hp");  // 100
+    dot_walk(data, "player.stats");     // the nested mapping
+    dot_walk(data, "player.gear.head"); // undefined (no "gear" key){{di0}}

--- a/doc/sefun/driver_version.help
+++ b/doc/sefun/driver_version.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "driver_version"
+}
+---
+### NAME
+
+    driver_version() - Returns the version of the MUD driver.
+
+### SYNOPSIS
+
+    string driver_version( void );
+
+### DESCRIPTION
+
+    Returns the version of the MUD driver.
+
+### RETURN VALUES
+
+    (string) The driver version.

--- a/doc/sefun/dump_socket_status.help
+++ b/doc/sefun/dump_socket_status.help
@@ -1,0 +1,21 @@
+---
+{
+  title: "dump_socket_status"
+}
+---
+### NAME
+
+    dump_socket_status() - Returns a formatted string displaying the status
+    of all sockets.
+
+### SYNOPSIS
+
+    string dump_socket_status( void );
+
+### DESCRIPTION
+
+    Returns a formatted string displaying the status of all sockets.
+
+### RETURN VALUES
+
+    (string) The formatted socket status information.

--- a/doc/sefun/each.help
+++ b/doc/sefun/each.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "each"
+}
+---
+### NAME
+
+    each() - Executes a function for each element in an array or mapping.
+
+### SYNOPSIS
+
+    varargs void each( mixed src, function fun, mixed extra... );
+
+### DESCRIPTION
+
+    Executes a function for each element in an array or mapping.
+
+    For arrays, the function is called with (element, index, array,
+    ...extra). For mappings, the function is called with (key, value,
+    mapping, ...extra).
+
+### PARAMETERS
+
+    src    (mixed)
+           Array or mapping to iterate over
+
+    fun    (function)
+           Function called per element/pair (see above)
+
+    extra  (mixed, optional)
+           Additional arguments passed to the callback starting at $4

--- a/doc/sefun/eject.help
+++ b/doc/sefun/eject.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "eject"
+}
+---
+### NAME
+
+    eject() - Removes and returns an element at a specific index.
+
+### SYNOPSIS
+
+    mixed eject( mixed ref *arr, int index );
+
+### DESCRIPTION
+
+    Removes and returns an element at a specific index.
+
+### PARAMETERS
+
+    arr    (mixed*)
+           Array to modify
+
+    index  (int)
+           Index of element to remove
+
+### RETURN VALUES
+
+    (mixed) The removed element

--- a/doc/sefun/eject_value.help
+++ b/doc/sefun/eject_value.help
@@ -1,0 +1,44 @@
+---
+{
+  title: "eject_value"
+}
+---
+### NAME
+
+    eject_value() - Removes the first occurrence of a value from an array.
+
+### SYNOPSIS
+
+    varargs int eject_value( mixed ref *arr, mixed value );
+
+### DESCRIPTION
+
+    Removes the first occurrence of a value from an array.
+
+    This function finds and removes the first occurrence of a specified
+    value from an array. If the value is found, it is removed and the
+    function returns the index where it was found. If the value is not
+    found, the array remains unchanged and -1 is returned.
+
+### PARAMETERS
+
+    arr    (mixed)
+           The array to modify.
+
+    value  (mixed)
+           The value to remove from the array.
+
+### RETURN VALUES
+
+    (int) The index where the value was found and removed, or -1 if not
+    found.
+
+### ERRORS
+
+    If the first argument is not an array
+
+### EXAMPLE
+
+    {{di1}}mixed *fruits = ({"apple", "banana", "orange"});
+    int removed_at = eject_value(ref fruits, "banana"); // Returns 1, fruits becomes ({"apple", "orange"})
+    int not_found = eject_value(ref fruits, "grape"); // Returns -1, fruits remains unchanged{{di0}}

--- a/doc/sefun/eject_value_all.help
+++ b/doc/sefun/eject_value_all.help
@@ -1,0 +1,48 @@
+---
+{
+  title: "eject_value_all"
+}
+---
+### NAME
+
+    eject_value_all() - Removes all occurrences of a value from an array.
+
+### SYNOPSIS
+
+    varargs int eject_value_all( mixed ref *arr, mixed value );
+
+### DESCRIPTION
+
+    Removes all occurrences of a value from an array.
+
+    This function finds and removes all occurrences of a specified value
+    from an array. It continues removing until no more instances of the
+    value are found. The function returns the total number of elements that
+    were removed.
+
+### PARAMETERS
+
+    arr    (mixed)
+           The array to modify.
+
+    value  (mixed)
+           The value to remove from the array.
+
+### RETURN VALUES
+
+    (int) The total number of occurrences that were removed.
+
+### ERRORS
+
+    If the first argument is not an array
+
+### EXAMPLE
+
+    {{di1}}mixed *items = ({"apple", "banana", "apple", "orange", "apple"});
+    int removed = eject_value_all(ref items, "apple"); // Returns 3, items becomes ({"banana", "orange"})
+
+    mixed *numbers = ({1, 2, 3, 2, 4, 2});
+    int count = eject_value_all(ref numbers, 2); // Returns 3, numbers becomes ({1, 3, 4})
+
+    mixed *empty = ({});
+    int none = eject_value_all(ref empty, "test"); // Returns 0, array remains empty{{di0}}

--- a/doc/sefun/element_of.help
+++ b/doc/sefun/element_of.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "element_of"
+}
+---
+### NAME
+
+    element_of()
+
+### SYNOPSIS
+
+    varargs mixed element_of( mixed *arr, int secure );
+
+### PARAMETERS
+
+    arr     (mixed*)
+            The array to select a random element from
+
+    secure  (int, optional)
+            If true, uses secure_random() instead of the standard PRNG
+
+### RETURN VALUES
+
+    (mixed) A randomly selected element from the array
+
+### ERRORS
+
+    If a non-array value is passed

--- a/doc/sefun/element_of_weighted.help
+++ b/doc/sefun/element_of_weighted.help
@@ -1,0 +1,27 @@
+---
+{
+  title: "element_of_weighted"
+}
+---
+### NAME
+
+    element_of_weighted() - Selects an element from a weighted mapping based
+    on their weights.
+
+### SYNOPSIS
+
+    mixed element_of_weighted( mapping m );
+
+### DESCRIPTION
+
+    Selects an element from a weighted mapping based on their weights.
+
+### PARAMETERS
+
+    m  (mapping)
+       The weighted mapping to select from, where keys are the elements and
+       values are their weights.
+
+### RETURN VALUES
+
+    (mixed) The selected element.

--- a/doc/sefun/emit.help
+++ b/doc/sefun/emit.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "emit"
+}
+---
+### NAME
+
+    emit() - Emit a signal to all objects that have registered a slot for
+    the signal.
+
+### SYNOPSIS
+
+    void emit( string sig, mixed arg... );
+
+### DESCRIPTION
+
+    Emit a signal to all objects that have registered a slot for the signal.
+
+### PARAMETERS
+
+    sig  (string)
+         string signal identifier (use `SIG_*` macros)
+
+### ERRORS
+
+    If `sig` is not a string this function calls `error()` and thus raises
+    an exception. This enforces use of the `SIG_*` defines and avoids silent
+    mismatches.

--- a/doc/sefun/ends_with.help
+++ b/doc/sefun/ends_with.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "ends_with"
+}
+---
+### NAME
+
+    ends_with() - Checks if a string ends with a specific substring.
+
+### SYNOPSIS
+
+    int ends_with( string str, string ending_string );
+
+### DESCRIPTION
+
+    Checks if a string ends with a specific substring.
+
+### PARAMETERS
+
+    str            (string)
+                   The string to check.
+
+    ending_string  (string)
+                   The substring to check for at the end.
+
+### RETURN VALUES
+
+    (int) 1 if the string ends with the specified substring, 0 otherwise.
+
+### ERRORS
+
+    If either argument is not a string.

--- a/doc/sefun/eval_first.help
+++ b/doc/sefun/eval_first.help
@@ -1,0 +1,35 @@
+---
+{
+  title: "eval_first"
+}
+---
+### NAME
+
+    eval_first() - Finds and returns the first non-null result of applying a
+    function to each element in an array.
+
+### SYNOPSIS
+
+    varargs mixed eval_first( mixed *src, function fun, mixed extra... );
+
+### DESCRIPTION
+
+    Finds and returns the first non-null result of applying a function to
+    each element in an array.
+
+    Iterates over the array, calling the provided function for each element.
+    If the function returns a non-null value for any element, that value is
+    immediately returned. If no such value is found, returns UNDEFINED.
+
+### PARAMETERS
+
+    src  (mixed*)
+         The array to search
+
+    fun  (function)
+         The function to apply to each element (called as fun(element,
+         index, array, size, ...extra))
+
+### RETURN VALUES
+
+    (mixed) The first non-null result, or UNDEFINED if none found

--- a/doc/sefun/eval_last.help
+++ b/doc/sefun/eval_last.help
@@ -1,0 +1,42 @@
+---
+{
+  title: "eval_last"
+}
+---
+### NAME
+
+    eval_last() - Finds and returns the last non-null result of applying a
+    function to each element in an array.
+
+### SYNOPSIS
+
+    varargs mixed eval_last( mixed *src, function fun, mixed extra... );
+
+### DESCRIPTION
+
+    Finds and returns the last non-null result of applying a function to
+    each element in an array.
+
+    Iterates over the array in reverse order, calling the provided function
+    for each element. If the function returns a non-null value for any
+    element, that value is immediately returned. If no such value is found,
+    returns UNDEFINED.
+
+### PARAMETERS
+
+    src  (mixed*)
+         The array to search
+
+    fun  (function)
+         The function to apply to each element (called as fun(element,
+         index, array, size, ...extra))
+
+### RETURN VALUES
+
+    (mixed) The last non-null result, or UNDEFINED if none found
+
+### EXAMPLE
+
+    {{di1}}// Find the last string starting with 'a'
+    string *words = ({"cat", "apple", "ant", "dog"});
+    string last_a = eval_last(words, (: sscanf($1, "a%*s") ? $1 : 0 :)); // Returns "ant"{{di0}}

--- a/doc/sefun/evaluate_number.help
+++ b/doc/sefun/evaluate_number.help
@@ -1,0 +1,85 @@
+---
+{
+  title: "evaluate_number"
+}
+---
+### NAME
+
+    evaluate_number() - Evaluates a number against a condition. The
+    condition can be a simple comparison, or a compound condition using
+    `AND` and `OR`. This system allows for the evaluation of numeric
+    conditions using a specific set of operators and syntax rules.
+
+### SYNOPSIS
+
+    int evaluate_number( int number, string condition );
+
+### DESCRIPTION
+
+    Evaluates a number against a condition. The condition can be a simple
+    comparison, or a compound condition using `AND` and `OR`. This system
+    allows for the evaluation of numeric conditions using a specific set of
+    operators and syntax rules.
+
+    ### Basic Operators:
+
+    * `<` - Less than * `>` - Greater than * `<=` - Less than or equal to *
+    `>=` - Greater than or equal to * `=` or `==` - Equal to * `!=` - Not
+    equal to * `%` - Checks if a number is divisible by the given value.
+
+    ### Range Operator:
+
+    Use a hyphen (`-`) to specify a range, inclusive of both ends. Example:
+    `5-15` means any number from `5` to `15`, including `5` and `15`.
+
+    ### Set Inclusion/Exclusion:
+
+    `[a,b,c]` - Checks if a number is one of the listed values. `![a,b,c]` -
+    Checks if a number is not one of the listed values.
+
+    ### Logical Operators:
+
+    `AND` - Both conditions must be true. `OR` - At least one condition must
+    be true.
+
+    ### Grouping
+
+    Use parentheses `()` to group conditions and override default
+    precedence.
+
+    ### Precedence (from highest to lowest):
+
+    * Parentheses `()` * Basic operators (`<`, `>`, `<=`, `>=`, `=`, `!=`),
+    Range, Modulo, Set inclusion/exclusion * `AND` * `OR`
+
+    ### Syntax Rules
+
+    * No spaces are allowed in the condition string. * Operators must be
+    used exactly as specified (e.g., >= is valid, but => is not). * Set
+    values must be comma-separated without spaces.
+
+    #### Example of a complex condition
+
+    `(5-15AND%3)OR[20,25,30]`
+
+    This checks if a number is between `5` and `15` (inclusive) `AND`
+    divisible by `3`, `OR` if it's `20`, `25`, or `30`.
+
+    Invalid syntax will result in an error, ensuring strict adherence to
+    these rules.
+
+### PARAMETERS
+
+    number     (int)
+               The number to evaluate.
+
+    condition  (string)
+               The condition to evaluate against.
+
+### RETURN VALUES
+
+    (int) 1 if the condition evaluates to true, 0 otherwise.
+
+### ERRORS
+
+    If the condition contains invalid syntax or operators.

--- a/doc/sefun/every.help
+++ b/doc/sefun/every.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "every"
+}
+---
+### NAME
+
+    every() - Checks if every element in the array satisfies a testing rule.
+
+### SYNOPSIS
+
+    int every( mixed *arr, mixed criteria );
+
+### DESCRIPTION
+
+    Checks if every element in the array satisfies a testing rule.
+
+### PARAMETERS
+
+    arr       (mixed*)
+              Array to test
+
+    criteria  (mixed)
+              Function or value to test each element
+
+### RETURN VALUES
+
+    (int) 1 if all elements pass the test, 0 if any fail
+
+### ERRORS
+
+    If arguments are invalid types

--- a/doc/sefun/exec.help
+++ b/doc/sefun/exec.help
@@ -1,0 +1,24 @@
+---
+{
+  title: "exec"
+}
+---
+### NAME
+
+    exec()
+
+### SYNOPSIS
+
+    int exec( object to, object from );
+
+### PARAMETERS
+
+    to    (object)
+          The object to transfer execution to
+
+    from  (object)
+          The object to transfer execution from
+
+### RETURN VALUES
+
+    (int) 1 on success, 0 if the caller lacks permission

--- a/doc/sefun/explode_file.help
+++ b/doc/sefun/explode_file.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "explode_file"
+}
+---
+### NAME
+
+    explode_file() - Reads file content into array of lines.
+
+### SYNOPSIS
+
+    string *explode_file( string file );
+
+### DESCRIPTION
+
+    Reads file content into array of lines.
+
+    Filters out comments and empty lines.
+
+### PARAMETERS
+
+    file  (string)
+          File to read
+
+### RETURN VALUES
+
+    (string*) Array of non-empty, non-comment lines
+
+### EXAMPLE
+
+    {{di1}}string *config = explode_file("/etc/config.rc");{{di0}}

--- a/doc/sefun/extract.help
+++ b/doc/sefun/extract.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "extract"
+}
+---
+### NAME
+
+    extract() - Extracts a substring from a string.
+
+### SYNOPSIS
+
+    varargs string extract( string str, int from, int to );
+
+### DESCRIPTION
+
+    Extracts a substring from a string.
+
+### PARAMETERS
+
+    str   (string)
+          The string to extract from.
+
+    from  (int)
+          The starting position to extract from.
+
+    to    (int, optional)
+          The ending position to extract to.
+
+### RETURN VALUES
+
+    (string) The extracted substring.

--- a/doc/sefun/falsy.help
+++ b/doc/sefun/falsy.help
@@ -1,0 +1,35 @@
+---
+{
+  title: "falsy"
+}
+---
+### NAME
+
+    falsy() - The opposite of `truthy()`, determines if a value is falsy or
+    not. Falsy, not in the LPC sense, but more in a JS sense.
+
+### SYNOPSIS
+
+    int falsy( mixed val );
+
+### DESCRIPTION
+
+    The opposite of `truthy()`, determines if a value is falsy or not.
+    Falsy, not in the LPC sense, but more in a JS sense.
+
+    A falsy value is one that is null, 0 or a string that is empty.
+
+### PARAMETERS
+
+    val  (mixed)
+         The value to test if it is falsy.
+
+### RETURN VALUES
+
+    (int) 1 if the value is falsy, 0 if not.
+
+### EXAMPLE
+
+    {{di1}}falsy(1) // 0
+    falsy("") // 1
+    falsy("hi") // 0{{di0}}

--- a/doc/sefun/file_exists.help
+++ b/doc/sefun/file_exists.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "file_exists"
+}
+---
+### NAME
+
+    file_exists() - Checks if a regular file exists in the filesystem.
+
+### SYNOPSIS
+
+    int file_exists( string file );
+
+### DESCRIPTION
+
+    Checks if a regular file exists in the filesystem.
+
+### PARAMETERS
+
+    file  (string)
+          Path of file to check
+
+### RETURN VALUES
+
+    (int) 1 if file exists and is readable, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}if(file_exists(user_file)) {
+        restore_object(user_file);
+    }{{di0}}

--- a/doc/sefun/file_owner.help
+++ b/doc/sefun/file_owner.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "file_owner"
+}
+---
+### NAME
+
+    file_owner() - Determines ownership of a file based on its path.
+
+### SYNOPSIS
+
+    string file_owner( string file );
+
+### DESCRIPTION
+
+    Determines ownership of a file based on its path.
+
+    Analyzes path structure to identify file owner, with special handling
+    for admin directories.
+
+### PARAMETERS
+
+    file  (string)
+          Path to analyze
+
+### RETURN VALUES
+
+    (string) Owner name or "Admin/name" for admin files, 0 if not found
+
+### EXAMPLE
+
+    {{di1}}string owner = file_owner("/home/players/bob/workroom.c");  // Returns "bob"{{di0}}

--- a/doc/sefun/fill_array.help
+++ b/doc/sefun/fill_array.help
@@ -1,0 +1,37 @@
+---
+{
+  title: "fill_array"
+}
+---
+### NAME
+
+    fill_array() - Returns an array filled with the specified value. If no
+    array is provided, an empty array is created. If no value is provided, 0
+    is used as the value to fill the array with. If no start index is
+    provided, the array is filled from the end.
+
+### SYNOPSIS
+
+    varargs mixed fill_array( mixed *arr, mixed value, int size, int start_index );
+
+### DESCRIPTION
+
+    Returns an array filled with the specified value. If no array is
+    provided, an empty array is created. If no value is provided, 0 is used
+    as the value to fill the array with. If no start index is provided, the
+    array is filled from the end.
+
+### PARAMETERS
+
+    arr          (mixed*)
+                 The array to fill.
+
+    value        (mixed)
+                 The value to fill the array with.
+
+    start_index  (int)
+                 The index at which to start filling the array. (optional)
+
+### RETURN VALUES
+
+    (mixed) The filled array.

--- a/doc/sefun/find.help
+++ b/doc/sefun/find.help
@@ -1,0 +1,35 @@
+---
+{
+  title: "find"
+}
+---
+### NAME
+
+    find() - Returns the first element that passes the test function.
+
+### SYNOPSIS
+
+    varargs mixed find( mixed *arr, function fun, mixed extra... );
+
+### DESCRIPTION
+
+    Returns the first element that passes the test function.
+
+### PARAMETERS
+
+    arr    (mixed*)
+           Array to search
+
+    fun    (function)
+           Test function taking (element, index, array, ...extra)
+
+    extra  (mixed, optional)
+           Additional arguments passed to the callback starting at $4
+
+### RETURN VALUES
+
+    (mixed) First matching element or null if none found
+
+### ERRORS
+
+    If arguments are invalid types

--- a/doc/sefun/find_index.help
+++ b/doc/sefun/find_index.help
@@ -1,0 +1,36 @@
+---
+{
+  title: "find_index"
+}
+---
+### NAME
+
+    find_index() - Returns the index of the first element that passes the
+    test function.
+
+### SYNOPSIS
+
+    varargs int find_index( mixed *arr, function fun, mixed extra... );
+
+### DESCRIPTION
+
+    Returns the index of the first element that passes the test function.
+
+### PARAMETERS
+
+    arr    (mixed*)
+           Array to search
+
+    fun    (function)
+           Test function taking (element, index, array, ...extra)
+
+    extra  (mixed, optional)
+           Additional arguments passed to the callback starting at $4
+
+### RETURN VALUES
+
+    (int) Index of first matching element or -1 if none found
+
+### ERRORS
+
+    If arguments are invalid types

--- a/doc/sefun/find_key.help
+++ b/doc/sefun/find_key.help
@@ -1,0 +1,58 @@
+---
+{
+  title: "find_key"
+}
+---
+### NAME
+
+    find_key() - Finds the first key in a mapping that corresponds to a
+    specific value or satisfies a given condition.
+
+### SYNOPSIS
+
+    varargs mixed find_key( mapping map, mixed value, mixed arg... );
+
+### DESCRIPTION
+
+    Finds the first key in a mapping that corresponds to a specific value or
+    satisfies a given condition.
+
+    When a function is provided as the value parameter, it acts as a
+    predicate. Any trailing arguments passed to `find_key` are forwarded to
+    the predicate, so its full call signature is `(val, key, map, arg...)` —
+    `$1` is the value at the current key, `$2` is the key, `$3` is the
+    mapping, and `$4..` are the forwarded extras. The predicate should
+    return truthy when the desired key is found.
+
+### PARAMETERS
+
+    map    (mapping)
+           The mapping to search.
+
+    value  (mixed|function)
+           The value to find, or a predicate function.
+
+### RETURN VALUES
+
+    (mixed) The first matching key, or 0 if no match found.
+
+### EXAMPLE
+
+    {{di1}}// Find key for a specific value
+    mapping scores = (["Alice": 95, "Bob": 87, "Charlie": 95]);
+    string name = find_key(scores, 95); // Returns "Alice"
+
+    // Find key using a predicate function ($1 = value at key)
+    name = find_key(scores, (: $1 > 90 :)); // First student with score > 90
+
+    // Forwarding an extra arg lets the closure stay capture-free
+    int threshold = 90;
+    name = find_key(scores, (: $1 > $4 :), threshold);
+
+    // Common pattern: condition-strings as keys, value as forwarded arg
+    mapping bands = ([
+      ">=0AND<50":   ([ "size": "small"  ]),
+      ">=50AND<80":  ([ "size": "medium" ]),
+      ">=80AND<100": ([ "size": "large"  ]),
+    ]);
+    string key = find_key(bands, (: evaluate_number($4, $2) :), mass);{{di0}}

--- a/doc/sefun/find_keys.help
+++ b/doc/sefun/find_keys.help
@@ -1,0 +1,54 @@
+---
+{
+  title: "find_keys"
+}
+---
+### NAME
+
+    find_keys() - Finds all keys in a mapping that correspond to a specific
+    value or satisfy a given condition.
+
+### SYNOPSIS
+
+    varargs mixed *find_keys( mapping map, mixed value, mixed arg... );
+
+### DESCRIPTION
+
+    Finds all keys in a mapping that correspond to a specific value or
+    satisfy a given condition.
+
+    When a function is provided as the value parameter, it acts as a
+    predicate. Any trailing arguments passed to `find_keys` are forwarded to
+    the predicate, so its full call signature is `(val, key, map, arg...)` —
+    `$1` is the value at the current key, `$2` is the key, `$3` is the
+    mapping, and `$4..` are the forwarded extras. The predicate should
+    return truthy for each key that should be included in the result.
+
+### PARAMETERS
+
+    map    (mapping)
+           The mapping to search.
+
+    value  (mixed|function)
+           The value to find, or a predicate function.
+
+### RETURN VALUES
+
+    (mixed*) Array of all matching keys, empty array if none found.
+
+### EXAMPLE
+
+    {{di1}}// Find all keys for a specific value
+    mapping scores = (["Alice": 95, "Bob": 87, "Charlie": 95]);
+    string* names = find_keys(scores, 95); // Returns ({"Alice", "Charlie"})
+
+    // Find all keys using a predicate function ($1 = value at key)
+    names = find_keys(scores, (: $1 > 90 :)); // All students with score > 90
+
+    // Forwarding an extra arg lets the closure stay capture-free
+    int threshold = 90;
+    names = find_keys(scores, (: $1 > $4 :), threshold);
+
+    // Using with evaluate_number for complex conditions
+    string* honor_roll = find_keys(scores, (: evaluate_number($1, ">=95OR(>=80AND%5)") :));
+    // Returns students with scores ≥95 OR (scores ≥80 AND divisible by 5){{di0}}

--- a/doc/sefun/find_ob.help
+++ b/doc/sefun/find_ob.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "find_ob"
+}
+---
+### NAME
+
+    find_ob() - Finds an object within a container using precise criteria.
+
+### SYNOPSIS
+
+    varargs object find_ob( mixed ob, mixed cont );
+
+### DESCRIPTION
+
+    Finds an object within a container using precise criteria.
+
+### PARAMETERS
+
+    ob    (mixed)
+          Target object or filename
+
+    cont  (mixed, optional)
+          Container to search in
+
+### RETURN VALUES
+
+    (object) Matching object or 0 if not found
+
+### EXAMPLE
+
+    {{di1}}find_ob("sword", this_body());
+    find_ob("/obj/weapon/sword#12", room);{{di0}}

--- a/doc/sefun/find_target.help
+++ b/doc/sefun/find_target.help
@@ -1,0 +1,42 @@
+---
+{
+  title: "find_target"
+}
+---
+### NAME
+
+    find_target() - This simul_efun will find a single object in a
+    container, such as a room, chest, player's inventory, that matches the
+    specified argument. The argument can be a name, ID, or other identifier
+    that can be used to match objects.
+
+### SYNOPSIS
+
+    varargs object find_target( object user, string arg, object source, function f );
+
+### DESCRIPTION
+
+    This simul_efun will find a single object in a container, such as a
+    room, chest, player's inventory, that matches the specified argument.
+    The argument can be a name, ID, or other identifier that can be used to
+    match objects.
+
+    The simul_efun will then filter the objects based on the visibility of
+    the calling object, and apply an additional custom filter function if
+    provided.
+
+### PARAMETERS
+
+    arg     (string)
+            The argument to match objects against
+
+    source  (object)
+            The object to search within, such as a room or container. If not
+            provided, the environment of the calling object will be used.
+
+    f       (function)
+            An optional custom filter function to further filter
+
+### RETURN VALUES
+
+    (object) The located object, or 0 if not found.

--- a/doc/sefun/find_targets.help
+++ b/doc/sefun/find_targets.help
@@ -1,0 +1,44 @@
+---
+{
+  title: "find_targets"
+}
+---
+### NAME
+
+    find_targets() - This simul_efun will find all objects in a container,
+    such as a room, chest, player's inventory, that match the specified
+    argument. The argument can be a name, ID, or other identifier that can
+    be used to match objects.
+
+### SYNOPSIS
+
+    varargs object *find_targets( object user, string arg, object source, function f );
+
+### DESCRIPTION
+
+    This simul_efun will find all objects in a container, such as a room,
+    chest, player's inventory, that match the specified argument. The
+    argument can be a name, ID, or other identifier that can be used to
+    match objects.
+
+    The simul_efun will then filter the objects based on the visibility of
+    the calling object, and apply an additional custom filter function if
+    provided.
+
+### PARAMETERS
+
+    arg     (string)
+            The argument to match objects against
+
+    source  (object)
+            The object to search within, such as a room or container. If not
+            provided, the environment of the calling object will be used.
+
+    f       (function)
+            An optional custom filter function to further filter the
+            objects.
+
+### RETURN VALUES
+
+    (object* | undefined) An array of located objects or undefined (0) if
+    none are found.

--- a/doc/sefun/flatten.help
+++ b/doc/sefun/flatten.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "flatten"
+}
+---
+### NAME
+
+    flatten() - Flattens a nested array into a single-level array.
+
+### SYNOPSIS
+
+    mixed *flatten( mixed *arr );
+
+### DESCRIPTION
+
+    Flattens a nested array into a single-level array.
+
+### PARAMETERS
+
+    arr  (mixed*)
+         Array to flatten
+
+### RETURN VALUES
+
+    (mixed*) Flattened array
+
+### ERRORS
+
+    If argument is not an array

--- a/doc/sefun/from_string.help
+++ b/doc/sefun/from_string.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "from_string"
+}
+---
+### NAME
+
+    from_string() - Converts a string representation of an LPC value to the
+    corresponding LPC value.
+
+### SYNOPSIS
+
+    varargs mixed from_string( string str, int flag );
+
+### DESCRIPTION
+
+    Converts a string representation of an LPC value to the corresponding
+    LPC value.
+
+### PARAMETERS
+
+    str   (string)
+          The string to convert.
+
+    flag  (int, optional, default: 0)
+          If set, returns an array with the value and the remaining string.
+
+### RETURN VALUES
+
+    (mixed) The LPC value represented by the string.

--- a/doc/sefun/generate_uuid.help
+++ b/doc/sefun/generate_uuid.help
@@ -1,0 +1,22 @@
+---
+{
+  title: "generate_uuid"
+}
+---
+### NAME
+
+    generate_uuid() - Generates a random "version 4" UUID. Version 4 UUIDs
+    are based on random numbers.
+
+### SYNOPSIS
+
+    string generate_uuid( void );
+
+### DESCRIPTION
+
+    Generates a random "version 4" UUID. Version 4 UUIDs are based on random
+    numbers.
+
+### RETURN VALUES
+
+    (string) A randomly generated version 4 UUID.

--- a/doc/sefun/get_files.help
+++ b/doc/sefun/get_files.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "get_files"
+}
+---
+### NAME
+
+    get_files() - Resolves a path and returns an array of matching files,
+    supporting * wildcard pattern.
+
+### SYNOPSIS
+
+    string *get_files( string base_dir, string path );
+
+### DESCRIPTION
+
+    Resolves a path and returns an array of matching files, supporting *
+    wildcard pattern.
+
+### PARAMETERS
+
+    base_dir  (string)
+              The base directory to resolve relative paths from.
+
+    path      (string)
+              The path or pattern to resolve and search for files.
+
+### RETURN VALUES
+
+    (string*) An array of matching file paths, or ({}) if invalid.

--- a/doc/sefun/get_living.help
+++ b/doc/sefun/get_living.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "get_living"
+}
+---
+### NAME
+
+    get_living() - Locates a living object by the specified name within the
+    specified room.
+
+### SYNOPSIS
+
+    object get_living( string id, object room );
+
+### DESCRIPTION
+
+    Locates a living object by the specified name within the specified room.
+
+### PARAMETERS
+
+    id  (string)
+        The name of the living object to locate.
+
+### RETURN VALUES
+
+    (object) The located living object, or 0 if not found.

--- a/doc/sefun/get_livings.help
+++ b/doc/sefun/get_livings.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "get_livings"
+}
+---
+### NAME
+
+    get_livings() - Locates living objects by the specified names within the
+    specified room.
+
+### SYNOPSIS
+
+    object *get_livings( mixed ids, object room );
+
+### DESCRIPTION
+
+    Locates living objects by the specified names within the specified room.
+
+### PARAMETERS
+
+    ids  (string|string*)
+         The name of the living objects to locate.
+
+### RETURN VALUES
+
+    (object*) An array of located living objects.

--- a/doc/sefun/get_long.help
+++ b/doc/sefun/get_long.help
@@ -1,0 +1,39 @@
+---
+{
+  title: "get_long"
+}
+---
+### NAME
+
+    get_long() - Returns an object's long description with optional extras.
+
+### SYNOPSIS
+
+    varargs string get_long( object ob, int extras );
+
+### DESCRIPTION
+
+    Returns an object's long description with optional extras.
+
+    Retrieves the base long description and appends any extra long
+    descriptions. Handles formatting of newlines and removes trailing
+    whitespace.
+
+### PARAMETERS
+
+    ob      (STD_OBJECT)
+            Object to get description from, defaults to previous_object()
+
+    extras  (int, optional, default: 1)
+            Whether to include extra descriptions (1=yes, 0=no)
+
+### RETURN VALUES
+
+    (string) Formatted long description
+
+### EXAMPLE
+
+    {{di1}}// Basic usage
+    tell_me(get_long(room));
+    // Without extras
+    tell_me(get_long(room, 0));{{di0}}

--- a/doc/sefun/get_object.help
+++ b/doc/sefun/get_object.help
@@ -1,0 +1,35 @@
+---
+{
+  title: "get_object"
+}
+---
+### NAME
+
+    get_object() - Locates a target object using flexible search criteria.
+
+### SYNOPSIS
+
+    varargs object get_object( string str, object player );
+
+### DESCRIPTION
+
+    Locates a target object using flexible search criteria.
+
+    Comprehensive search that looks through environments and inventories for
+    matching objects. Supports special prefixes and location markers.
+
+### PARAMETERS
+
+    str  (string)
+         Search string with optional prefixes
+
+### RETURN VALUES
+
+    (object) First matching object or 0 if none found
+
+### EXAMPLE
+
+    {{di1}}get_object("sword");           // Basic search
+    get_object("@orc");           // Environment of orc
+    get_object("me", this_body()); // The player themselves
+    get_object("here");           // Current room{{di0}}

--- a/doc/sefun/get_objects.help
+++ b/doc/sefun/get_objects.help
@@ -1,0 +1,38 @@
+---
+{
+  title: "get_objects"
+}
+---
+### NAME
+
+    get_objects() - Locates multiple objects using extended search syntax.
+
+### SYNOPSIS
+
+    varargs mixed get_objects( string str, object player, int no_arr );
+
+### DESCRIPTION
+
+    Locates multiple objects using extended search syntax.
+
+    Supports advanced search patterns with colons for relationships: - :i =
+    inventory - :e = environment - :d = deep inventory - :c = children - :s
+    = shadows
+
+### PARAMETERS
+
+    str     (string)
+            Search pattern with relationship markers
+
+    no_arr  (int, optional)
+            Return single object instead of array
+
+### RETURN VALUES
+
+    (mixed) Matching object(s) or 0 if none found
+
+### EXAMPLE
+
+    {{di1}}get_objects("users:i");      // All items in all users' inventories
+    get_objects("room:e:guard"); // Guards in room's environment
+    get_objects("/std/monster:c"); // All monster clones{{di0}}

--- a/doc/sefun/get_player.help
+++ b/doc/sefun/get_player.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "get_player"
+}
+---
+### NAME
+
+    get_player() - Locates a player object by the specified name within the
+    specified room.
+
+### SYNOPSIS
+
+    object get_player( string name, object room );
+
+### DESCRIPTION
+
+    Locates a player object by the specified name within the specified room.
+
+### PARAMETERS
+
+    name  (string)
+          The name of the player to locate.
+
+    room  (object)
+          The room to search for the player in.
+
+### RETURN VALUES
+
+    (object STD_PLAYER|0) The located player object, or 0 if not found.

--- a/doc/sefun/get_players.help
+++ b/doc/sefun/get_players.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "get_players"
+}
+---
+### NAME
+
+    get_players() - Locates player objects by the specified names within a
+    room.
+
+### SYNOPSIS
+
+    object *get_players( mixed names, object room );
+
+### DESCRIPTION
+
+    Locates player objects by the specified names within a room.
+
+### PARAMETERS
+
+    names  (string|string*)
+           The name of the player objects to locate.
+
+### RETURN VALUES
+
+    (object STD_PLAYER*) An array of located player objects.

--- a/doc/sefun/get_short.help
+++ b/doc/sefun/get_short.help
@@ -1,0 +1,40 @@
+---
+{
+  title: "get_short"
+}
+---
+### NAME
+
+    get_short() - Returns an object's short description with optional
+    extras.
+
+### SYNOPSIS
+
+    varargs string get_short( object ob, int extras );
+
+### DESCRIPTION
+
+    Returns an object's short description with optional extras.
+
+    Retrieves the base short description and appends any extra short
+    descriptions in parentheses. Filters out null or empty extra
+    descriptions.
+
+### PARAMETERS
+
+    ob      (STD_OBJECT)
+            Object to get description from, defaults to previous_object()
+
+    extras  (int, optional, default: 1)
+            Whether to include extra descriptions (1=yes, 0=no)
+
+### RETURN VALUES
+
+    (string) Formatted short description
+
+### EXAMPLE
+
+    {{di1}}// Basic usage
+    tell_me(get_short(sword));  // "a sharp sword (glowing) (magical)"
+    // Without extras
+    tell_me(get_short(sword, 0));  // "a sharp sword"{{di0}}

--- a/doc/sefun/getoid.help
+++ b/doc/sefun/getoid.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "getoid"
+}
+---
+### NAME
+
+    getoid() - Retrieves the unique object ID of the given object as
+    assigned by the driver. For example:
+
+### SYNOPSIS
+
+    int getoid( object ob );
+
+### DESCRIPTION
+
+    Retrieves the unique object ID of the given object as assigned by the
+    driver. For example:
+
+### PARAMETERS
+
+    ob  (object)
+        The object to get the ID of.
+
+### RETURN VALUES
+
+    (int)
+
+### EXAMPLE
+
+    {{di1}}object knife = new("/obj/knife"); // obj/knife#232
+    get_oid(knife); // 232{{di0}}

--- a/doc/sefun/ghostp.help
+++ b/doc/sefun/ghostp.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "ghostp"
+}
+---
+### NAME
+
+    ghostp() - Returns 1 if the object is a ghost, 0 if not.
+
+### SYNOPSIS
+
+    int ghostp( object ob );
+
+### DESCRIPTION
+
+    Returns 1 if the object is a ghost, 0 if not.
+
+### PARAMETERS
+
+    ob  (STD_GHOST)
+        The object to check.
+
+### RETURN VALUES
+
+    (ob is STD_GHOST) 1 if the object is a ghost, otherwise 0.

--- a/doc/sefun/gradient_hex.help
+++ b/doc/sefun/gradient_hex.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "gradient_hex"
+}
+---
+### NAME
+
+    gradient_hex() - Adjusts a hex colour by a uniform step value across all
+    RGB channels, clamping each channel to the 0-255 range.
+
+### SYNOPSIS
+
+    string gradient_hex( string hex, float step );
+
+### DESCRIPTION
+
+    Adjusts a hex colour by a uniform step value across all RGB channels,
+    clamping each channel to the 0-255 range.
+
+### PARAMETERS
+
+    hex   (string)
+          The hex colour string to adjust
+
+    step  (float)
+          The amount to add to each RGB channel
+
+### RETURN VALUES
+
+    (string) The adjusted colour as a `{{RRGGBB}}` colour code

--- a/doc/sefun/has.help
+++ b/doc/sefun/has.help
@@ -1,0 +1,38 @@
+---
+{
+  title: "has"
+}
+---
+### NAME
+
+    has() - Checks if an object has one or more specified functions defined.
+
+### SYNOPSIS
+
+    string has( object ob, mixed function_names );
+
+### DESCRIPTION
+
+    Checks if an object has one or more specified functions defined.
+
+    Accepts either a single function name or an array of function names.
+    When given an array, checks each function in order and returns the
+    location of the first one that exists.
+
+### PARAMETERS
+
+    ob              (object)
+                    The object to check.
+
+    function_names  (string|string*)
+                    Function name(s) to look for `(string|string*)`
+
+### RETURN VALUES
+
+    (string|null) The filename where a function is defined, or null if none
+    found or if ob is not an object.
+
+### EXAMPLE
+
+    {{di1}}has(player, "query_level");  // Returns "/std/body.c" if exists
+    has(item, ({ "is_weapon", "is_armour" }));  // Returns filename of first existing function{{di0}}

--- a/doc/sefun/home_path.help
+++ b/doc/sefun/home_path.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "home_path"
+}
+---
+### NAME
+
+    home_path() - Returns the home directory path for the user.
+
+### SYNOPSIS
+
+    string home_path( mixed name );
+
+### DESCRIPTION
+
+    Returns the home directory path for the user.
+
+### RETURN VALUES
+
+    (string) The home directory path for the user.

--- a/doc/sefun/identify.help
+++ b/doc/sefun/identify.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "identify"
+}
+---
+### NAME
+
+    identify() - Converts a variable to its string representation for
+    debugging purposes, handling various data types and preventing deep
+    recursion.
+
+### SYNOPSIS
+
+    varargs string identify( mixed a, string indent );
+
+### DESCRIPTION
+
+    Converts a variable to its string representation for debugging purposes,
+    handling various data types and preventing deep recursion.
+
+### PARAMETERS
+
+    a       (mixed)
+            The variable to identify.
+
+    indent  (string, optional, default: "")
+            The indentation string to use for formatting.
+
+### RETURN VALUES
+
+    (string) The string representation of the variable.

--- a/doc/sefun/implode_file.help
+++ b/doc/sefun/implode_file.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "implode_file"
+}
+---
+### NAME
+
+    implode_file() - Writes array of lines to a file.
+
+### SYNOPSIS
+
+    varargs void implode_file( string file, string *lines, int overwrite );
+
+### DESCRIPTION
+
+    Writes array of lines to a file.
+
+### PARAMETERS
+
+    file       (string)
+               Target file path
+
+    lines      (string*)
+               Lines to write
+
+    overwrite  (int, optional, default: 0)
+               Whether to overwrite existing content
+
+### EXAMPLE
+
+    {{di1}}implode_file("/save/names.txt", ({ "Bob", "Alice" }), 1);{{di0}}

--- a/doc/sefun/in_array.help
+++ b/doc/sefun/in_array.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "in_array"
+}
+---
+### NAME
+
+    in_array() - Checks if a value exists in an array without caring about
+    its position.
+
+### SYNOPSIS
+
+    varargs int in_array( mixed needle, mixed *haystack, function f );
+
+### DESCRIPTION
+
+    Checks if a value exists in an array without caring about its position.
+
+### PARAMETERS
+
+    needle    (mixed)
+              The value to search for
+
+    haystack  (mixed*)
+              The array to search in
+
+    f         (function, optional)
+              Comparison function taking (elem, needle)
+
+### RETURN VALUES
+
+    (int) Returns 1 if found, 0 if not found

--- a/doc/sefun/in_range.help
+++ b/doc/sefun/in_range.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "in_range"
+}
+---
+### NAME
+
+    in_range() - Checks if an index is within the valid range of an array.
+
+### SYNOPSIS
+
+    int in_range( int index, mixed *arr );
+
+### DESCRIPTION
+
+    Checks if an index is within the valid range of an array.
+
+### PARAMETERS
+
+    index  (int)
+           Index to check
+
+    arr    (mixed*)
+           Array to check against
+
+### RETURN VALUES
+
+    (int) 1 if index is valid, 0 if not

--- a/doc/sefun/includes.help
+++ b/doc/sefun/includes.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "includes"
+}
+---
+### NAME
+
+    includes() - Checks if an array includes a specific element.
+
+### SYNOPSIS
+
+    varargs int includes( mixed *arr, mixed elem, function f );
+
+### DESCRIPTION
+
+    Checks if an array includes a specific element.
+
+### PARAMETERS
+
+    arr   (mixed*)
+          Array to search
+
+    elem  (mixed)
+          Element to find
+
+    f     (function, optional)
+          Optional comparison function taking (array_element,
+          search_element)
+
+### RETURN VALUES
+
+    (int) 1 if element is found, 0 if not

--- a/doc/sefun/insert.help
+++ b/doc/sefun/insert.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "insert"
+}
+---
+### NAME
+
+    insert() - Inserts an element at a specific index.
+
+### SYNOPSIS
+
+    mixed insert( mixed ref *arr, mixed value, int index );
+
+### DESCRIPTION
+
+    Inserts an element at a specific index.
+
+### PARAMETERS
+
+    arr    (mixed*)
+           Array to modify
+
+    value  (mixed)
+           Value to insert
+
+    index  (int)
+           Index where to insert
+
+### RETURN VALUES
+
+    (int) New size of array

--- a/doc/sefun/int_string.help
+++ b/doc/sefun/int_string.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "int_string"
+}
+---
+### NAME
+
+    int_string() - Converts a numerical number to its worded number
+    representation.
+
+### SYNOPSIS
+
+    string int_string( int num );
+
+### DESCRIPTION
+
+    Converts a numerical number to its worded number representation.
+
+### PARAMETERS
+
+    num  (int)
+         The numerical number to convert.
+
+### RETURN VALUES
+
+    (string) The worded number representation of the integer.

--- a/doc/sefun/intersection.help
+++ b/doc/sefun/intersection.help
@@ -1,0 +1,67 @@
+---
+{
+  title: "intersection"
+}
+---
+### NAME
+
+    intersection() - Finds the intersection of two arrays - elements that
+    appear in both arrays.
+
+### SYNOPSIS
+
+    varargs mixed *intersection( mixed *arr1, mixed *arr2, function f );
+
+### DESCRIPTION
+
+    Finds the intersection of two arrays - elements that appear in both
+    arrays.
+
+    This function supports comparing elements with a custom comparison
+    function, which is particularly useful for complex data types like
+    mappings or objects where simple equality comparison isn't sufficient.
+    For example, finding objects with matching properties or mappings with
+    specific key values.
+
+    The result contains all elements from both arrays that match according
+    to the comparison logic, with duplicates removed.
+
+### PARAMETERS
+
+    arr1  (mixed*)
+          First array to compare
+
+    arr2  (mixed*)
+          Second array to compare
+
+    f     (function, optional)
+          Optional comparison function taking (array_element,
+          search_element)
+
+### RETURN VALUES
+
+    (mixed*) New array containing elements found in both input arrays
+
+### EXAMPLE
+
+    {{di1}}// Simple intersection of string arrays
+    string *weapons1 = ({"sword", "axe", "spear"});
+    string *weapons2 = ({"bow", "spear", "sword"});
+    // Returns ({"sword", "spear"})
+    string *common = intersection(weapons1, weapons2);
+
+    // Intersection with custom comparison of object arrays
+    object *players1 = ({player1, player2, player3});
+    object *players2 = ({player2, player4, player5});
+    // Returns objects with matching races
+    object *matching_race = intersection(players1, players2,
+      (: $1->query_race() == $2->query_race() :));
+
+    // Intersection of mappings by specific property
+    mapping *items1 = ({(["type":"weapon", "name":"sword"]),
+                       (["type":"armor", "name":"shield"])});
+    mapping *items2 = ({(["type":"potion", "name":"healing"]),
+                       (["type":"weapon", "name":"dagger"])});
+    // Returns items of type "weapon"
+    mapping *weapons = intersection(items1, items2,
+      (: $1["type"] == $2["type"] && $1["type"] == "weapon" :));{{di0}}

--- a/doc/sefun/intersects.help
+++ b/doc/sefun/intersects.help
@@ -1,0 +1,51 @@
+---
+{
+  title: "intersects"
+}
+---
+### NAME
+
+    intersects() - Checks if two arrays have any elements in common
+    (intersection is not empty). This is a faster alternative to checking
+    `sizeof(intersection(arr1, arr2)) > 0`.
+
+### SYNOPSIS
+
+    varargs int intersects( mixed *arr1, mixed *arr2, function compare );
+
+### DESCRIPTION
+
+    Checks if two arrays have any elements in common (intersection is not
+    empty). This is a faster alternative to checking
+    `sizeof(intersection(arr1, arr2)) > 0`.
+
+### PARAMETERS
+
+    arr1     (mixed*)
+             First array to check
+
+    arr2     (mixed*)
+             Second array to check
+
+    compare  (function, optional)
+             Optional comparison function taking (array_element,
+             search_element)
+
+### RETURN VALUES
+
+    (int) 1 if arrays have at least one element in common, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}// Check if any weapons match between two arrays
+    string *weapons1 = ({"sword", "axe", "mace"});
+    string *weapons2 = ({"bow", "axe", "dagger"});
+    if(intersects(weapons1, weapons2))
+      write("You have some matching weapons!\n");
+
+    // With custom comparison function
+    object *players1 = ({player1, player2, player3});
+    object *players2 = ({player4, player5, player6});
+    // Check if any players share the same guild
+    if(intersects(players1, players2, (: $1->query_guild() == $2->query_guild() :)))
+      write("Some players share the same guild!\n");{{di0}}

--- a/doc/sefun/is_member.help
+++ b/doc/sefun/is_member.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "is_member"
+}
+---
+### NAME
+
+    is_member() - Checks if a user is a member of a specified group.
+
+### SYNOPSIS
+
+    int is_member( string user, string group );
+
+### DESCRIPTION
+
+    Checks if a user is a member of a specified group.
+
+### PARAMETERS
+
+    user   (string)
+           The username to check.
+
+    group  (string)
+           The group to check membership in.
+
+### RETURN VALUES
+
+    (int) 1 if the user is a member of the group, otherwise 0.

--- a/doc/sefun/is_numeric.help
+++ b/doc/sefun/is_numeric.help
@@ -1,0 +1,39 @@
+---
+{
+  title: "is_numeric"
+}
+---
+### NAME
+
+    is_numeric() - Checks if `str` is a numeric literal (integer or float).
+    It can optionally start with '-' for negatives. Uses a regex to confirm
+    the format.
+
+### SYNOPSIS
+
+    varargs int is_numeric( string str, int allow_float: (: 0 :) );
+
+### DESCRIPTION
+
+    Checks if `str` is a numeric literal (integer or float). It can
+    optionally start with '-' for negatives. Uses a regex to confirm the
+    format.
+
+### PARAMETERS
+
+    str  (string)
+         The string to check
+
+### RETURN VALUES
+
+    (int) 1 if it matches a numeric pattern, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}if(is_numeric("3")) {
+      write("It's a number.\n");
+    }
+
+    if(is_numeric("3.14159", 1)) {
+      write("It's a number.\n");
+    }{{di0}}

--- a/doc/sefun/j.help
+++ b/doc/sefun/j.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "j"
+}
+---
+### NAME
+
+    j() - Converts a variable to its string representation in
+    JavaScript-like format, handling various data types and preventing deep
+    recursion.
+
+### SYNOPSIS
+
+    varargs string j( mixed a, string indent );
+
+### DESCRIPTION
+
+    Converts a variable to its string representation in JavaScript-like
+    format, handling various data types and preventing deep recursion.
+
+### PARAMETERS
+
+    a       (mixed)
+            The variable to represent as a JS-like string.
+
+    indent  (string, optional, default: "")
+            The indentation string to use for formatting.
+
+### RETURN VALUES
+
+    (string) The JS-like string representation of the variable.

--- a/doc/sefun/json_decode.help
+++ b/doc/sefun/json_decode.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "json_decode"
+}
+---
+### NAME
+
+    json_decode() - Deserializes a JSON string into an LPC value.
+
+### SYNOPSIS
+
+    mixed json_decode( string text );
+
+### DESCRIPTION
+
+    Deserializes a JSON string into an LPC value.
+
+### PARAMETERS
+
+    text  (string)
+          The JSON string to deserialize.
+
+### RETURN VALUES
+
+    (mixed) The deserialized LPC value.

--- a/doc/sefun/json_encode.help
+++ b/doc/sefun/json_encode.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "json_encode"
+}
+---
+### NAME
+
+    json_encode() - Serializes an LPC value into a JSON string.
+
+### SYNOPSIS
+
+    varargs string json_encode( mixed value, mixed* pointers );
+
+### DESCRIPTION
+
+    Serializes an LPC value into a JSON string.
+
+### PARAMETERS
+
+    value     (mixed)
+              The LPC value to serialize.
+
+    pointers  (mixed*, optional)
+              An optional array of pointers to handle circular references.
+
+### RETURN VALUES
+
+    (string) The JSON string representation of the LPC value.

--- a/doc/sefun/ldate.help
+++ b/doc/sefun/ldate.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "ldate"
+}
+---
+### NAME
+
+    ldate() - Returns a formatted date string.
+
+### SYNOPSIS
+
+    varargs string ldate( int x, int brief );
+
+### DESCRIPTION
+
+    Returns a formatted date string.
+
+### PARAMETERS
+
+    x      (int, optional, default: time())
+           The timestamp to format. Defaults to the current time.
+
+    brief  (int, optional, default: 0)
+           If set to 1, returns a brief date format (MM-DD). Otherwise,
+           returns a full date format (YYYY-MM-DD).
+
+### RETURN VALUES
+
+    (string) The formatted date string.

--- a/doc/sefun/ldatetime.help
+++ b/doc/sefun/ldatetime.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "ldatetime"
+}
+---
+### NAME
+
+    ldatetime() - Returns a formatted date and time string.
+
+### SYNOPSIS
+
+    varargs string ldatetime( int x, int brief );
+
+### DESCRIPTION
+
+    Returns a formatted date and time string.
+
+### PARAMETERS
+
+    x      (int, optional, default: time())
+           The timestamp to format. Defaults to the current time.
+
+    brief  (int, optional, default: 0)
+           If set to 1, returns a brief date and time format (MM-DD HH:MM).
+           Otherwise, returns a full date and time format (YYYY-MM-DD
+           HH:MM:SS).

--- a/doc/sefun/lib_name.help
+++ b/doc/sefun/lib_name.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "lib_name"
+}
+---
+### NAME
+
+    lib_name() - Returns the name of the library being used by the MUD.
+
+### SYNOPSIS
+
+    string lib_name( void );
+
+### DESCRIPTION
+
+    Returns the name of the library being used by the MUD.
+
+### RETURN VALUES
+
+    (string) The library name.

--- a/doc/sefun/lib_version.help
+++ b/doc/sefun/lib_version.help
@@ -1,0 +1,21 @@
+---
+{
+  title: "lib_version"
+}
+---
+### NAME
+
+    lib_version() - Returns the version of the library being used by the
+    MUD.
+
+### SYNOPSIS
+
+    string lib_version( void );
+
+### DESCRIPTION
+
+    Returns the version of the library being used by the MUD.
+
+### RETURN VALUES
+
+    (string) The library version.

--- a/doc/sefun/load_lpml.help
+++ b/doc/sefun/load_lpml.help
@@ -1,0 +1,40 @@
+---
+{
+  title: "load_lpml"
+}
+---
+### NAME
+
+    load_lpml() - Loads and decodes an LPML file.
+
+### SYNOPSIS
+
+    varargs mixed load_lpml( string file, string root );
+
+### DESCRIPTION
+
+    Loads and decodes an LPML file.
+
+    Reads the file and parses it via lpml_decode(). The optional root
+    argument is forwarded to lpml_decode() as the base path used for
+    resolving relative #-includes within the LPML text.
+
+### PARAMETERS
+
+    file  (string)
+          Path to the LPML file to load
+
+    root  (string, optional)
+          Base path for resolving relative includes
+
+### RETURN VALUES
+
+    (mixed) Decoded LPML value, or "" if the file is missing or empty
+
+### ERRORS
+
+    If file is not a non-zero length string
+
+### EXAMPLE
+
+    {{di1}}mapping cfg = load_lpml("/d/village/spawn.lpml");{{di0}}

--- a/doc/sefun/log_dir.help
+++ b/doc/sefun/log_dir.help
@@ -1,0 +1,22 @@
+---
+{
+  title: "log_dir"
+}
+---
+### NAME
+
+    log_dir() - Returns the directory where log files are stored as
+    configured by the driver runtime configuration.
+
+### SYNOPSIS
+
+    string log_dir( void );
+
+### DESCRIPTION
+
+    Returns the directory where log files are stored as configured by the
+    driver runtime configuration.
+
+### RETURN VALUES
+
+    (string) The log directory.

--- a/doc/sefun/log_file.help
+++ b/doc/sefun/log_file.help
@@ -1,0 +1,37 @@
+---
+{
+  title: "log_file"
+}
+---
+### NAME
+
+    log_file() - Writes a message to a log file.
+
+### SYNOPSIS
+
+    varargs int log_file( string file, string str, mixed arg... );
+
+### DESCRIPTION
+
+    Writes a message to a log file.
+
+    Routes logging through master object for security.
+
+### PARAMETERS
+
+    file  (string)
+          Log file name
+
+    str   (string)
+          Message to log
+
+    arg   (mixed, optional)
+          Optional formatting arguments
+
+### RETURN VALUES
+
+    (int) 1 on success, 0 on failure
+
+### EXAMPLE
+
+    {{di1}}log_file("system.log", "Server started at %s", ctime());{{di0}}

--- a/doc/sefun/lpml_decode.help
+++ b/doc/sefun/lpml_decode.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "lpml_decode"
+}
+---
+### NAME
+
+    lpml_decode() - Deserializes a LPML string into an LPC value.
+
+### SYNOPSIS
+
+    varargs mixed lpml_decode( string text, string base_path );
+
+### DESCRIPTION
+
+    Deserializes a LPML string into an LPC value.
+
+### PARAMETERS
+
+    text       (string)
+               The LPML string to deserialize.
+
+    base_path  (string)
+               Optional base directory for relative includes
+
+### RETURN VALUES
+
+    (mixed) The deserialized LPC value.

--- a/doc/sefun/lpml_encode.help
+++ b/doc/sefun/lpml_encode.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "lpml_encode"
+}
+---
+### NAME
+
+    lpml_encode() - Serializes an LPC value into JSON text.
+
+### SYNOPSIS
+
+    varargs string lpml_encode( mixed value, mixed* pointers );
+
+### DESCRIPTION
+
+    Serializes an LPC value into JSON text.
+
+### PARAMETERS
+
+    value  (mixed)
+           The LPC value to serialize.
+
+### RETURN VALUES
+
+    (string) The JSON string representation. Note: Encoding produces
+    standard JSON

--- a/doc/sefun/ltime.help
+++ b/doc/sefun/ltime.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "ltime"
+}
+---
+### NAME
+
+    ltime() - Returns a formatted time string.
+
+### SYNOPSIS
+
+    varargs string ltime( int x, int brief );
+
+### DESCRIPTION
+
+    Returns a formatted time string.
+
+### PARAMETERS
+
+    x      (int, optional, default: time())
+           The timestamp to format. Defaults to the current time.
+
+    brief  (int, optional, default: 0)
+           If set to 1, returns a brief time format (HH:MM). Otherwise,
+           returns a full time format (HH:MM:SS).
+
+### RETURN VALUES
+
+    (string) The formatted time string.

--- a/doc/sefun/merge_arrays.help
+++ b/doc/sefun/merge_arrays.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "merge_arrays"
+}
+---
+### NAME
+
+    merge_arrays() - Inserts one array into another array at a specific
+    position.
+
+### SYNOPSIS
+
+    varargs mixed *merge_arrays( mixed *array, mixed *new_array, int at );
+
+### DESCRIPTION
+
+    Inserts one array into another array at a specific position.
+
+### PARAMETERS
+
+    array      (mixed*)
+               The original array
+
+    new_array  (mixed*)
+               The array to insert
+
+    at         (int)
+               The position to insert at
+
+### RETURN VALUES
+
+    (mixed*) New combined array

--- a/doc/sefun/mud_config.help
+++ b/doc/sefun/mud_config.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "mud_config"
+}
+---
+### NAME
+
+    mud_config() - Retrieves a specific configuration value from the MUD
+    config.
+
+### SYNOPSIS
+
+    mixed mud_config( string str );
+
+### DESCRIPTION
+
+    Retrieves a specific configuration value from the MUD config.
+
+    Thin wrapper around `CONFIG_D->get_mud_config`. The key may be a flat
+    top-level key (`"PORT"`) or a dot-separated path into nested mappings
+    (`"RESOURCE.GLOBAL_SPAWN_CHANCE"`); the daemon resolves dotted paths via
+    `dot_walk`.
+
+### PARAMETERS
+
+    str  (string)
+         The configuration key or dot-separated path to retrieve.
+
+### RETURN VALUES
+
+    (mixed) The configuration value.

--- a/doc/sefun/mud_name.help
+++ b/doc/sefun/mud_name.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "mud_name"
+}
+---
+### NAME
+
+    mud_name() - Returns the name of the MUD.
+
+### SYNOPSIS
+
+    string mud_name( void );
+
+### DESCRIPTION
+
+    Returns the name of the MUD.
+
+### RETURN VALUES
+
+    (string) The name of the MUD.

--- a/doc/sefun/no_ansi.help
+++ b/doc/sefun/no_ansi.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "no_ansi"
+}
+---
+### NAME
+
+    no_ansi() - Returns a string with all colour removed.
+
+### SYNOPSIS
+
+    string no_ansi( string str );
+
+### DESCRIPTION
+
+    Returns a string with all colour removed.
+
+### PARAMETERS
+
+    str  (string)
+         The string to remove colour from.
+
+### RETURN VALUES
+
+    (string) The string without colour.

--- a/doc/sefun/npcp.help
+++ b/doc/sefun/npcp.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "npcp"
+}
+---
+### NAME
+
+    npcp() - Returns 1 if the object is an npc, 0 if not.
+
+### SYNOPSIS
+
+    int npcp( object ob );
+
+### DESCRIPTION
+
+    Returns 1 if the object is an npc, 0 if not.
+
+### PARAMETERS
+
+    ob  (STD_NPC)
+        The object to check.
+
+### RETURN VALUES
+
+    (ob is STD_PLAYER) 1 if the object is an npc, otherwise 0.

--- a/doc/sefun/number_word.help
+++ b/doc/sefun/number_word.help
@@ -1,0 +1,36 @@
+---
+{
+  title: "number_word"
+}
+---
+### NAME
+
+    number_word() - Converts a number to its English word representation.
+
+### SYNOPSIS
+
+    string number_word( int num );
+
+### DESCRIPTION
+
+    Converts a number to its English word representation.
+
+    Returns word form for numbers 0-9, string representation for larger
+    numbers. Follows common English style guidelines for number usage in
+    text.
+
+### PARAMETERS
+
+    num  (int)
+         The number to convert
+
+### RETURN VALUES
+
+    (string) Word form for 0-9 ("one", "two", etc) or string for larger
+    numbers
+
+### EXAMPLE
+
+    {{di1}}number_word(1);   // Returns "one"
+    number_word(5);   // Returns "five"
+    number_word(10);  // Returns "10"{{di0}}

--- a/doc/sefun/object_data_directory.help
+++ b/doc/sefun/object_data_directory.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "object_data_directory"
+}
+---
+### NAME
+
+    object_data_directory() - Returns the data directory path for the
+    specified object.
+
+### SYNOPSIS
+
+    string object_data_directory( object ob );
+
+### DESCRIPTION
+
+    Returns the data directory path for the specified object.
+
+### PARAMETERS
+
+    ob  (object)
+        The object to get the data directory for.
+
+### RETURN VALUES
+
+    (string) The data directory path for the object.

--- a/doc/sefun/object_data_file.help
+++ b/doc/sefun/object_data_file.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "object_data_file"
+}
+---
+### NAME
+
+    object_data_file() - Returns the data file path for the specified
+    object.
+
+### SYNOPSIS
+
+    string object_data_file( object ob );
+
+### DESCRIPTION
+
+    Returns the data file path for the specified object.
+
+### PARAMETERS
+
+    ob  (object)
+        The object to get the data file for.
+
+### RETURN VALUES
+
+    (string) The data file path for the object.

--- a/doc/sefun/objective.help
+++ b/doc/sefun/objective.help
@@ -1,0 +1,24 @@
+---
+{
+  title: "objective"
+}
+---
+### NAME
+
+    objective() - Gets the objective pronoun for a gender.
+
+### SYNOPSIS
+
+    string objective( mixed ob );
+
+### DESCRIPTION
+
+    Gets the objective pronoun for a gender.
+
+### RETURN VALUES
+
+    (string) Objective pronoun (him/her/it/them)
+
+### EXAMPLE
+
+    {{di1}}objective("female");  // Returns "her"{{di0}}

--- a/doc/sefun/of.help
+++ b/doc/sefun/of.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "of"
+}
+---
+### NAME
+
+    of() - Checks if a value is present in an array, mapping, or string.
+
+### SYNOPSIS
+
+    int of( mixed needle, mixed haystack );
+
+### DESCRIPTION
+
+    Checks if a value is present in an array, mapping, or string.
+
+### PARAMETERS
+
+    needle    (mixed)
+              The value to search for.
+
+    haystack  (mixed)
+              The array, mapping, or string to search in.
+
+### RETURN VALUES
+
+    (int) 1 if the value is found, 0 otherwise.

--- a/doc/sefun/ofile_exists.help
+++ b/doc/sefun/ofile_exists.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "ofile_exists"
+}
+---
+### NAME
+
+    ofile_exists() - Checks if a save file exists.
+
+### SYNOPSIS
+
+    int ofile_exists( string file );
+
+### DESCRIPTION
+
+    Checks if a save file exists.
+
+    Automatically appends the mud's save extension before checking.
+
+### PARAMETERS
+
+    file  (string)
+          Base path of save file without extension
+
+### RETURN VALUES
+
+    (int) 1 if save file exists, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}if(ofile_exists("/save/players/" + name)) {
+      restore_object("/save/players/" + name);
+    }{{di0}}

--- a/doc/sefun/open_status.help
+++ b/doc/sefun/open_status.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "open_status"
+}
+---
+### NAME
+
+    open_status() - Returns the open status of the MUD.
+
+### SYNOPSIS
+
+    string open_status( void );
+
+### DESCRIPTION
+
+    Returns the open status of the MUD.
+
+### RETURN VALUES
+
+    (string) The open status of the MUD.

--- a/doc/sefun/ordinal.help
+++ b/doc/sefun/ordinal.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "ordinal"
+}
+---
+### NAME
+
+    ordinal() - Converts an integer to its ordinal string representation.
+
+### SYNOPSIS
+
+    string ordinal( int num );
+
+### DESCRIPTION
+
+    Converts an integer to its ordinal string representation.
+
+### PARAMETERS
+
+    num  (int)
+         The integer to convert.
+
+### RETURN VALUES
+
+    (string) The ordinal string representation of the integer.
+
+### ERRORS
+
+    If num is not greater than or equal to 0.

--- a/doc/sefun/ownerp.help
+++ b/doc/sefun/ownerp.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "ownerp"
+}
+---
+### NAME
+
+    ownerp() - Checks if a user has owner privileges. Owner is nested inside
+    admin, so every owner is also an admin, but not every admin is an owner.
+    Use this to guard actions an admin must not perform against an owner
+    (e.g. stripping their access).
+
+### SYNOPSIS
+
+    varargs int ownerp( mixed user );
+
+### DESCRIPTION
+
+    Checks if a user has owner privileges. Owner is nested inside admin, so
+    every owner is also an admin, but not every admin is an owner. Use this
+    to guard actions an admin must not perform against an owner (e.g.
+    stripping their access).
+
+### PARAMETERS
+
+    user  (mixed)
+          The user to check, either as a username string or an object.
+          Defaults to the previous object.
+
+### RETURN VALUES
+
+    (int) 1 if the user has owner privileges, otherwise 0.

--- a/doc/sefun/pad_array.help
+++ b/doc/sefun/pad_array.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "pad_array"
+}
+---
+### NAME
+
+    pad_array() - Extends an array to a specified size by padding with a
+    value.
+
+### SYNOPSIS
+
+    varargs mixed *pad_array( mixed *arr, int sz, mixed val );
+
+### DESCRIPTION
+
+    Extends an array to a specified size by padding with a value.
+
+### PARAMETERS
+
+    arr  (mixed*)
+         Array to pad
+
+    sz   (int)
+         Target size
+
+    val  (mixed, optional, default: UNDEFINED)
+         Value to pad with
+
+### RETURN VALUES
+
+    (mixed*) Padded array

--- a/doc/sefun/pcp.help
+++ b/doc/sefun/pcp.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "pcp"
+}
+---
+### NAME
+
+    pcp() - Returns 1 if the object is a player, 0 if not.
+
+### SYNOPSIS
+
+    int pcp( object ob );
+
+### DESCRIPTION
+
+    Returns 1 if the object is a player, 0 if not.
+
+### PARAMETERS
+
+    ob  (STD_PLAYER)
+        The object to check.
+
+### RETURN VALUES
+
+    (ob is STD_PLAYER) 1 if the object is a player, otherwise 0.

--- a/doc/sefun/pcre_strsrch.help
+++ b/doc/sefun/pcre_strsrch.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "pcre_strsrch"
+}
+---
+### NAME
+
+    pcre_strsrch() - Searches for the position of a substring in a string
+    using a regular expression.
+
+### SYNOPSIS
+
+    varargs int pcre_strsrch( string str, string substr, int reverse );
+
+### DESCRIPTION
+
+    Searches for the position of a substring in a string using a regular
+    expression.
+
+### PARAMETERS
+
+    str      (string)
+             The string to search in.
+
+    substr   (string)
+             The regular expression to search for.
+
+    reverse  (int, optional, default: 0)
+             If set, the search will start from the end of the string.
+
+### RETURN VALUES
+
+    (int) The position of the substring in the string, or -1 if not found.

--- a/doc/sefun/pelement_of.help
+++ b/doc/sefun/pelement_of.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "pelement_of"
+}
+---
+### NAME
+
+    pelement_of() - Selects an element from an array using the xorshift128+
+    algorithm.
+
+### SYNOPSIS
+
+    mixed *pelement_of( mixed seed, mixed *arr );
+
+### DESCRIPTION
+
+    Selects an element from an array using the xorshift128+ algorithm.
+
+### PARAMETERS
+
+    seed  (mixed)
+          The seed for the random number generator.
+
+    arr   (mixed*)
+          The array to select an element from.
+
+### RETURN VALUES
+
+    (mixed*) A two element array where the first element is the updated seed
+    and the second is the selected element.

--- a/doc/sefun/pelement_of_weighted.help
+++ b/doc/sefun/pelement_of_weighted.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "pelement_of_weighted"
+}
+---
+### NAME
+
+    pelement_of_weighted() - Selects an element from a weighted mapping
+    using the xorshift128+ algorithm.
+
+### SYNOPSIS
+
+    mixed *pelement_of_weighted( mixed seed, mapping weights );
+
+### DESCRIPTION
+
+    Selects an element from a weighted mapping using the xorshift128+
+    algorithm.
+
+### PARAMETERS
+
+    seed     (mixed)
+             The seed for the random number generator.
+
+    weights  (mapping)
+             The weighted mapping to select from, where keys are the
+             elements and values are their weights.
+
+### RETURN VALUES
+
+    (mixed*) A two element array where the first element is the updated seed
+    and the second is the selected element.

--- a/doc/sefun/percent.help
+++ b/doc/sefun/percent.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "percent"
+}
+---
+### NAME
+
+    percent() - Calculates what percentage `a` is of `b`.
+
+### SYNOPSIS
+
+    float percent( float a, float b );
+
+### DESCRIPTION
+
+    Calculates what percentage `a` is of `b`.
+
+### PARAMETERS
+
+    a  (float)
+       The part value.
+
+    b  (float)
+       The whole value.
+
+### RETURN VALUES
+
+    (float) The percentage of `a` out of `b`.

--- a/doc/sefun/percent_of.help
+++ b/doc/sefun/percent_of.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "percent_of"
+}
+---
+### NAME
+
+    percent_of() - Calculates what `a%` of `b` is.
+
+### SYNOPSIS
+
+    float percent_of( float a, float b );
+
+### DESCRIPTION
+
+    Calculates what `a%` of `b` is.
+
+### PARAMETERS
+
+    a  (float)
+       The percentage value.
+
+    b  (float)
+       The whole value.
+
+### RETURN VALUES
+
+    (float) The value that is `a` percent of `b`.

--- a/doc/sefun/pipe.help
+++ b/doc/sefun/pipe.help
@@ -1,0 +1,38 @@
+---
+{
+  title: "pipe"
+}
+---
+### NAME
+
+    pipe() - Threads a value through a left-to-right pipeline of functions.
+
+### SYNOPSIS
+
+    mixed pipe( mixed result, function *funcs... );
+
+### DESCRIPTION
+
+    Threads a value through a left-to-right pipeline of functions.
+
+    Each function receives the previous result and returns the next. With no
+    functions supplied, the initial value is evaluated and returned (so a
+    bare function pointer is invoked, while a plain value passes through
+    unchanged).
+
+### PARAMETERS
+
+    result  (mixed)
+            Initial value to thread through the pipeline.
+
+### RETURN VALUES
+
+    (mixed) The final transformed value.
+
+### ERRORS
+
+    If any element in funcs is not a valid function.
+
+### EXAMPLE
+
+    {{di1}}int n = pipe(5, (: $1 * 2 :), (: $1 + 1 :));  // 11{{di0}}

--- a/doc/sefun/pop.help
+++ b/doc/sefun/pop.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "pop"
+}
+---
+### NAME
+
+    pop() - Removes and returns the last element of the array.
+
+### SYNOPSIS
+
+    mixed pop( mixed ref *arr );
+
+### DESCRIPTION
+
+    Removes and returns the last element of the array.
+
+### PARAMETERS
+
+    arr  (mixed*)
+         The array from which to pop an element.
+
+### RETURN VALUES
+
+    (mixed) The last element of the array.

--- a/doc/sefun/port.help
+++ b/doc/sefun/port.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "port"
+}
+---
+### NAME
+
+    port() - Returns the port number the MUD is running on.
+
+### SYNOPSIS
+
+    int port( void );
+
+### DESCRIPTION
+
+    Returns the port number the MUD is running on.
+
+### RETURN VALUES
+
+    (int) The port number.

--- a/doc/sefun/possessive.help
+++ b/doc/sefun/possessive.help
@@ -1,0 +1,24 @@
+---
+{
+  title: "possessive"
+}
+---
+### NAME
+
+    possessive() - Gets the possessive adjective for a gender.
+
+### SYNOPSIS
+
+    string possessive( mixed ob );
+
+### DESCRIPTION
+
+    Gets the possessive adjective for a gender.
+
+### RETURN VALUES
+
+    (string) Possessive adjective (his/her/its/their)
+
+### EXAMPLE
+
+    {{di1}}possessive("female");  // Returns "her"{{di0}}

--- a/doc/sefun/possessive_noun.help
+++ b/doc/sefun/possessive_noun.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "possessive_noun"
+}
+---
+### NAME
+
+    possessive_noun() - Creates the possessive form of a noun.
+
+### SYNOPSIS
+
+    string possessive_noun( mixed ob );
+
+### DESCRIPTION
+
+    Creates the possessive form of a noun.
+
+### RETURN VALUES
+
+    (string) Possessive form ("'s" or "'" depending on ending)
+
+### EXAMPLE
+
+    {{di1}}possessive_noun("James");  // Returns "James'"
+    possessive_noun("cat");    // Returns "cat's"{{di0}}

--- a/doc/sefun/possessive_pronoun.help
+++ b/doc/sefun/possessive_pronoun.help
@@ -1,0 +1,24 @@
+---
+{
+  title: "possessive_pronoun"
+}
+---
+### NAME
+
+    possessive_pronoun() - Gets the possessive pronoun for a gender.
+
+### SYNOPSIS
+
+    string possessive_pronoun( mixed ob );
+
+### DESCRIPTION
+
+    Gets the possessive pronoun for a gender.
+
+### RETURN VALUES
+
+    (string) Possessive pronoun (his/hers/its/theirs)
+
+### EXAMPLE
+
+    {{di1}}possessive_pronoun("female");  // Returns "hers"{{di0}}

--- a/doc/sefun/possessive_proper_noun.help
+++ b/doc/sefun/possessive_proper_noun.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "possessive_proper_noun"
+}
+---
+### NAME
+
+    possessive_proper_noun() - Creates the possessive form of a proper noun.
+
+### SYNOPSIS
+
+    string possessive_proper_noun( mixed ob );
+
+### DESCRIPTION
+
+    Creates the possessive form of a proper noun.
+
+    Always adds "'s" regardless of ending, following proper noun rules.
+
+### RETURN VALUES
+
+    (string) Possessive form with "'s"
+
+### EXAMPLE
+
+    {{di1}}possessive_proper_noun("James");  // Returns "James's"{{di0}}

--- a/doc/sefun/prandom.help
+++ b/doc/sefun/prandom.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "prandom"
+}
+---
+### NAME
+
+    prandom() - Generates a random number within a specified range using the
+    xorshift128+ algorithm.
+
+### SYNOPSIS
+
+    int *prandom( mixed seed, int size );
+
+### DESCRIPTION
+
+    Generates a random number within a specified range using the
+    xorshift128+ algorithm.
+
+### PARAMETERS
+
+    seed  (mixed)
+          The seed for the random number generator.
+
+    size  (int)
+          The upper bound for the random number.
+
+### RETURN VALUES
+
+    (int*) A two element array where the first element is the updated seed
+    and the second is the random number.

--- a/doc/sefun/prandom_clamp.help
+++ b/doc/sefun/prandom_clamp.help
@@ -1,0 +1,34 @@
+---
+{
+  title: "prandom_clamp"
+}
+---
+### NAME
+
+    prandom_clamp() - Generates a random number within a specified range
+    using the xorshift128+ algorithm.
+
+### SYNOPSIS
+
+    mixed *prandom_clamp( mixed seed, int min, int max );
+
+### DESCRIPTION
+
+    Generates a random number within a specified range using the
+    xorshift128+ algorithm.
+
+### PARAMETERS
+
+    seed  (mixed)
+          The seed for the random number generator.
+
+    min   (int)
+          The lower bound (inclusive) of the range.
+
+    max   (int)
+          The upper bound (inclusive) of the range.
+
+### RETURN VALUES
+
+    (mixed*) A two element array where the first element is the updated seed
+    and the second is the random number.

--- a/doc/sefun/prandom_float.help
+++ b/doc/sefun/prandom_float.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "prandom_float"
+}
+---
+### NAME
+
+    prandom_float() - Generates a random float within a specified range
+    using the xorshift128+ algorithm.
+
+### SYNOPSIS
+
+    mixed *prandom_float( mixed seed, float size );
+
+### DESCRIPTION
+
+    Generates a random float within a specified range using the xorshift128+
+    algorithm.
+
+### PARAMETERS
+
+    seed  (mixed)
+          The seed for the random number generator.
+
+    size  (float)
+          The upper bound for the random float.
+
+### RETURN VALUES
+
+    (mixed*) A two element array where the first element is the updated seed
+    and the second is the random float.

--- a/doc/sefun/prepend.help
+++ b/doc/sefun/prepend.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "prepend"
+}
+---
+### NAME
+
+    prepend() - Prepends a string to another string if it is not already
+    there. If the string is already present, the original string is
+    returned.
+
+### SYNOPSIS
+
+    string prepend( string source, string to_prepend );
+
+### DESCRIPTION
+
+    Prepends a string to another string if it is not already there. If the
+    string is already present, the original string is returned.
+
+### PARAMETERS
+
+    source      (string)
+                The string to prepend to.
+
+    to_prepend  (string)
+                The string to prepend.
+
+### RETURN VALUES
+
+    (string) The original string with the prepended string if it was not
+    already present.

--- a/doc/sefun/present_clones.help
+++ b/doc/sefun/present_clones.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "present_clones"
+}
+---
+### NAME
+
+    present_clones() - Retrieves all clones of the specified file present in
+    the specified container. If the file is an object, it will retrieve all
+    clones using the object's base name.
+
+### SYNOPSIS
+
+    object *present_clones( mixed file, object container );
+
+### DESCRIPTION
+
+    Retrieves all clones of the specified file present in the specified
+    container. If the file is an object, it will retrieve all clones using
+    the object's base name.
+
+    If container is not provided, will default to previous_object().
+
+### PARAMETERS
+
+    file  (string|object)
+          The file or object to look for clones of in a container.
+
+### RETURN VALUES
+
+    (object*) An array of clones of the specified file present in the
+    container.

--- a/doc/sefun/present_livings.help
+++ b/doc/sefun/present_livings.help
@@ -1,0 +1,21 @@
+---
+{
+  title: "present_livings"
+}
+---
+### NAME
+
+    present_livings() - Retrieves all living objects present in the
+    specified room.
+
+### SYNOPSIS
+
+    object *present_livings( object room );
+
+### DESCRIPTION
+
+    Retrieves all living objects present in the specified room.
+
+### RETURN VALUES
+
+    (STD_BODY*) An array of living objects present in the room.

--- a/doc/sefun/present_npcs.help
+++ b/doc/sefun/present_npcs.help
@@ -1,0 +1,22 @@
+---
+{
+  title: "present_npcs"
+}
+---
+### NAME
+
+    present_npcs() - Retrieves all non-player characters (NPCs) present in
+    the specified room.
+
+### SYNOPSIS
+
+    object *present_npcs( object room );
+
+### DESCRIPTION
+
+    Retrieves all non-player characters (NPCs) present in the specified
+    room.
+
+### RETURN VALUES
+
+    (object STD_NPC*) An array of NPC objects present in the room.

--- a/doc/sefun/present_players.help
+++ b/doc/sefun/present_players.help
@@ -1,0 +1,21 @@
+---
+{
+  title: "present_players"
+}
+---
+### NAME
+
+    present_players() - Retrieves all player objects present in the
+    specified room.
+
+### SYNOPSIS
+
+    object *present_players( object room );
+
+### DESCRIPTION
+
+    Retrieves all player objects present in the specified room.
+
+### RETURN VALUES
+
+    (object STD_PLAYER*) An array of player objects present in the room.

--- a/doc/sefun/pretty_map.help
+++ b/doc/sefun/pretty_map.help
@@ -1,0 +1,27 @@
+---
+{
+  title: "pretty_map"
+}
+---
+### NAME
+
+    pretty_map() - Returns a formatted string representation of a mapping,
+    removing any size annotations.
+
+### SYNOPSIS
+
+    string pretty_map( mapping map );
+
+### DESCRIPTION
+
+    Returns a formatted string representation of a mapping, removing any
+    size annotations.
+
+### PARAMETERS
+
+    map  (mapping)
+         The mapping to format.
+
+### RETURN VALUES
+
+    (string) The formatted string representation of the mapping.

--- a/doc/sefun/prompt_colour.help
+++ b/doc/sefun/prompt_colour.help
@@ -1,0 +1,49 @@
+---
+{
+  title: "prompt_colour"
+}
+---
+### NAME
+
+    prompt_colour() - Prompts a player to choose a colour. Presents the
+    configured base palette and accepts:
+
+### SYNOPSIS
+
+    varargs void prompt_colour( object body, mixed *cb, string prompt );
+
+### DESCRIPTION
+
+    Prompts a player to choose a colour. Presents the configured base
+    palette and accepts:
+
+    - A named colour from the palette - A numeric index 0-255 - A hex code
+    prefixed with `#` - `c` to display the full colour list - `p` or `plain`
+    for no colour - `q` or `quit` to cancel
+
+    The chosen value is delivered through the callback.
+
+### PARAMETERS
+
+    body    (STD_PLAYER)
+            The player to prompt.
+
+    cb      (mixed*)
+            Callback array (assembled via assemble_call_back) invoked with
+            the chosen colour code in `{{...}}` form for hex or named
+            selections, the literal `"plain"` for no colour, or `"cancel"`
+            if the player quit.
+
+    prompt  (string, optional)
+            Custom prompt header. Defaults to "Select a colour from the
+            following list:".
+
+### ERRORS
+
+    If body is not a player, or cb is not an array.
+
+### EXAMPLE
+
+    {{di1}}prompt_colour(this_body(), assemble_call_back(
+        this_object(), "colour_callback", this_body()
+    ));{{di0}}

--- a/doc/sefun/prompt_password.help
+++ b/doc/sefun/prompt_password.help
@@ -1,0 +1,40 @@
+---
+{
+  title: "prompt_password"
+}
+---
+### NAME
+
+    prompt_password() - Prompts a player for a password and verifies it
+    against the stored hash via ACCOUNT_D. Echo and escape sequences are
+    suppressed during input. The result is delivered through the callback: 1
+    on a match, 0 if the player exhausts their attempts.
+
+### SYNOPSIS
+
+    void prompt_password( object body, int attempts, mixed *cb );
+
+### DESCRIPTION
+
+    Prompts a player for a password and verifies it against the stored hash
+    via ACCOUNT_D. Echo and escape sequences are suppressed during input.
+    The result is delivered through the callback: 1 on a match, 0 if the
+    player exhausts their attempts.
+
+### PARAMETERS
+
+    body      (STD_PLAYER)
+              The player to prompt.
+
+    attempts  (int)
+              Number of tries allowed before the callback fires with 0.
+
+    cb        (mixed*)
+              Callback array (assembled via assemble_call_back) invoked with
+              1 on success or 0 on exhausted attempts.
+
+### EXAMPLE
+
+    {{di1}}prompt_password(this_body(), 3, assemble_call_back(
+        this_object(), "password_callback", this_body()
+    ));{{di0}}

--- a/doc/sefun/pshuffle.help
+++ b/doc/sefun/pshuffle.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "pshuffle"
+}
+---
+### NAME
+
+    pshuffle() - Shuffles an array using the xorshift128+ algorithm.
+
+### SYNOPSIS
+
+    mixed *pshuffle( mixed seed, mixed *arr );
+
+### DESCRIPTION
+
+    Shuffles an array using the xorshift128+ algorithm.
+
+### PARAMETERS
+
+    seed  (mixed)
+          The seed for the random number generator.
+
+    arr   (mixed*)
+          The array to shuffle.
+
+### RETURN VALUES
+
+    (mixed*) A two element array where the first element is the updated seed
+    and the second is the shuffled array.

--- a/doc/sefun/push.help
+++ b/doc/sefun/push.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "push"
+}
+---
+### NAME
+
+    push() - Adds a new element to the end of the array and returns the new
+    size of the array.
+
+### SYNOPSIS
+
+    int push( mixed ref *arr, mixed value );
+
+### DESCRIPTION
+
+    Adds a new element to the end of the array and returns the new size of
+    the array.
+
+### PARAMETERS
+
+    arr    (mixed*)
+           The array to which to push an element.
+
+    value  (mixed)
+           The element to push onto the array.
+
+### RETURN VALUES
+
+    (int) The new size of the array.

--- a/doc/sefun/query_directory.help
+++ b/doc/sefun/query_directory.help
@@ -1,0 +1,36 @@
+---
+{
+  title: "query_directory"
+}
+---
+### NAME
+
+    query_directory() - Gets the directory portion of an object's file path.
+
+### SYNOPSIS
+
+    varargs string query_directory( object ob );
+
+### DESCRIPTION
+
+    Gets the directory portion of an object's file path.
+
+    Returns a directory path with leading and trailing slashes. Uses
+    previous_object() if no object is provided.
+
+### PARAMETERS
+
+    ob  (object, optional)
+        Object to get directory for
+
+### RETURN VALUES
+
+    (string) Directory path with both leading and trailing slash
+
+### ERRORS
+
+    If no valid object is available
+
+### EXAMPLE
+
+    {{di1}}string dir = query_directory(sword);  // Returns "/obj/weapon/"{{di0}}

--- a/doc/sefun/query_file_name.help
+++ b/doc/sefun/query_file_name.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "query_file_name"
+}
+---
+### NAME
+
+    query_file_name() - Gets filename portion of an object's path.
+
+### SYNOPSIS
+
+    varargs string query_file_name( object ob );
+
+### DESCRIPTION
+
+    Gets filename portion of an object's path.
+
+### PARAMETERS
+
+    ob  (object, optional)
+        Object to query, defaults to previous_object()
+
+### RETURN VALUES
+
+    (string) Base filename without path
+
+### ERRORS
+
+    If no valid object available
+
+### EXAMPLE
+
+    {{di1}}string name = query_file_name(this_object());  // Returns "room.c"{{di0}}

--- a/doc/sefun/query_num.help
+++ b/doc/sefun/query_num.help
@@ -1,0 +1,24 @@
+---
+{
+  title: "query_num"
+}
+---
+### NAME
+
+    query_num()
+
+### SYNOPSIS
+
+    varargs string query_num( int x, int many );
+
+### PARAMETERS
+
+    x     (int)
+          The number to convert to a string.
+
+    many  (int)
+          If true, the number will be returned in plural form.
+
+### RETURN VALUES
+
+    (string) The number in string form.

--- a/doc/sefun/random_clamp.help
+++ b/doc/sefun/random_clamp.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "random_clamp"
+}
+---
+### NAME
+
+    random_clamp() - Generates a random integer within a specified range.
+
+### SYNOPSIS
+
+    int random_clamp( int min, int max );
+
+### DESCRIPTION
+
+    Generates a random integer within a specified range.
+
+### PARAMETERS
+
+    min  (int)
+         The lower bound (inclusive) of the range.
+
+    max  (int)
+         The upper bound (inclusive) of the range.
+
+### RETURN VALUES
+
+    (int) A random number in the specified range.

--- a/doc/sefun/random_float.help
+++ b/doc/sefun/random_float.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "random_float"
+}
+---
+### NAME
+
+    random_float() - Generates a random float between 0 and upper_bound.
+
+### SYNOPSIS
+
+    float random_float( mixed upper_bound );
+
+### DESCRIPTION
+
+    Generates a random float between 0 and upper_bound.
+
+### PARAMETERS
+
+    upper_bound  (mixed)
+                 The upper bound for the random float.
+
+### RETURN VALUES
+
+    (float) The random float between 0 and upper_bound.

--- a/doc/sefun/read_directory.help
+++ b/doc/sefun/read_directory.help
@@ -1,0 +1,43 @@
+---
+{
+  title: "read_directory"
+}
+---
+### NAME
+
+    read_directory() - Reads a directory and returns its contents
+    partitioned into files and subdirectories.
+
+### SYNOPSIS
+
+    varargs mapping read_directory( string directory, string pattern );
+
+### DESCRIPTION
+
+    Reads a directory and returns its contents partitioned into files and
+    subdirectories.
+
+    Each entry is a mapping carrying the bare name split into
+    base/extension, the full path, and metadata. File entries include size
+    and access time; directory entries include access time only. If a
+    pattern is supplied it is appended to the directory and passed through
+    to get_dir(), so standard wildcard matching applies (e.g. "*.c").
+
+### PARAMETERS
+
+    directory  (string)
+               Path to an existing directory
+
+    pattern    (string, optional)
+               Optional glob pattern appended to the directory
+
+### RETURN VALUES
+
+    (mapping) ([ "files": ({ ([ "name", "base", "ext", "path", "size",
+    "accessed" ]) ... }), "directories": ({ ([ "name", "base", "ext",
+    "path", "accessed" ]) ... }), ])
+
+### EXAMPLE
+
+    {{di1}}mapping listing = read_directory("/cmds/object");
+    mapping lpc_only = read_directory("/cmds/object", "*.lpc");{{di0}}

--- a/doc/sefun/recursive_delete.help
+++ b/doc/sefun/recursive_delete.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "recursive_delete"
+}
+---
+### NAME
+
+    recursive_delete() - Recursively deletes a directory's contents, and
+    optionally the directory itself.
+
+### SYNOPSIS
+
+    void recursive_delete( mapping dir, int include_self: (: 0 :) );
+
+### DESCRIPTION
+
+    Recursively deletes a directory's contents, and optionally the directory
+    itself.
+
+### PARAMETERS
+
+    dir           (mapping)
+                  A directory entry as produced by as_directory()
+
+    include_self  (int, optional, default: 0)
+                  When true, remove the directory itself once it has been
+                  emptied
+
+### ERRORS
+
+    If dir["path"] is not an existing directory (propagated from
+    read_directory()), or if a listed entry no longer exists when rm() is
+    called on it.

--- a/doc/sefun/reduce.help
+++ b/doc/sefun/reduce.help
@@ -1,0 +1,45 @@
+---
+{
+  title: "reduce"
+}
+---
+### NAME
+
+    reduce() - Reduces an array to a single value by applying a function to
+    each element. The function accumulates a result as it processes each
+    element.
+
+### SYNOPSIS
+
+    varargs mixed reduce( mixed *arr, function fun, mixed init, mixed arg... );
+
+### DESCRIPTION
+
+    Reduces an array to a single value by applying a function to each
+    element. The function accumulates a result as it processes each element.
+
+### PARAMETERS
+
+    arr   (mixed*)
+          Array to reduce
+
+    fun   (function)
+          Function taking (accumulator, current_value, index, array, ...arg)
+
+    init  (mixed, optional, default: arr[0])
+          Initial value for accumulator
+
+    arg   (mixed, optional)
+          Additional arguments passed to the callback starting at $5
+
+### RETURN VALUES
+
+    (mixed) Final accumulated value
+
+### EXAMPLE
+
+    {{di1}}int *nums = ({1, 2, 3, 4});
+    // Sum all numbers
+    int sum = reduce(nums, (: $1 + $2 :), 0);
+    // Multiply all numbers
+    int product = reduce(nums, (: $1 * $2 :), 1);{{di0}}

--- a/doc/sefun/reflexive.help
+++ b/doc/sefun/reflexive.help
@@ -1,0 +1,24 @@
+---
+{
+  title: "reflexive"
+}
+---
+### NAME
+
+    reflexive() - Gets the reflexive pronoun for a gender.
+
+### SYNOPSIS
+
+    string reflexive( mixed ob );
+
+### DESCRIPTION
+
+    Gets the reflexive pronoun for a gender.
+
+### RETURN VALUES
+
+    (string) Reflexive pronoun (himself/herself/itself/themself)
+
+### EXAMPLE
+
+    {{di1}}reflexive("female");  // Returns "herself"{{di0}}

--- a/doc/sefun/remainder.help
+++ b/doc/sefun/remainder.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "remainder"
+}
+---
+### NAME
+
+    remainder() - Calculates the remainder of `a` divided by `b`.
+
+### SYNOPSIS
+
+    varargs float remainder( mixed a, mixed b );
+
+### DESCRIPTION
+
+    Calculates the remainder of `a` divided by `b`.
+
+### PARAMETERS
+
+    a  (mixed)
+       The dividend.
+
+    b  (mixed)
+       The divisor.
+
+### RETURN VALUES
+
+    (float) The floored remainder of `a` divided by `b`.

--- a/doc/sefun/remove_array_element.help
+++ b/doc/sefun/remove_array_element.help
@@ -1,0 +1,38 @@
+---
+{
+  title: "remove_array_element"
+}
+---
+### NAME
+
+    remove_array_element() - Returns a new array containing the elements of
+    the input array from index 0 to start-1, and from end+1 to the end of
+    the input array. If start is greater than end, the new array will
+    contain all the elements of the input array.
+
+### SYNOPSIS
+
+    varargs mixed *remove_array_element( mixed *arr, int start, int end );
+
+### DESCRIPTION
+
+    Returns a new array containing the elements of the input array from
+    index 0 to start-1, and from end+1 to the end of the input array. If
+    start is greater than end, the new array will contain all the elements
+    of the input array.
+
+### PARAMETERS
+
+    arr    (mixed*)
+           The input array.
+
+    start  (int)
+           The starting index of elements to be removed.
+
+    end    (int)
+           The ending index of elements to be removed. Defaults to start if
+           not specified.
+
+### RETURN VALUES
+
+    (mixed*) A new array with specified elements removed.

--- a/doc/sefun/remove_article.help
+++ b/doc/sefun/remove_article.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "remove_article"
+}
+---
+### NAME
+
+    remove_article() - Removes leading article from string if present.
+
+### SYNOPSIS
+
+    string remove_article( string str );
+
+### DESCRIPTION
+
+    Removes leading article from string if present.
+
+### PARAMETERS
+
+    str  (string)
+         String to process
+
+### RETURN VALUES
+
+    (string) String with any leading article removed
+
+### EXAMPLE
+
+    {{di1}}remove_article("the bear");  // Returns "bear"
+    remove_article("an apple");  // Returns "apple"{{di0}}

--- a/doc/sefun/resolve_dir.help
+++ b/doc/sefun/resolve_dir.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "resolve_dir"
+}
+---
+### NAME
+
+    resolve_dir() - Resolves a directory path without checking its
+    existence, ensuring it ends with a slash.
+
+### SYNOPSIS
+
+    string resolve_dir( string base_dir, string path );
+
+### DESCRIPTION
+
+    Resolves a directory path without checking its existence, ensuring it
+    ends with a slash.
+
+### PARAMETERS
+
+    base_dir  (string)
+              The base directory to resolve relative paths from.
+
+    path      (string)
+              The directory path to resolve.
+
+### RETURN VALUES
+
+    (string) The resolved absolute directory path, ending with a slash.

--- a/doc/sefun/resolve_file.help
+++ b/doc/sefun/resolve_file.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "resolve_file"
+}
+---
+### NAME
+
+    resolve_file() - Resolves a file path without checking its existence.
+
+### SYNOPSIS
+
+    string resolve_file( string base_dir, string path );
+
+### DESCRIPTION
+
+    Resolves a file path without checking its existence.
+
+### PARAMETERS
+
+    base_dir  (string)
+              The base directory to resolve relative paths from.
+
+    path      (string)
+              The file path to resolve.
+
+### RETURN VALUES
+
+    (string) The resolved absolute file path.

--- a/doc/sefun/resolve_path.help
+++ b/doc/sefun/resolve_path.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "resolve_path"
+}
+---
+### NAME
+
+    resolve_path() - Resolves a given path relative to the current path,
+    handling special cases such as user directories and relative paths.
+
+### SYNOPSIS
+
+    string resolve_path( string base_dir, string path );
+
+### DESCRIPTION
+
+    Resolves a given path relative to the current path, handling special
+    cases such as user directories and relative paths.
+
+### PARAMETERS
+
+    base_dir  (string)
+              The current path.
+
+    path      (string)
+              The next path to resolve.
+
+### RETURN VALUES
+
+    (string) The resolved absolute path.

--- a/doc/sefun/reverse_array.help
+++ b/doc/sefun/reverse_array.help
@@ -1,0 +1,37 @@
+---
+{
+  title: "reverse_array"
+}
+---
+### NAME
+
+    reverse_array() - Creates a new array with elements in reverse order. If
+    'in_place' is non-zero, the array will be mutated in place rather than
+    returning a reversed copy.
+
+### SYNOPSIS
+
+    varargs mixed *reverse_array( mixed *elements, int in_place );
+
+### DESCRIPTION
+
+    Creates a new array with elements in reverse order. If 'in_place' is
+    non-zero, the array will be mutated in place rather than returning a
+    reversed copy.
+
+### PARAMETERS
+
+    elements  (mixed*)
+              Array to reverse
+
+    in_place  (int, optional)
+              Whether to mutate the original array.
+
+### RETURN VALUES
+
+    (mixed*) New array with elements in reverse order
+
+### EXAMPLE
+
+    {{di1}}mixed *nums = ({1, 2, 3, 4});
+    nums = reverse_array(nums); // Returns ({4, 3, 2, 1}){{di0}}

--- a/doc/sefun/reverse_string.help
+++ b/doc/sefun/reverse_string.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "reverse_string"
+}
+---
+### NAME
+
+    reverse_string() - Reverses a string.
+
+### SYNOPSIS
+
+    string reverse_string( string str );
+
+### DESCRIPTION
+
+    Reverses a string.
+
+### PARAMETERS
+
+    str  (string)
+         The string to reverse.
+
+### RETURN VALUES
+
+    (string) The reversed string.

--- a/doc/sefun/reverse_strsrch.help
+++ b/doc/sefun/reverse_strsrch.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "reverse_strsrch"
+}
+---
+### NAME
+
+    reverse_strsrch() - Searches for a substring in a string starting from a
+    given position and moving backwards.
+
+### SYNOPSIS
+
+    varargs int reverse_strsrch( string str, string sub, int start );
+
+### DESCRIPTION
+
+    Searches for a substring in a string starting from a given position and
+    moving backwards.
+
+### PARAMETERS
+
+    str    (string)
+           The string to search in.
+
+    sub    (string)
+           The substring to search for.
+
+    start  (int, optional, default: -1)
+           The starting position to search from.
+
+### RETURN VALUES
+
+    (int) The position of the substring in the string, or -1 if not found.

--- a/doc/sefun/roomp.help
+++ b/doc/sefun/roomp.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "roomp"
+}
+---
+### NAME
+
+    roomp() - Determine if an object is a room or not.
+
+### SYNOPSIS
+
+    int roomp( object ob );
+
+### DESCRIPTION
+
+    Determine if an object is a room or not.
+
+### PARAMETERS
+
+    ob  (object)
+        The object to test.
+
+### RETURN VALUES
+
+    (ob as STD_ROOM) 1 if the object is a room, otherwise 0.

--- a/doc/sefun/same_array.help
+++ b/doc/sefun/same_array.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "same_array"
+}
+---
+### NAME
+
+    same_array() - Checks if two arrays contain the same elements.
+
+### SYNOPSIS
+
+    varargs int same_array( mixed *one, mixed *two, int exact );
+
+### DESCRIPTION
+
+    Checks if two arrays contain the same elements.
+
+### PARAMETERS
+
+    one    (mixed*)
+           First array to compare
+
+    two    (mixed*)
+           Second array to compare
+
+    exact  (int, optional, default: 0)
+           If 1, checks for exact match including order
+
+### RETURN VALUES
+
+    (int) 1 if arrays match, 0 if not

--- a/doc/sefun/same_env_check.help
+++ b/doc/sefun/same_env_check.help
@@ -1,0 +1,36 @@
+---
+{
+  title: "same_env_check"
+}
+---
+### NAME
+
+    same_env_check() - This simul_efun will return 1 if the two objects are
+    in the same environment, or 0 if they are not.
+
+### SYNOPSIS
+
+    varargs int same_env_check( object one, object two, int top_env );
+
+### DESCRIPTION
+
+    This simul_efun will return 1 if the two objects are in the same
+    environment, or 0 if they are not.
+
+    If top_env is set to 1, the simul_efun will check if the two objects
+    share the same top-level environment.
+
+### PARAMETERS
+
+    one      (object)
+             The first object to compare.
+
+    two      (object)
+             The second object to compare.
+
+    top_env  (int)
+             Whether to check the top-level environment.
+
+### RETURN VALUES
+
+    (int) 1 if the objects are in the same environment, 0 otherwise.

--- a/doc/sefun/sanitize_seed.help
+++ b/doc/sefun/sanitize_seed.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "sanitize_seed"
+}
+---
+### NAME
+
+    sanitize_seed() - Sanitizes the seed for the random number generator.
+    Ensuring that the seed is a non-zero integer and within the range of a
+    64-bit unsigned integer.
+
+### SYNOPSIS
+
+    public int *sanitize_seed( mixed seed );
+
+### DESCRIPTION
+
+    Sanitizes the seed for the random number generator. Ensuring that the
+    seed is a non-zero integer and within the range of a 64-bit unsigned
+    integer.
+
+### PARAMETERS
+
+    seed  (mixed)
+          The seed to sanitize.
+
+### RETURN VALUES
+
+    (int*) The sanitized seed.

--- a/doc/sefun/seq_clear.help
+++ b/doc/sefun/seq_clear.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "seq_clear"
+}
+---
+### NAME
+
+    seq_clear() - Removes all key-value pairs from a sequential map. This
+    mirrors JavaScript Map.clear() behavior.
+
+### SYNOPSIS
+
+    void seq_clear( mixed ref *map );
+
+### DESCRIPTION
+
+    Removes all key-value pairs from a sequential map. This mirrors
+    JavaScript Map.clear() behavior.
+
+### PARAMETERS
+
+    map  (mixed)
+         The sequential map to clear
+
+### EXAMPLE
+
+    {{di1}}mixed *usermap = ({{"alice", 25}, {"bob", 30}});
+    seq_clear(ref usermap); // Returns 0, map becomes ({}){{di0}}

--- a/doc/sefun/seq_delete.help
+++ b/doc/sefun/seq_delete.help
@@ -1,0 +1,36 @@
+---
+{
+  title: "seq_delete"
+}
+---
+### NAME
+
+    seq_delete() - Removes a key-value pair from a sequential map. This
+    mirrors JavaScript Map.delete() behavior.
+
+### SYNOPSIS
+
+    int seq_delete( mixed ref *map, mixed key );
+
+### DESCRIPTION
+
+    Removes a key-value pair from a sequential map. This mirrors JavaScript
+    Map.delete() behavior.
+
+### PARAMETERS
+
+    map  (mixed*)
+         The sequential map to modify
+
+    key  (mixed)
+         The key to remove
+
+### RETURN VALUES
+
+    (int) 1 if key was found and removed, 0 if key didn't exist
+
+### EXAMPLE
+
+    {{di1}}mixed *usermap = ({{"alice", 25}, {"bob", 30}, {"charlie", 35}});
+    seq_delete(ref usermap, "bob"); // Returns 1, removes bob
+    seq_delete(ref usermap, "david"); // Returns 0, key didn't exist{{di0}}

--- a/doc/sefun/seq_from_mapping.help
+++ b/doc/sefun/seq_from_mapping.help
@@ -1,0 +1,44 @@
+---
+{
+  title: "seq_from_mapping"
+}
+---
+### NAME
+
+    seq_from_mapping() - Converts a mapping to a sequential map (array of
+    key-value pairs). This utility function creates a sequential map from an
+    existing LPC mapping, preserving all key-value associations. The
+    resulting sequential map maintains insertion order and can be used with
+    the seq_* family of functions.
+
+### SYNOPSIS
+
+    mixed *seq_from_mapping( mapping m );
+
+### DESCRIPTION
+
+    Converts a mapping to a sequential map (array of key-value pairs). This
+    utility function creates a sequential map from an existing LPC mapping,
+    preserving all key-value associations. The resulting sequential map
+    maintains insertion order and can be used with the seq_* family of
+    functions.
+
+### PARAMETERS
+
+    m  (mapping)
+       The mapping to convert
+
+### RETURN VALUES
+
+    (mixed*) A sequential map containing all key-value pairs from the
+    mapping
+
+### EXAMPLE
+
+    {{di1}}mapping stats = (["hp":100, "sp":50, "ep":75]);
+    mixed *seq = seq_from_mapping(stats);
+    // Results in: ({{"hp", 100}, {"sp", 50}, {"ep", 75}})
+
+    // Can now use sequential map functions
+    seq_set(ref seq, "mp", 25);
+    int hp = seq_get(seq, "hp"); // Returns 100{{di0}}

--- a/doc/sefun/seq_get.help
+++ b/doc/sefun/seq_get.help
@@ -1,0 +1,36 @@
+---
+{
+  title: "seq_get"
+}
+---
+### NAME
+
+    seq_get() - Gets the value associated with a key in a sequential map.
+    This mirrors JavaScript Map.get() behavior.
+
+### SYNOPSIS
+
+    mixed seq_get( mixed *map, mixed key );
+
+### DESCRIPTION
+
+    Gets the value associated with a key in a sequential map. This mirrors
+    JavaScript Map.get() behavior.
+
+### PARAMETERS
+
+    map  (mixed*)
+         The sequential map to search
+
+    key  (mixed)
+         The key to look for
+
+### RETURN VALUES
+
+    (mixed) The value associated with the key, or null if not found
+
+### EXAMPLE
+
+    {{di1}}mixed *usermap = ({{"alice", 25}, {"bob", 30}});
+    int age = seq_get(usermap, "alice"); // Returns 25
+    int unknown = seq_get(usermap, "charlie"); // Returns 0{{di0}}

--- a/doc/sefun/seq_has.help
+++ b/doc/sefun/seq_has.help
@@ -1,0 +1,37 @@
+---
+{
+  title: "seq_has"
+}
+---
+### NAME
+
+    seq_has() - Checks if a key exists in a sequential map. This mirrors
+    JavaScript Map.has() behavior.
+
+### SYNOPSIS
+
+    int seq_has( mixed *map, mixed key );
+
+### DESCRIPTION
+
+    Checks if a key exists in a sequential map. This mirrors JavaScript
+    Map.has() behavior.
+
+### PARAMETERS
+
+    map  (mixed*)
+         The sequential map to search
+
+    key  (mixed)
+         The key to look for
+
+### RETURN VALUES
+
+    (int) 1 if key exists, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}mixed *usermap = ({{"alice", 25}, {"bob", 30}});
+    if(seq_has(usermap, "alice")) {
+      write("Alice is in the map!\n");
+    }{{di0}}

--- a/doc/sefun/seq_keys.help
+++ b/doc/sefun/seq_keys.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "seq_keys"
+}
+---
+### NAME
+
+    seq_keys() - Gets all keys from a sequential map. This mirrors
+    JavaScript Map.keys() behavior.
+
+### SYNOPSIS
+
+    mixed *seq_keys( mixed *map );
+
+### DESCRIPTION
+
+    Gets all keys from a sequential map. This mirrors JavaScript Map.keys()
+    behavior.
+
+### PARAMETERS
+
+    map  (mixed*)
+         The sequential map to extract keys from
+
+### RETURN VALUES
+
+    (mixed*) Array of all keys
+
+### EXAMPLE
+
+    {{di1}}mixed *usermap = ({{"alice", 25}, {"bob", 30}});
+    mixed *keys = seq_keys(usermap); // Returns ({"alice", "bob"}){{di0}}

--- a/doc/sefun/seq_set.help
+++ b/doc/sefun/seq_set.help
@@ -1,0 +1,40 @@
+---
+{
+  title: "seq_set"
+}
+---
+### NAME
+
+    seq_set() - Sets a key-value pair in a sequential map. Creates new entry
+    or updates existing. This mirrors JavaScript Map.set() behavior - always
+    succeeds.
+
+### SYNOPSIS
+
+    int seq_set( mixed ref *map, mixed key, mixed value );
+
+### DESCRIPTION
+
+    Sets a key-value pair in a sequential map. Creates new entry or updates
+    existing. This mirrors JavaScript Map.set() behavior - always succeeds.
+
+### PARAMETERS
+
+    map    (mixed*)
+           The sequential map to modify (array of {key, value} pairs)
+
+    key    (mixed)
+           The key to set
+
+    value  (mixed)
+           The value to associate with the key
+
+### RETURN VALUES
+
+    (int) The size of the sequential map after the operation
+
+### EXAMPLE
+
+    {{di1}}mixed *usermap = ({{"alice", 25}, {"bob", 30}});
+    seq_set(ref usermap, "alice", 26); // Updates alice to 26, returns 2
+    seq_set(ref usermap, "charlie", 35); // Adds charlie, returns 3{{di0}}

--- a/doc/sefun/seq_to_mapping.help
+++ b/doc/sefun/seq_to_mapping.help
@@ -1,0 +1,42 @@
+---
+{
+  title: "seq_to_mapping"
+}
+---
+### NAME
+
+    seq_to_mapping() - Converts a sequential map to a mapping. This utility
+    function creates an LPC mapping from a sequential map, converting the
+    array of key-value pairs back to the standard mapping format. This is
+    useful for interoperability with existing code that expects mappings.
+
+### SYNOPSIS
+
+    mapping seq_to_mapping( mixed *map );
+
+### DESCRIPTION
+
+    Converts a sequential map to a mapping. This utility function creates an
+    LPC mapping from a sequential map, converting the array of key-value
+    pairs back to the standard mapping format. This is useful for
+    interoperability with existing code that expects mappings.
+
+### PARAMETERS
+
+    map  (mixed*)
+         The sequential map to convert (array of key-value pairs)
+
+### RETURN VALUES
+
+    (mapping) A mapping containing all key-value pairs from the sequential
+    map
+
+### EXAMPLE
+
+    {{di1}}mixed *seq = ({{"name", "sword"}, {"damage", 15}, {"weight", 5}});
+    mapping item_data = seq_to_mapping(seq);
+    // Results in: (["name":"sword", "damage":15, "weight":5])
+
+    // Can now use standard mapping operations
+    string name = item_data["name"]; // Returns "sword"
+    item_data["enchanted"] = 1;{{di0}}

--- a/doc/sefun/seq_values.help
+++ b/doc/sefun/seq_values.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "seq_values"
+}
+---
+### NAME
+
+    seq_values() - Gets all values from a sequential map. This mirrors
+    JavaScript Map.values() behavior.
+
+### SYNOPSIS
+
+    mixed *seq_values( mixed *map );
+
+### DESCRIPTION
+
+    Gets all values from a sequential map. This mirrors JavaScript
+    Map.values() behavior.
+
+### PARAMETERS
+
+    map  (mixed*)
+         The sequential map to extract values from
+
+### RETURN VALUES
+
+    (mixed*) Array of all values
+
+### EXAMPLE
+
+    {{di1}}mixed *usermap = ({{"alice", 25}, {"bob", 30}});
+    mixed *values = seq_values(usermap); // Returns ({25, 30}){{di0}}

--- a/doc/sefun/set_privs.help
+++ b/doc/sefun/set_privs.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "set_privs"
+}
+---
+### NAME
+
+    set_privs()
+
+### SYNOPSIS
+
+    void set_privs( object ob, string privs );
+
+### PARAMETERS
+
+    ob     (object)
+           The object to set privileges on
+
+    privs  (string)
+           The privilege string to assign

--- a/doc/sefun/set_push.help
+++ b/doc/sefun/set_push.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "set_push"
+}
+---
+### NAME
+
+    set_push() - Adds a value to the end of an array only if it doesn't
+    already exist.
+
+### SYNOPSIS
+
+    int set_push( mixed ref *arr, mixed value );
+
+### DESCRIPTION
+
+    Adds a value to the end of an array only if it doesn't already exist.
+
+### PARAMETERS
+
+    arr    (mixed)
+           The array to modify
+
+    value  (mixed)
+           The value to add uniquely
+
+### RETURN VALUES
+
+    (int) The size of the array after the operation

--- a/doc/sefun/set_unshift.help
+++ b/doc/sefun/set_unshift.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "set_unshift"
+}
+---
+### NAME
+
+    set_unshift() - Adds a value to the beginning of an array only if it
+    doesn't already exist.
+
+### SYNOPSIS
+
+    int set_unshift( mixed ref *arr, mixed value );
+
+### DESCRIPTION
+
+    Adds a value to the beginning of an array only if it doesn't already
+    exist.
+
+### PARAMETERS
+
+    arr    (mixed)
+           The array to modify
+
+    value  (mixed)
+           The value to add uniquely
+
+### RETURN VALUES
+
+    (int) The size of the array after the operation

--- a/doc/sefun/shift.help
+++ b/doc/sefun/shift.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "shift"
+}
+---
+### NAME
+
+    shift() - Removes and returns the first element of the array.
+
+### SYNOPSIS
+
+    mixed shift( mixed ref *arr );
+
+### DESCRIPTION
+
+    Removes and returns the first element of the array.
+
+### PARAMETERS
+
+    arr  (mixed*)
+         The array from which to shift an element.
+
+### RETURN VALUES
+
+    (mixed) The first element of the array.

--- a/doc/sefun/shuffle_array.help
+++ b/doc/sefun/shuffle_array.help
@@ -1,0 +1,27 @@
+---
+{
+  title: "shuffle_array"
+}
+---
+### NAME
+
+    shuffle_array() - Creates a new array with elements in random order
+    using the Fisher-Yates shuffle algorithm.
+
+### SYNOPSIS
+
+    mixed *shuffle_array( mixed *items );
+
+### DESCRIPTION
+
+    Creates a new array with elements in random order using the Fisher-Yates
+    shuffle algorithm.
+
+### PARAMETERS
+
+    items  (mixed*)
+           The array to shuffle
+
+### RETURN VALUES
+
+    (mixed*) New array with elements in random order

--- a/doc/sefun/shutdown.help
+++ b/doc/sefun/shutdown.help
@@ -1,0 +1,17 @@
+---
+{
+  title: "shutdown"
+}
+---
+### NAME
+
+    shutdown()
+
+### SYNOPSIS
+
+    void shutdown( int how );
+
+### PARAMETERS
+
+    how  (int)
+         The shutdown mode passed to the driver

--- a/doc/sefun/shutdown_d.help
+++ b/doc/sefun/shutdown_d.help
@@ -1,0 +1,16 @@
+---
+{
+  title: "shutdown_d"
+}
+---
+### NAME
+
+    shutdown_d()
+
+### SYNOPSIS
+
+    object shutdown_d( void );
+
+### RETURN VALUES
+
+    (SHUTDOWN_D) The shutdown daemon object.

--- a/doc/sefun/signal_d.help
+++ b/doc/sefun/signal_d.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "signal_d"
+}
+---
+### NAME
+
+    signal_d() - Get the signal daemon object.
+
+### SYNOPSIS
+
+    object signal_d( void );
+
+### DESCRIPTION
+
+    Get the signal daemon object.
+
+### RETURN VALUES
+
+    (object) signal daemon object

--- a/doc/sefun/simple_list.help
+++ b/doc/sefun/simple_list.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "simple_list"
+}
+---
+### NAME
+
+    simple_list() - Returns a string that is a simple list of the elements
+    of an array, joined by a conjunction.
+
+### SYNOPSIS
+
+    varargs string simple_list( string *arr, string conjunction );
+
+### DESCRIPTION
+
+    Returns a string that is a simple list of the elements of an array,
+    joined by a conjunction.
+
+### PARAMETERS
+
+    arr          (string*)
+                 The array to make a list from.
+
+    conjunction  (string, optional, default: "and")
+                 The word to join the last two elements of the list.
+
+### RETURN VALUES
+
+    (string) The simple list string.

--- a/doc/sefun/simul_efun.help
+++ b/doc/sefun/simul_efun.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "simul_efun"
+}
+---
+### NAME
+
+    simul_efun() - Returns the simul_efun object.
+
+### SYNOPSIS
+
+    object simul_efun( void );
+
+### DESCRIPTION
+
+    Returns the simul_efun object.
+
+### RETURN VALUES
+
+    (object "adm/obj/simul_efun") The simul_efun object.

--- a/doc/sefun/slice.help
+++ b/doc/sefun/slice.help
@@ -1,0 +1,35 @@
+---
+{
+  title: "slice"
+}
+---
+### NAME
+
+    slice() - Returns a new array containing the elements of the input array
+    from the start index to the end index. If the end index is negative, it
+    will start from the end of the array.
+
+### SYNOPSIS
+
+    varargs mixed *slice( mixed *arr, int start, int end );
+
+### DESCRIPTION
+
+    Returns a new array containing the elements of the input array from the
+    start index to the end index. If the end index is negative, it will
+    start from the end of the array.
+
+### PARAMETERS
+
+    arr    (mixed*)
+           The array to slice.
+
+    start  (int)
+           The starting index of the slice.
+
+    end    (int)
+           The ending index of the slice.
+
+### RETURN VALUES
+
+    (mixed*) A new array with the specified elements.

--- a/doc/sefun/slot.help
+++ b/doc/sefun/slot.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "slot"
+}
+---
+### NAME
+
+    slot() - Register a slot for a signal.
+
+### SYNOPSIS
+
+    int slot( string sig, string func );
+
+### DESCRIPTION
+
+    Register a slot for a signal.
+
+### PARAMETERS
+
+    sig   (string)
+          string signal identifier (use `SIG_*` macros)
+
+    func  (string)
+          function to call when the signal is emitted
+
+### RETURN VALUES
+
+    (int) `SIG_SLOT_OK` if the slot was registered successfully.
+
+### ERRORS
+
+    If `sig` is not a string this function calls `error()` and raises an
+    exception to loudly indicate incorrect usage.

--- a/doc/sefun/some.help
+++ b/doc/sefun/some.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "some"
+}
+---
+### NAME
+
+    some() - Tests whether at least one element in the array passes the
+    test.
+
+### SYNOPSIS
+
+    int some( mixed *arr, mixed criteria );
+
+### DESCRIPTION
+
+    Tests whether at least one element in the array passes the test.
+
+### PARAMETERS
+
+    arr       (mixed*)
+              Array to test
+
+    criteria  (mixed)
+              Function or value to test each element
+
+### RETURN VALUES
+
+    (int) 1 if any element passes, 0 if none do
+
+### ERRORS
+
+    If arguments are invalid types

--- a/doc/sefun/source_file.help
+++ b/doc/sefun/source_file.help
@@ -1,0 +1,39 @@
+---
+{
+  title: "source_file"
+}
+---
+### NAME
+
+    source_file() - Resolves a path to its on-disk source file, preferring
+    .lpc over .c.
+
+### SYNOPSIS
+
+    string source_file( string path_and_file );
+
+### DESCRIPTION
+
+    Resolves a path to its on-disk source file, preferring .lpc over .c.
+
+    Any existing .lpc or .c extension on the input is stripped, then the
+    function probes for a sibling .lpc file and falls back to .c. If neither
+    exists the .lpc form is returned anyway as a default — callers that need
+    to know whether the file is real should check file_size() on the result.
+
+### PARAMETERS
+
+    path_and_file  (string)
+                   Path to a source file, with or without a .lpc / .c
+                   extension
+
+### RETURN VALUES
+
+    (string) Path to the existing source file, preferring .lpc; or the .lpc
+    form if no source file is found
+
+### EXAMPLE
+
+    {{di1}}source_file("/cmds/object/work");      // -> "/cmds/object/work.lpc"
+    source_file("/cmds/file/pwd.c");       // -> "/cmds/file/pwd.c"
+    source_file("/no/such/thing");         // -> "/no/such/thing.lpc"{{di0}}

--- a/doc/sefun/splice.help
+++ b/doc/sefun/splice.help
@@ -1,0 +1,44 @@
+---
+{
+  title: "splice"
+}
+---
+### NAME
+
+    splice() - Modifies the content of an array by removing existing
+    elements and/or adding new elements. Returns a new array with the
+    modifications.
+
+### SYNOPSIS
+
+    varargs mixed *splice( mixed *arr, int start, int delete_count, mixed *items_to_add );
+
+### DESCRIPTION
+
+    Modifies the content of an array by removing existing elements and/or
+    adding new elements. Returns a new array with the modifications.
+
+### PARAMETERS
+
+    arr           (mixed*)
+                  The array from which elements will be removed and to which
+                  new elements may be added.
+
+    start         (int)
+                  The zero-based index at which to start changing the array.
+                  If negative, it will begin that many elements from the
+                  end.
+
+    delete_count  (int)
+                  The number of elements to remove from the array, starting
+                  from the index specified by start. If delete_count is 0,
+                  no elements are removed.
+
+    items_to_add  (mixed*)
+                  An array of elements to add to the array at the start
+                  index. Can be omitted or passed as null if no elements are
+                  to be added.
+
+### RETURN VALUES
+
+    (mixed*) A new array reflecting the desired modifications.

--- a/doc/sefun/starts_with.help
+++ b/doc/sefun/starts_with.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "starts_with"
+}
+---
+### NAME
+
+    starts_with() - Checks if a string starts with a specific substring.
+
+### SYNOPSIS
+
+    int starts_with( string str, string starting_string );
+
+### DESCRIPTION
+
+    Checks if a string starts with a specific substring.
+
+### PARAMETERS
+
+    str              (string)
+                     The string to check.
+
+    starting_string  (string)
+                     The substring to check for at the start.
+
+### RETURN VALUES
+
+    (int) 1 if the string starts with the specified substring, 0 otherwise.
+
+### ERRORS
+
+    If either argument is not a string.

--- a/doc/sefun/stringify.help
+++ b/doc/sefun/stringify.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "stringify"
+}
+---
+### NAME
+
+    stringify() - Converts an LPC value to its string representation.
+
+### SYNOPSIS
+
+    string stringify( mixed val );
+
+### DESCRIPTION
+
+    Converts an LPC value to its string representation.
+
+### PARAMETERS
+
+    val  (mixed)
+         The value to convert.
+
+### RETURN VALUES
+
+    (string) The string representation of the value.

--- a/doc/sefun/subjective.help
+++ b/doc/sefun/subjective.help
@@ -1,0 +1,24 @@
+---
+{
+  title: "subjective"
+}
+---
+### NAME
+
+    subjective() - Gets the subjective pronoun for a gender.
+
+### SYNOPSIS
+
+    string subjective( mixed ob );
+
+### DESCRIPTION
+
+    Gets the subjective pronoun for a gender.
+
+### RETURN VALUES
+
+    (string) Subjective pronoun (he/she/it/they)
+
+### EXAMPLE
+
+    {{di1}}subjective("female");  // Returns "she"{{di0}}

--- a/doc/sefun/substr.help
+++ b/doc/sefun/substr.help
@@ -1,0 +1,37 @@
+---
+{
+  title: "substr"
+}
+---
+### NAME
+
+    substr() - Returns a substring of a string, starting from 0 and ending
+    at the first occurrence of another string within it. If the reverse flag
+    is set, the substring will start at the last occurrence of the substring
+    within the string.
+
+### SYNOPSIS
+
+    varargs string substr( string str, string sub, int reverse );
+
+### DESCRIPTION
+
+    Returns a substring of a string, starting from 0 and ending at the first
+    occurrence of another string within it. If the reverse flag is set, the
+    substring will start at the last occurrence of the substring within the
+    string.
+
+### PARAMETERS
+
+    str      (string)
+             The string to extract from.
+
+    sub      (string)
+             The substring to extract to.
+
+    reverse  (int, optional, default: 0)
+             If set, the substring will start at the last occurrence.
+
+### RETURN VALUES
+
+    (string) The extracted substring.

--- a/doc/sefun/sum.help
+++ b/doc/sefun/sum.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "sum"
+}
+---
+### NAME
+
+    sum() - Calculates the sum of all elements in an array.
+
+### SYNOPSIS
+
+    int sum( int *arr );
+
+### DESCRIPTION
+
+    Calculates the sum of all elements in an array.
+
+### PARAMETERS
+
+    arr  (int*)
+         The array of numbers to sum.
+
+### RETURN VALUES
+
+    (int) The sum of all elements in the array.

--- a/doc/sefun/sum_array.help
+++ b/doc/sefun/sum_array.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "sum_array"
+}
+---
+### NAME
+
+    sum_array() - Calculates the sum of all integers in an array.
+
+### SYNOPSIS
+
+    int sum_array( int *nums );
+
+### DESCRIPTION
+
+    Calculates the sum of all integers in an array.
+
+### PARAMETERS
+
+    nums  (int*)
+          Array of integers to sum
+
+### RETURN VALUES
+
+    (int) The sum of all elements

--- a/doc/sefun/tail.help
+++ b/doc/sefun/tail.help
@@ -1,0 +1,38 @@
+---
+{
+  title: "tail"
+}
+---
+### NAME
+
+    tail() - Returns the last n lines of a file.
+
+### SYNOPSIS
+
+    varargs string tail( string path, int line_count );
+
+### DESCRIPTION
+
+    Returns the last n lines of a file.
+
+    Reads from end of file efficiently, even for large files.
+
+### PARAMETERS
+
+    path        (string)
+                File to read
+
+    line_count  (int, optional, default: 25)
+                Number of lines to return
+
+### RETURN VALUES
+
+    (string) Requested lines with proper newline formatting
+
+### ERRORS
+
+    If file path is null or invalid
+
+### EXAMPLE
+
+    {{di1}}tell_me(tail("/log/system.log", 10));  // Shows last 10 log entries{{di0}}

--- a/doc/sefun/tell.help
+++ b/doc/sefun/tell.help
@@ -1,0 +1,36 @@
+---
+{
+  title: "tell"
+}
+---
+### NAME
+
+    tell() - Sends a direct message to the specified object without
+    considering containment hierarchy.
+
+### SYNOPSIS
+
+    varargs void tell( mixed *args... );
+
+### DESCRIPTION
+
+    Sends a direct message to the specified object without considering
+    containment hierarchy.
+
+### PARAMETERS
+
+    str       (string)
+              The message string to send (sent to previous_object()).
+
+    ob        (object)
+              The object to send the message to.
+
+    str       (string)
+              The message string to send.
+
+    msg_type  (int, optional)
+              The message type.
+
+### ERRORS
+
+    If insufficient arguments are provided.

--- a/doc/sefun/tell_all.help
+++ b/doc/sefun/tell_all.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "tell_all"
+}
+---
+### NAME
+
+    tell_all() - Sends a message to all objects in the same environment,
+    regardless of their position in the containment hierarchy.
+
+### SYNOPSIS
+
+    varargs void tell_all( object ob, string str, int msg_type, mixed exclude );
+
+### DESCRIPTION
+
+    Sends a message to all objects in the same environment, regardless of
+    their position in the containment hierarchy.
+
+### PARAMETERS
+
+    str       (string)
+              The message string to send.
+
+    msg_type  (int, optional)
+              The message type, which will be combined with ALL_MSG.
+
+    exclude   (mixed, optional)
+              The objects to exclude from receiving the message.

--- a/doc/sefun/tell_direct.help
+++ b/doc/sefun/tell_direct.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "tell_direct"
+}
+---
+### NAME
+
+    tell_direct() - Sends a direct message to the specified object without
+    considering containment hierarchy.
+
+### SYNOPSIS
+
+    varargs void tell_direct( object ob, string str, int msg_type );
+
+### DESCRIPTION
+
+    Sends a direct message to the specified object without considering
+    containment hierarchy.
+
+### PARAMETERS
+
+    str       (string)
+              The message string to send.
+
+    msg_type  (int, optional)
+              The message type, which will be combined with DIRECT_MSG.

--- a/doc/sefun/tell_down.help
+++ b/doc/sefun/tell_down.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "tell_down"
+}
+---
+### NAME
+
+    tell_down() - Sends a message downward through the containment
+    hierarchy, such as from a container to all objects it contains.
+
+### SYNOPSIS
+
+    varargs void tell_down( object ob, string str, int msg_type, mixed exclude );
+
+### DESCRIPTION
+
+    Sends a message downward through the containment hierarchy, such as from
+    a container to all objects it contains.
+
+### PARAMETERS
+
+    str       (string)
+              The message string to send.
+
+    msg_type  (int, optional)
+              The message type, which will be combined with DOWN_MSG.
+
+    exclude   (mixed, optional)
+              The objects to exclude from receiving the message.

--- a/doc/sefun/tell_me.help
+++ b/doc/sefun/tell_me.help
@@ -1,0 +1,24 @@
+---
+{
+  title: "tell_me"
+}
+---
+### NAME
+
+    tell_me() - Sends a direct message to the current player (this_body()).
+
+### SYNOPSIS
+
+    varargs void tell_me( string str, int message_type );
+
+### DESCRIPTION
+
+    Sends a direct message to the current player (this_body()).
+
+### PARAMETERS
+
+    str           (string)
+                  The message string to send
+
+    message_type  (int, optional)
+                  The message type flag

--- a/doc/sefun/tell_them.help
+++ b/doc/sefun/tell_them.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "tell_them"
+}
+---
+### NAME
+
+    tell_them() - Sends a message to all objects in the current player's
+    environment, excluding the current player and any additional specified
+    objects.
+
+### SYNOPSIS
+
+    varargs void tell_them( string str, object *exclude, int message_type );
+
+### DESCRIPTION
+
+    Sends a message to all objects in the current player's environment,
+    excluding the current player and any additional specified objects.
+
+### PARAMETERS
+
+    str           (string)
+                  The message string to send
+
+    exclude       (object*, optional)
+                  Additional objects to exclude from receiving the message,
+                  beyond the current player
+
+    message_type  (int, optional)
+                  The message type flag

--- a/doc/sefun/tell_up.help
+++ b/doc/sefun/tell_up.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "tell_up"
+}
+---
+### NAME
+
+    tell_up() - Sends a message upward through the containment hierarchy,
+    such as from an object to its container, and further up to the room or
+    environment.
+
+### SYNOPSIS
+
+    varargs void tell_up( object ob, string str, int msg_type, mixed exclude );
+
+### DESCRIPTION
+
+    Sends a message upward through the containment hierarchy, such as from
+    an object to its container, and further up to the room or environment.
+
+### PARAMETERS
+
+    str       (string)
+              The message string to send.
+
+    msg_type  (int, optional)
+              The message type, which will be combined with UP_MSG.
+
+    exclude   (mixed, optional)
+              The objects to exclude from receiving the message.

--- a/doc/sefun/temp_file.help
+++ b/doc/sefun/temp_file.help
@@ -1,0 +1,35 @@
+---
+{
+  title: "temp_file"
+}
+---
+### NAME
+
+    temp_file() - Generates a unique temporary file path.
+
+### SYNOPSIS
+
+    varargs string temp_file( mixed arg );
+
+### DESCRIPTION
+
+    Generates a unique temporary file path.
+
+    Creates path based on object name or provided string with timestamp.
+
+### PARAMETERS
+
+    arg  (object|string, optional)
+         Base for temp filename, defaults to previous_object()
+
+### RETURN VALUES
+
+    (string) Full path to temporary file
+
+### ERRORS
+
+    If argument is invalid type
+
+### EXAMPLE
+
+    {{di1}}string tmp = temp_file("backup");  // Returns "/tmp/backup.1234567890"{{di0}}

--- a/doc/sefun/this_body.help
+++ b/doc/sefun/this_body.help
@@ -1,0 +1,24 @@
+---
+{
+  title: "this_body"
+}
+---
+### NAME
+
+    this_body() - This is a simul_efun that will return the body object of
+    the current living who executed a command.
+
+### SYNOPSIS
+
+    object this_body( void );
+
+### DESCRIPTION
+
+    This is a simul_efun that will return the body object of the current
+    living who executed a command.
+
+    It is used as a replacement for this_player().
+
+### RETURN VALUES
+
+    (STD_BODY) The body of the current calling living.

--- a/doc/sefun/this_caller.help
+++ b/doc/sefun/this_caller.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "this_caller"
+}
+---
+### NAME
+
+    this_caller() - This is a simul_efun that will return the object that
+    called the current operation. This may be this_body(), but it may also
+    be a shadow another player who initiated the chain. For example, a
+    wizard using the force command.
+
+### SYNOPSIS
+
+    object this_caller( void );
+
+### DESCRIPTION
+
+    This is a simul_efun that will return the object that called the current
+    operation. This may be this_body(), but it may also be a shadow another
+    player who initiated the chain. For example, a wizard using the force
+    command.
+
+    Be careful with this one, you don't want to accidentally perform
+    operations on the wrong object.
+
+    * @returns {object STD_PLAYER|object STD_NPC} The object that called the
+    current operation.

--- a/doc/sefun/time_frac.help
+++ b/doc/sefun/time_frac.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "time_frac"
+}
+---
+### NAME
+
+    time_frac() - Converts a time value from nanoseconds to a fractional
+    value in seconds. This function takes a time value in nanoseconds and
+    converts it to a fractional value representing seconds by dividing the
+    input by 1,000,000,000.
+
+### SYNOPSIS
+
+    varargs float time_frac( int nanoseconds );
+
+### DESCRIPTION
+
+    Converts a time value from nanoseconds to a fractional value in seconds.
+    This function takes a time value in nanoseconds and converts it to a
+    fractional value representing seconds by dividing the input by
+    1,000,000,000.
+
+### PARAMETERS
+
+    nanoseconds  (int)
+                 The time value in nanoseconds. Defaults to the current time
+                 in nanoseconds if not provided.
+
+### RETURN VALUES
+
+    (float) The time value converted to a fractional value in seconds.

--- a/doc/sefun/time_ms.help
+++ b/doc/sefun/time_ms.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "time_ms"
+}
+---
+### NAME
+
+    time_ms() - Converts a time value from nanoseconds to milliseconds. This
+    function takes a time value in nanoseconds and converts it to
+    milliseconds by dividing the input by 1,000,000.
+
+### SYNOPSIS
+
+    varargs int time_ms( int nanoseconds );
+
+### DESCRIPTION
+
+    Converts a time value from nanoseconds to milliseconds. This function
+    takes a time value in nanoseconds and converts it to milliseconds by
+    dividing the input by 1,000,000.
+
+### PARAMETERS
+
+    nanoseconds  (int)
+                 The time value in nanoseconds. Defaults to the current time
+                 in nanoseconds if not provided.
+
+### RETURN VALUES
+
+    (int) The time value converted to milliseconds.

--- a/doc/sefun/tmp_dir.help
+++ b/doc/sefun/tmp_dir.help
@@ -1,0 +1,20 @@
+---
+{
+  title: "tmp_dir"
+}
+---
+### NAME
+
+    tmp_dir() - Returns the directory where temporary files are stored.
+
+### SYNOPSIS
+
+    string tmp_dir( void );
+
+### DESCRIPTION
+
+    Returns the directory where temporary files are stored.
+
+### RETURN VALUES
+
+    (string) The temporary directory.

--- a/doc/sefun/top_environment.help
+++ b/doc/sefun/top_environment.help
@@ -1,0 +1,27 @@
+---
+{
+  title: "top_environment"
+}
+---
+### NAME
+
+    top_environment() - Retrieves the top-level environment of the specified
+    object, traversing up through nested environments.
+
+### SYNOPSIS
+
+    varargs object top_environment( object ob );
+
+### DESCRIPTION
+
+    Retrieves the top-level environment of the specified object, traversing
+    up through nested environments.
+
+### PARAMETERS
+
+    ob  (object)
+        The object to get the top-level environment of.
+
+### RETURN VALUES
+
+    (object) The top-level environment of the object. Usually STD_ROOM.

--- a/doc/sefun/touch.help
+++ b/doc/sefun/touch.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "touch"
+}
+---
+### NAME
+
+    touch() - Creates or updates a file's timestamp.
+
+### SYNOPSIS
+
+    int touch( string file );
+
+### DESCRIPTION
+
+    Creates or updates a file's timestamp.
+
+    Creates parent directories if needed.
+
+### PARAMETERS
+
+    file  (string)
+          File to touch
+
+### RETURN VALUES
+
+    (int) 1 if successful, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}touch("/var/run/daemon.pid");{{di0}}

--- a/doc/sefun/truthy.help
+++ b/doc/sefun/truthy.help
@@ -1,0 +1,36 @@
+---
+{
+  title: "truthy"
+}
+---
+### NAME
+
+    truthy() - Determines if a value is truthy or not. Truthy, not in the
+    LPC sense, but more in a JS sense.
+
+### SYNOPSIS
+
+    int truthy( mixed val );
+
+### DESCRIPTION
+
+    Determines if a value is truthy or not. Truthy, not in the LPC sense,
+    but more in a JS sense.
+
+    A truthy value is: a value that is not null, 0, or a string that is not
+    empty.
+
+### PARAMETERS
+
+    val  (mixed)
+         The value to test if it is truthy.
+
+### RETURN VALUES
+
+    (int) 1 if the value is truthy, 0 if not.
+
+### EXAMPLE
+
+    {{di1}}truthy(1) // 1
+    truthy("") // 0
+    truthy("hi") // 1{{di0}}

--- a/doc/sefun/typeof.help
+++ b/doc/sefun/typeof.help
@@ -1,0 +1,21 @@
+---
+{
+  title: "typeof"
+}
+---
+### NAME
+
+    typeof()
+
+### SYNOPSIS
+
+    string typeof( mixed val );
+
+### PARAMETERS
+
+    val  (mixed)
+         The value to type-check.
+
+### RETURN VALUES
+
+    (string) The type name, or `T_UNDEFINED` when `val` is null/undefined.

--- a/doc/sefun/uniformp.help
+++ b/doc/sefun/uniformp.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "uniformp"
+}
+---
+### NAME
+
+    uniformp() - Checks if all elements in the input array are of the
+    specified type. If the array is of size 0, it is considered uniform.
+
+### SYNOPSIS
+
+    int uniformp( mixed *arr, string type );
+
+### DESCRIPTION
+
+    Checks if all elements in the input array are of the specified type. If
+    the array is of size 0, it is considered uniform.
+
+### PARAMETERS
+
+    arr   (mixed*)
+          The array to check.
+
+    type  (string)
+          The type to check for.
+
+### RETURN VALUES
+
+    (int) Returns 1 if all elements are of the specified type, 0 otherwise.

--- a/doc/sefun/uniq_array.help
+++ b/doc/sefun/uniq_array.help
@@ -1,0 +1,27 @@
+---
+{
+  title: "uniq_array"
+}
+---
+### NAME
+
+    uniq_array() - Creates a new array with only unique elements from the
+    input array while preserving their first-seen order.
+
+### SYNOPSIS
+
+    mixed *uniq_array( mixed *arr );
+
+### DESCRIPTION
+
+    Creates a new array with only unique elements from the input array while
+    preserving their first-seen order.
+
+### PARAMETERS
+
+    arr  (mixed*)
+         The array to deduplicate
+
+### RETURN VALUES
+
+    (mixed*) New array containing only unique elements

--- a/doc/sefun/unshift.help
+++ b/doc/sefun/unshift.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "unshift"
+}
+---
+### NAME
+
+    unshift() - Adds a new element to the beginning of the array and returns
+    the new size of the array.
+
+### SYNOPSIS
+
+    int unshift( mixed ref *arr, mixed value );
+
+### DESCRIPTION
+
+    Adds a new element to the beginning of the array and returns the new
+    size of the array.
+
+### PARAMETERS
+
+    arr    (mixed*)
+           The array to which to unshift an element.
+
+    value  (mixed)
+           The element to unshift onto the array.
+
+### RETURN VALUES
+
+    (int) The new size of the array.

--- a/doc/sefun/unslot.help
+++ b/doc/sefun/unslot.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "unslot"
+}
+---
+### NAME
+
+    unslot() - Unregister a slot for a signal.
+
+### SYNOPSIS
+
+    int unslot( string sig );
+
+### DESCRIPTION
+
+    Unregister a slot for a signal.
+
+### PARAMETERS
+
+    sig  (string)
+         string signal identifier (use `SIG_*` macros)
+
+### RETURN VALUES
+
+    (int) `SIG_SLOT_OK` if the slot was unregistered successfully.
+
+### ERRORS
+
+    If `sig` is not a string this function calls `error()` and raises an
+    exception so incorrect calls fail loudly.

--- a/doc/sefun/user_body_data.help
+++ b/doc/sefun/user_body_data.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "user_body_data"
+}
+---
+### NAME
+
+    user_body_data() - Returns the file path for the user's mob data file.
+
+### SYNOPSIS
+
+    string user_body_data( string name );
+
+### DESCRIPTION
+
+    Returns the file path for the user's mob data file.
+
+### PARAMETERS
+
+    name  (string)
+          The user's name.
+
+### RETURN VALUES
+
+    (string) The file path for the user's mob data file, or 0 if the input
+    is invalid.

--- a/doc/sefun/user_data_directory.help
+++ b/doc/sefun/user_data_directory.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "user_data_directory"
+}
+---
+### NAME
+
+    user_data_directory() - Returns the directory path for the user's data
+    directory based on their name.
+
+### SYNOPSIS
+
+    string user_data_directory( string name );
+
+### DESCRIPTION
+
+    Returns the directory path for the user's data directory based on their
+    name.
+
+### PARAMETERS
+
+    name  (string)
+          The user's name.
+
+### RETURN VALUES
+
+    (string) The directory path for the user's data directory, or 0 if the
+    input is invalid.

--- a/doc/sefun/user_data_file.help
+++ b/doc/sefun/user_data_file.help
@@ -1,0 +1,26 @@
+---
+{
+  title: "user_data_file"
+}
+---
+### NAME
+
+    user_data_file() - Returns the file path for the user's data file.
+
+### SYNOPSIS
+
+    string user_data_file( string name );
+
+### DESCRIPTION
+
+    Returns the file path for the user's data file.
+
+### PARAMETERS
+
+    name  (string)
+          The user's name.
+
+### RETURN VALUES
+
+    (string) The file path for the user's data file, or 0 if the input is
+    invalid.

--- a/doc/sefun/user_exists.help
+++ b/doc/sefun/user_exists.help
@@ -1,0 +1,33 @@
+---
+{
+  title: "user_exists"
+}
+---
+### NAME
+
+    user_exists() - Checks if a user's data file exists.
+
+### SYNOPSIS
+
+    int user_exists( string user );
+
+### DESCRIPTION
+
+    Checks if a user's data file exists.
+
+    Looks for user save file in the standard user directory structure.
+
+### PARAMETERS
+
+    user  (string)
+          Username to check
+
+### RETURN VALUES
+
+    (int) 1 if user data exists, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}if(user_exists("alice")) {
+        tell_me("User account exists.\n");
+    }{{di0}}

--- a/doc/sefun/user_inventory_data.help
+++ b/doc/sefun/user_inventory_data.help
@@ -1,0 +1,27 @@
+---
+{
+  title: "user_inventory_data"
+}
+---
+### NAME
+
+    user_inventory_data() - Returns the file path for the user's inventory
+    data file.
+
+### SYNOPSIS
+
+    string user_inventory_data( string name );
+
+### DESCRIPTION
+
+    Returns the file path for the user's inventory data file.
+
+### PARAMETERS
+
+    name  (string)
+          The user's name.
+
+### RETURN VALUES
+
+    (string) The file path for the user's inventory data file, or 0 if the
+    input is invalid.

--- a/doc/sefun/userp.help
+++ b/doc/sefun/userp.help
@@ -1,0 +1,21 @@
+---
+{
+  title: "userp"
+}
+---
+### NAME
+
+    userp()
+
+### SYNOPSIS
+
+    varargs int userp( object ob );
+
+### PARAMETERS
+
+    ob  (object)
+        The object to check.
+
+### RETURN VALUES
+
+    (ob is STD_PLAYER) 1 if the object is a user, otherwise 0.

--- a/doc/sefun/valid_account.help
+++ b/doc/sefun/valid_account.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "valid_account"
+}
+---
+### NAME
+
+    valid_account() - Returns 1 if the account is valid, 0 if not.
+
+### SYNOPSIS
+
+    int valid_account( string name );
+
+### DESCRIPTION
+
+    Returns 1 if the account is valid, 0 if not.
+
+### PARAMETERS
+
+    name  (string)
+          The name of the account.
+
+### RETURN VALUES
+
+    (int) 1 if the account is valid, otherwise 0.

--- a/doc/sefun/valid_dir.help
+++ b/doc/sefun/valid_dir.help
@@ -1,0 +1,31 @@
+---
+{
+  title: "valid_dir"
+}
+---
+### NAME
+
+    valid_dir() - Resolves and validates a directory path, checking if it
+    exists as a directory.
+
+### SYNOPSIS
+
+    string valid_dir( string base_dir, string path );
+
+### DESCRIPTION
+
+    Resolves and validates a directory path, checking if it exists as a
+    directory.
+
+### PARAMETERS
+
+    base_dir  (string)
+              The base directory to resolve relative paths from.
+
+    path      (string)
+              The directory path to resolve and validate.
+
+### RETURN VALUES
+
+    (string|int) The resolved absolute directory path if valid, or 0 if
+    invalid.

--- a/doc/sefun/valid_dir_file.help
+++ b/doc/sefun/valid_dir_file.help
@@ -1,0 +1,36 @@
+---
+{
+  title: "valid_dir_file"
+}
+---
+### NAME
+
+    valid_dir_file() - Verifies directory and optionally file existence.
+
+### SYNOPSIS
+
+    varargs string *valid_dir_file( string path, int file_too );
+
+### DESCRIPTION
+
+    Verifies directory and optionally file existence.
+
+    Traverses path components to validate directory structure and optionally
+    checks if the final component exists as a file.
+
+### PARAMETERS
+
+    path      (string)
+              Path to verify
+
+    file_too  (int, optional, default: 0)
+              Whether to check file existence
+
+### RETURN VALUES
+
+    (({ string, string ) or null if invalid
+
+### EXAMPLE
+
+    {{di1}}string *parts = valid_dir_file("/d/town/square.c", 1);
+    // Returns ({ "/d/town/", "square.c" }) if path exists{{di0}}

--- a/doc/sefun/valid_file.help
+++ b/doc/sefun/valid_file.help
@@ -1,0 +1,29 @@
+---
+{
+  title: "valid_file"
+}
+---
+### NAME
+
+    valid_file() - Resolves and validates a file path, checking if it exists
+    as a file.
+
+### SYNOPSIS
+
+    string valid_file( string base_dir, string path );
+
+### DESCRIPTION
+
+    Resolves and validates a file path, checking if it exists as a file.
+
+### PARAMETERS
+
+    base_dir  (string)
+              The base directory to resolve relative paths from.
+
+    path      (string)
+              The file path to resolve and validate.
+
+### RETURN VALUES
+
+    (string|int) The resolved absolute file path if valid, or 0 if invalid.

--- a/doc/sefun/valid_function.help
+++ b/doc/sefun/valid_function.help
@@ -1,0 +1,35 @@
+---
+{
+  title: "valid_function"
+}
+---
+### NAME
+
+    valid_function() - Verifies that a function pointer is valid and usable.
+
+### SYNOPSIS
+
+    int valid_function( mixed f );
+
+### DESCRIPTION
+
+    Verifies that a function pointer is valid and usable.
+
+    Checks if the function exists and its owner object hasn't been
+    destructed.
+
+### PARAMETERS
+
+    f  (mixed)
+       Function pointer to validate
+
+### RETURN VALUES
+
+    (f is function) 1 if function is valid and callable, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}function f = (: object->method() :);
+    if(valid_function(f)) {
+      evaluate(f);
+    }{{di0}}

--- a/doc/sefun/valid_path.help
+++ b/doc/sefun/valid_path.help
@@ -1,0 +1,30 @@
+---
+{
+  title: "valid_path"
+}
+---
+### NAME
+
+    valid_path() - Resolves and validates a path, checking if it exists as
+    either a file or directory.
+
+### SYNOPSIS
+
+    string valid_path( string base_dir, string path );
+
+### DESCRIPTION
+
+    Resolves and validates a path, checking if it exists as either a file or
+    directory.
+
+### PARAMETERS
+
+    base_dir  (string)
+              The base directory to resolve relative paths from.
+
+    path      (string)
+              The path to resolve and validate.
+
+### RETURN VALUES
+
+    (string|int) The resolved absolute path if valid, or 0 if invalid.

--- a/doc/sefun/valid_seq.help
+++ b/doc/sefun/valid_seq.help
@@ -1,0 +1,39 @@
+---
+{
+  title: "valid_seq"
+}
+---
+### NAME
+
+    valid_seq() - Validates that an array is a valid simple map (array of
+    key-value pairs).
+
+### SYNOPSIS
+
+    varargs int valid_seq( mixed map, int non_empty );
+
+### DESCRIPTION
+
+    Validates that an array is a valid simple map (array of key-value
+    pairs).
+
+    Checks that the argument is an array, and if `non_empty` is true, also
+    checks that every element is a two-element array (i.e., a key-value
+    pair).
+
+### PARAMETERS
+
+    map        (mixed)
+               The array to validate
+
+    non_empty  (int)
+               If true, requires all elements to be key-value pairs
+
+### RETURN VALUES
+
+    (map is mixed*) 1 if valid, 0 otherwise
+
+### EXAMPLE
+
+    {{di1}}mixed *pairs = ({ ({"a", 1}), ({"b", 2}) });
+    if(valid_seq(pairs, 1)) write("Valid map!\n");{{di0}}

--- a/doc/sefun/valid_user.help
+++ b/doc/sefun/valid_user.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "valid_user"
+}
+---
+### NAME
+
+    valid_user() - Returns 1 if the object is a valid user, 0 if not.
+
+### SYNOPSIS
+
+    varargs int valid_user( mixed ob );
+
+### DESCRIPTION
+
+    Returns 1 if the object is a valid user, 0 if not.
+
+### PARAMETERS
+
+    ob  (mixed)
+        The object to check.
+
+### RETURN VALUES
+
+    (int) 1 if the object is a valid user, otherwise 0.

--- a/doc/sefun/wizardp.help
+++ b/doc/sefun/wizardp.help
@@ -1,0 +1,25 @@
+---
+{
+  title: "wizardp"
+}
+---
+### NAME
+
+    wizardp() - Checks if a user has developer privileges (alias for devp).
+
+### SYNOPSIS
+
+    int wizardp( mixed user) { return devp(user );
+
+### DESCRIPTION
+
+    Checks if a user has developer privileges (alias for devp).
+
+### PARAMETERS
+
+    user  (mixed)
+          The user to check, either as a username string or an object.
+
+### RETURN VALUES
+
+    (int) 1 if the user has developer privileges, otherwise 0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,22 +5,29 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@gesslar/bedoc": "^2.0.0",
+        "@gesslar/bedoc": "*",
         "@gesslar/lpc-mcp": "^1.6.0"
       }
     },
+    "node_modules/@astrojs/compiler": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
+      "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.84.0.tgz",
-      "integrity": "sha512-0xew1CxOam0gV5OMjh2KjFQZsKL2bByX1+q4j3E73MpYIdyUxcZb/xQct9ccUb+ve5KGUYbCUxyPnYB7RbuP+w==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.87.0.tgz",
+      "integrity": "sha512-mFXZloZMzuJZXSHUmAFu/pXTk0ZJTJBluuAkrvbzidpTN8W6F2bpRFuedSH+85kbdlRLJqc+gfN+kD3JOLJK5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "^1.0.8",
-        "@typescript-eslint/types": "^8.54.0",
-        "comment-parser": "1.4.5",
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.59.4",
+        "comment-parser": "1.4.7",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.1.1"
+        "jsdoc-type-pratt-parser": "~7.2.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -80,14 +87,14 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/object-schema": "^3.0.3",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
       },
@@ -96,23 +103,23 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/core": "^1.1.1"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -124,9 +131,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -135,14 +142,14 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/core": "^1.1.1",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -162,40 +169,10 @@
         "node": ">=24"
       }
     },
-    "node_modules/@gesslar/actioneer/node_modules/@gesslar/colours": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/colours/-/colours-1.0.0.tgz",
-      "integrity": "sha512-+u3j2gG6nWlAgqVJ2zXBtiSDMlc71US4sCG1D4EksZI72MUTYFuE5QYew2+XAGZwXKi31ibdNil+Hoy0y2jGEA==",
-      "dev": true,
-      "license": "0BSD",
-      "bin": {
-        "colours": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=24.11.0"
-      }
-    },
-    "node_modules/@gesslar/actioneer/node_modules/@gesslar/toolkit": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.5.2.tgz",
-      "integrity": "sha512-z9bNajNrT/1JQJiDokkq9F7E8Mt6BWsHuVqENoEBrGHbSwSZRqf30MdLh/ktDATgS3YaiD0QgFQgap4nzqiSEg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "0BSD",
-      "dependencies": {
-        "@gesslar/colours": "^1.0.0",
-        "json5": "^2.2.3",
-        "supports-color": "^10.2.2",
-        "yaml": "^2.9.0"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
     "node_modules/@gesslar/bedoc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/bedoc/-/bedoc-2.0.0.tgz",
-      "integrity": "sha512-Z3c5JQntj6fx3rlezyMAEMaFEjXQRKwv57LdwT/NpPKRevEMfaGXRpMdFGQ/hjaTGoVmjklM0hpZv+gchbLFNg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@gesslar/bedoc/-/bedoc-2.1.0.tgz",
+      "integrity": "sha512-cB2xk60lm5ZZw7XKAbyGjt2agoIgDGOtTea6uYmucVmU1i8ByOAlGLDqCA0o5LHYgkWxekyv0agW2uXcyvyWtA==",
       "dev": true,
       "license": "Unlicense",
       "dependencies": {
@@ -213,7 +190,7 @@
         "node": ">=24"
       }
     },
-    "node_modules/@gesslar/bedoc/node_modules/@gesslar/colours": {
+    "node_modules/@gesslar/colours": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@gesslar/colours/-/colours-1.0.0.tgz",
       "integrity": "sha512-+u3j2gG6nWlAgqVJ2zXBtiSDMlc71US4sCG1D4EksZI72MUTYFuE5QYew2+XAGZwXKi31ibdNil+Hoy0y2jGEA==",
@@ -226,46 +203,16 @@
         "node": ">=24.11.0"
       }
     },
-    "node_modules/@gesslar/bedoc/node_modules/@gesslar/toolkit": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.5.2.tgz",
-      "integrity": "sha512-z9bNajNrT/1JQJiDokkq9F7E8Mt6BWsHuVqENoEBrGHbSwSZRqf30MdLh/ktDATgS3YaiD0QgFQgap4nzqiSEg==",
+    "node_modules/@gesslar/lpc-mcp": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@gesslar/lpc-mcp/-/lpc-mcp-1.6.1.tgz",
+      "integrity": "sha512-ATnpY+jrJ9Yr04WTo85GRmul9FBvqMzZSuqcFwaxtvH9oRC59DUH/wTAe9s2GNuzdfdTEosUx3qYOeEDCthoXg==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "0BSD",
       "dependencies": {
-        "@gesslar/colours": "^1.0.0",
-        "json5": "^2.2.3",
-        "supports-color": "^10.2.2",
-        "yaml": "^2.9.0"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@gesslar/colours": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/colours/-/colours-0.8.0.tgz",
-      "integrity": "sha512-Sy+xwKAqoE+qVZ/0jvoVRsXEaNMJTc2pEUoyoRYewlAw5k4iLuIGR6cBcZ10W1UvgYTJKxh+462+Eg0QBAx44w==",
-      "dev": true,
-      "license": "Unlicense",
-      "bin": {
-        "colours": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@gesslar/lpc-mcp": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/lpc-mcp/-/lpc-mcp-1.6.0.tgz",
-      "integrity": "sha512-Tbp7U9495KD9DApEku2uyR6abb3iuxlCe4XjPYHejdyeB7lP0VWQQTwjVSwmoybF+ShSZpGm6T0eMJAqLU4L0Q==",
-      "dev": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "@gesslar/toolkit": "^4.4.0",
-        "@gesslar/uglier": "^2.3.1",
-        "@modelcontextprotocol/sdk": "^1.28.0",
+        "@gesslar/toolkit": "^5.0.1",
+        "@gesslar/uglier": "^2.4.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -292,20 +239,7 @@
         "node": ">=24.11.0"
       }
     },
-    "node_modules/@gesslar/negotiator/node_modules/@gesslar/colours": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/colours/-/colours-1.0.0.tgz",
-      "integrity": "sha512-+u3j2gG6nWlAgqVJ2zXBtiSDMlc71US4sCG1D4EksZI72MUTYFuE5QYew2+XAGZwXKi31ibdNil+Hoy0y2jGEA==",
-      "dev": true,
-      "license": "0BSD",
-      "bin": {
-        "colours": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=24.11.0"
-      }
-    },
-    "node_modules/@gesslar/negotiator/node_modules/@gesslar/toolkit": {
+    "node_modules/@gesslar/toolkit": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.5.2.tgz",
       "integrity": "sha512-z9bNajNrT/1JQJiDokkq9F7E8Mt6BWsHuVqENoEBrGHbSwSZRqf30MdLh/ktDATgS3YaiD0QgFQgap4nzqiSEg==",
@@ -322,49 +256,32 @@
         "node": ">=24"
       }
     },
-    "node_modules/@gesslar/toolkit": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-4.4.0.tgz",
-      "integrity": "sha512-BSD3BBxQQTt0rxFm78pwok2IXRURc+gVMxSuSWbP1xcZn9EM95Nf7NMp8cIY0OL6aPzzAT+mgoYKMO5ALIKy+g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "@gesslar/colours": "^0.8.0",
-        "ajv": "^8.18.0",
-        "json5": "^2.2.3",
-        "supports-color": "^10.2.2",
-        "yaml": "^2.8.2"
-      },
-      "engines": {
-        "node": ">=24.13.0"
-      }
-    },
     "node_modules/@gesslar/uglier": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@gesslar/uglier/-/uglier-2.3.1.tgz",
-      "integrity": "sha512-3VeLG7g9s0B839TgU8EeEnqACeZO9AYQKGOAEuJu+Mi3bAoGjTfolDsvB2bi1p6lnSgr2X0vpToznaY8eFQufw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@gesslar/uglier/-/uglier-2.4.1.tgz",
+      "integrity": "sha512-v4yxIoatmfQDpew1uR2Ro6XK5rFEwPu5WbPrbXQ6EOynJHY5wJbi4tfuZxYOdKG81zZIpqFFcn8jh/7h7lZB0w==",
       "dev": true,
-      "license": "Unlicense",
+      "license": "0BSD",
       "dependencies": {
-        "@gesslar/colours": ">=0.8.0",
-        "@gesslar/toolkit": ">=4.4.0",
+        "@gesslar/colours": ">=1.0.0",
+        "@gesslar/toolkit": ">=5.0.1",
         "@skarab/detect-package-manager": ">=1.0.0",
         "@stylistic/eslint-plugin": "^5.10.0",
-        "eslint-plugin-jsdoc": ">=62.8.1",
+        "eslint-plugin-astro": "^1.7.0",
+        "eslint-plugin-jsdoc": ">=62.9.0",
         "globals": ">=17.4.0"
       },
       "bin": {
         "uglier": "src/install.js"
       },
       "engines": {
-        "node": ">=24.13.0"
+        "node": ">=24.11.0"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -375,27 +292,42 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -430,10 +362,17 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -469,6 +408,57 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@sindresorhus/base62": {
@@ -528,9 +518,9 @@
       "peer": true
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -542,10 +532,28 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
-      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -554,6 +562,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/accepts": {
@@ -594,9 +633,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -638,6 +677,69 @@
         "node": ">=14"
       }
     },
+    "node_modules/astro-eslint-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/astro-eslint-parser/-/astro-eslint-parser-1.4.0.tgz",
+      "integrity": "sha512-+QDcgc7e+au6EZ0YjMmRRjNoQo5bDMlaR45aWDoFsuxQTCM9qmCHRoiKJPELgckJ8Wmr7vcfpa9eCDHBFh6G4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.0.0 || ^3.0.0",
+        "@typescript-eslint/scope-manager": "^7.0.0 || ^8.0.0",
+        "@typescript-eslint/types": "^7.0.0 || ^8.0.0",
+        "astrojs-compiler-sync": "^1.0.0",
+        "debug": "^4.3.4",
+        "entities": "^7.0.0",
+        "eslint-scope": "^8.0.1",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.0.0",
+        "fast-glob": "^3.3.3",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
+    "node_modules/astro-eslint-parser/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/astrojs-compiler-sync": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/astrojs-compiler-sync/-/astrojs-compiler-sync-1.1.1.tgz",
+      "integrity": "sha512-0mKvB9sDQRIZPsEJadw6OaFbGJ92cJPPR++ICca9XEyiUAZqgVuk25jNmzHPT0KF80rI94trSZrUR5iHFXGGOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "synckit": "^0.11.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "@astrojs/compiler": ">=0.27.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -675,9 +777,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -686,6 +788,19 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/bytes": {
@@ -740,9 +855,9 @@
       }
     },
     "node_modules/comment-parser": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
-      "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -750,9 +865,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -826,6 +941,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -894,6 +1022,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
@@ -925,9 +1066,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -958,19 +1099,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
-      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
+      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.3",
-        "@eslint/config-helpers": "^0.5.3",
-        "@eslint/core": "^1.1.1",
-        "@eslint/plugin-kit": "^0.6.1",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -1014,30 +1155,85 @@
         }
       }
     },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.5.tgz",
+      "integrity": "sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-astro": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-1.7.0.tgz",
+      "integrity": "sha512-89xpAn528UKCdmyysbg0AHHqi6sqcK89wXnJIpu4F0mFBN03zATEBNK7pRtMfl6gwtMOm5ECXs+Wz5qDHhwTFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14",
+        "@typescript-eslint/types": "^7.7.1 || ^8",
+        "astro-eslint-parser": "^1.3.0",
+        "eslint-compat-utils": "^0.6.0",
+        "globals": "^16.0.0",
+        "postcss": "^8.4.14",
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.57.0"
+      }
+    },
+    "node_modules/eslint-plugin-astro/node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "62.8.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.8.1.tgz",
-      "integrity": "sha512-e9358PdHgvcMF98foNd3L7hVCw70Lt+YcSL7JzlJebB8eT5oRJtW6bHMQKoAwJtw6q0q0w/fRIr2kwnHdFDI6A==",
+      "version": "63.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.2.tgz",
+      "integrity": "sha512-0TchoK1uS4VxHSo3P4CyWQ31Lm+6zsT+xkHMC5KbFKwgOf8YrXPf1Bl8EP7kpgw1wfe/Ui5jz5mSX7ou8WAVuw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.84.0",
+        "@es-joy/jsdoccomment": "~0.87.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.5",
+        "comment-parser": "1.4.7",
         "debug": "^4.4.3",
         "escape-string-regexp": "^4.0.0",
-        "espree": "^11.1.0",
+        "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "html-entities": "^2.6.0",
-        "object-deep-merge": "^2.0.0",
+        "object-deep-merge": "^2.0.1",
         "parse-imports-exports": "^0.2.4",
-        "semver": "^7.7.4",
+        "semver": "^7.8.2",
         "spdx-expression-parse": "^4.0.0",
         "to-valid-identifier": "^1.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^22.13.0 || >=24"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
@@ -1108,9 +1304,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1203,7 +1399,6 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -1256,9 +1451,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1310,13 +1505,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1335,6 +1530,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1352,9 +1577,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -1368,6 +1593,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -1380,6 +1615,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/finalhandler": {
@@ -1529,9 +1777,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1568,9 +1816,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1581,9 +1829,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1675,9 +1923,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1700,7 +1948,6 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1711,12 +1958,21 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-promise": {
@@ -1734,9 +1990,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1744,9 +2000,9 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.1.1.tgz",
-      "integrity": "sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1872,6 +2128,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -1900,14 +2193,14 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1922,6 +2215,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -1952,9 +2264,9 @@
       }
     },
     "node_modules/object-deep-merge": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
-      "integrity": "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2096,15 +2408,22 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
@@ -2127,6 +2446,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+      "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/prelude-ls": {
@@ -2166,9 +2528,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2180,6 +2542,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -2230,6 +2613,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -2247,6 +2641,30 @@
         "node": ">= 18"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2255,9 +2673,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2345,15 +2763,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2365,14 +2783,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2418,6 +2836,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/spdx-exceptions": {
@@ -2475,6 +2903,35 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.3.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/to-valid-identifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
@@ -2517,18 +2974,36 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/unpipe": {
@@ -2551,6 +3026,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -2637,9 +3119,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
+        "@gesslar/bedoc": "^2.0.0",
         "@gesslar/lpc-mcp": "^1.6.0"
       }
     },
@@ -148,6 +149,100 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@gesslar/actioneer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@gesslar/actioneer/-/actioneer-3.0.2.tgz",
+      "integrity": "sha512-cneXGjkqBfW0ygEVVFjOqECOJ442GwwhxpYtlmeAO5nzkwrBYB4ra4XvcsZIjUe+KwjvPaCNu0uygGmEMTZ5tQ==",
+      "dev": true,
+      "license": "0BSD",
+      "dependencies": {
+        "@gesslar/toolkit": "^5.5.2"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@gesslar/actioneer/node_modules/@gesslar/colours": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@gesslar/colours/-/colours-1.0.0.tgz",
+      "integrity": "sha512-+u3j2gG6nWlAgqVJ2zXBtiSDMlc71US4sCG1D4EksZI72MUTYFuE5QYew2+XAGZwXKi31ibdNil+Hoy0y2jGEA==",
+      "dev": true,
+      "license": "0BSD",
+      "bin": {
+        "colours": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=24.11.0"
+      }
+    },
+    "node_modules/@gesslar/actioneer/node_modules/@gesslar/toolkit": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.5.2.tgz",
+      "integrity": "sha512-z9bNajNrT/1JQJiDokkq9F7E8Mt6BWsHuVqENoEBrGHbSwSZRqf30MdLh/ktDATgS3YaiD0QgFQgap4nzqiSEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "0BSD",
+      "dependencies": {
+        "@gesslar/colours": "^1.0.0",
+        "json5": "^2.2.3",
+        "supports-color": "^10.2.2",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@gesslar/bedoc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@gesslar/bedoc/-/bedoc-2.0.0.tgz",
+      "integrity": "sha512-Z3c5JQntj6fx3rlezyMAEMaFEjXQRKwv57LdwT/NpPKRevEMfaGXRpMdFGQ/hjaTGoVmjklM0hpZv+gchbLFNg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "@gesslar/actioneer": "^3.0.1",
+        "@gesslar/colours": "^1.0.0",
+        "@gesslar/negotiator": "^1.0.0",
+        "@gesslar/toolkit": "^5.5.1",
+        "commander": "^15.0.0",
+        "error-stack-parser": "^2.1.4"
+      },
+      "bin": {
+        "bedoc": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@gesslar/bedoc/node_modules/@gesslar/colours": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@gesslar/colours/-/colours-1.0.0.tgz",
+      "integrity": "sha512-+u3j2gG6nWlAgqVJ2zXBtiSDMlc71US4sCG1D4EksZI72MUTYFuE5QYew2+XAGZwXKi31ibdNil+Hoy0y2jGEA==",
+      "dev": true,
+      "license": "0BSD",
+      "bin": {
+        "colours": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=24.11.0"
+      }
+    },
+    "node_modules/@gesslar/bedoc/node_modules/@gesslar/toolkit": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.5.2.tgz",
+      "integrity": "sha512-z9bNajNrT/1JQJiDokkq9F7E8Mt6BWsHuVqENoEBrGHbSwSZRqf30MdLh/ktDATgS3YaiD0QgFQgap4nzqiSEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "0BSD",
+      "dependencies": {
+        "@gesslar/colours": "^1.0.0",
+        "json5": "^2.2.3",
+        "supports-color": "^10.2.2",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
     "node_modules/@gesslar/colours": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@gesslar/colours/-/colours-0.8.0.tgz",
@@ -179,6 +274,52 @@
       },
       "engines": {
         "node": ">=24.13.0"
+      }
+    },
+    "node_modules/@gesslar/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@gesslar/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-+u06w0Y3aiwD2gbHIfIOwlhWdJb2SlVsvJXvaLDZ1bCzPt5o5P+/6ZxEw54bcFSyhoBPOP+HaWXuRY8lTnPRrQ==",
+      "dev": true,
+      "license": "0BSD",
+      "dependencies": {
+        "@gesslar/toolkit": "^5.0.1",
+        "ajv": "^8.18.0",
+        "json5": "^2.2.3",
+        "yaml": "^2.8.3"
+      },
+      "engines": {
+        "node": ">=24.11.0"
+      }
+    },
+    "node_modules/@gesslar/negotiator/node_modules/@gesslar/colours": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@gesslar/colours/-/colours-1.0.0.tgz",
+      "integrity": "sha512-+u3j2gG6nWlAgqVJ2zXBtiSDMlc71US4sCG1D4EksZI72MUTYFuE5QYew2+XAGZwXKi31ibdNil+Hoy0y2jGEA==",
+      "dev": true,
+      "license": "0BSD",
+      "bin": {
+        "colours": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=24.11.0"
+      }
+    },
+    "node_modules/@gesslar/negotiator/node_modules/@gesslar/toolkit": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.5.2.tgz",
+      "integrity": "sha512-z9bNajNrT/1JQJiDokkq9F7E8Mt6BWsHuVqENoEBrGHbSwSZRqf30MdLh/ktDATgS3YaiD0QgFQgap4nzqiSEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "0BSD",
+      "dependencies": {
+        "@gesslar/colours": "^1.0.0",
+        "json5": "^2.2.3",
+        "supports-color": "^10.2.2",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@gesslar/toolkit": {
@@ -588,6 +729,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/comment-parser": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
@@ -741,6 +892,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-define-property": {
@@ -2284,6 +2445,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2439,9 +2607,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
     "wiki:stop": "docker compose -f adm/etc/starlight/docker-compose.yml down",
     "wiki:dev": "npm --prefix doc/wiki run dev",
     "wiki:build": "npm --prefix doc/wiki run build",
-    "wiki:deploy": "gh workflow run deploy-wiki.yml"
+    "wiki:deploy": "gh workflow run deploy-wiki.yml",
+    "sefuns": "bash adm/bash/sefuns"
   },
   "devDependencies": {
-    "@gesslar/bedoc": "^2.0.0",
+    "@gesslar/bedoc": "*",
     "@gesslar/lpc-mcp": "^1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "wiki:deploy": "gh workflow run deploy-wiki.yml"
   },
   "devDependencies": {
+    "@gesslar/bedoc": "^2.0.0",
     "@gesslar/lpc-mcp": "^1.6.0"
   }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a BeDoc-powered pipeline that scrapes LPCDoc comment blocks from `adm/simul_efun/*.c` and emits a standalone `.help` file per public function into `doc/sefun/`. A new bash script (`adm/bash/sefuns`) drives clean rebuilds, and the generated `.help` files are committed alongside the tooling.

- **New tooling (`doc/bedoc/`)**: LPC parser, help formatter, and a per-function file-writer hook wired together via `sefun.json5`; `@gesslar/bedoc ^2.0.0` added as a dev dependency.
- **277 generated `.help` files** committed to `doc/sefun/` covering every public simul_efun.
- **`adm/bash/sefuns`**: wrapper script that clears `doc/sefun/*.help` and `tmp/bedoc/*` before invoking BeDoc, so orphaned files from renamed/removed sefuns are cleaned up on rebuild.

<h3>Confidence Score: 5/5</h3>

All changes are new documentation tooling and generated help files; no production LPC code is modified.

The parser, formatter, and hook are all new files with no pre-existing behaviour to regress. The generated `.help` files are static documentation. The bash script performs a clean delete then regenerate, with `tmp/bedoc/` already covered by the repo's `/tmp/*` gitignore rule.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Update doc/bedoc/sefun.json5"](https://github.com/gesslar/oxidus-mudlib/commit/b957797962f91a9a68a2cb1afeb264354700c82f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36615030)</sub>

<!-- /greptile_comment -->