### PR TITLE
feat: help system include directories with explicit privs

### DIFF
--- a/adm/daemons/help.c
+++ b/adm/daemons/help.c
@@ -18,16 +18,37 @@ public void rehash();
 private void rehash_directory(mapping directory);
 
 private nosave string  __help_root;
-private nosave string *__excludes; // wired, not yet filtered on — intentional
+private nosave string *__excluded_directories;
+private nosave mixed  *__included_directories;
 private nosave mapping __cache = ([]);
 
 void setup() {
   set_no_clean();
 
   __help_root = mud_config("DOC.ROOT") + mud_config("DOC.HELP.ROOT");
-  __excludes = map(
+  __excluded_directories = map(
     mud_config("DOC.HELP.EXCLUDE") ?? ({}),
     (: __help_root + $1 :)
+  );
+  __excluded_directories = map(__excluded_directories,
+    (: resolve_dir("", $1) :)
+  );
+
+  __included_directories = map(
+    mud_config("DOC.HELP.INCLUDE") ?? ({}),
+    (: ({
+        pointerp($1)
+          ? __help_root + $1[0]
+          : stringp($1)
+            ? __help_root + $1
+            : error("Invalid include format in config."),
+        pointerp($1) && sizeof($1) ? $1[1] : "all"
+      })
+    :)
+  );
+
+  __included_directories = map(__included_directories,
+    (: ({ resolve_dir("", $1[0]), $1[1] }) :)
   );
 
   rehash();
@@ -37,20 +58,41 @@ public void rehash() {
   __cache = ([]);
 
   mapping fd = read_directory(__help_root);
+  mixed *directories = map(fd["directories"], (: ({ $1, undefined }) :));
+  mixed *included_directories = map(
+    __included_directories,
+    (: ({ as_directory($1[0]), $1[1] }) :)
+  );
+  included_directories = filter(included_directories, (: $1[0] :));
+  mapping *excluded_directories = map(
+    __excluded_directories,
+    (: as_directory :)
+  );
+  excluded_directories = filter(excluded_directories, (: $1 :));
 
-  int sz = sizeof(fd["directories"]);
+  string *excluded_paths = map(excluded_directories, (: $1["path"] :));
+
+  directories += included_directories;
+  directories = filter(directories, (: !includes($(excluded_paths), $1[0]["path"]) :));
+
+  int sz = sizeof(directories);
 
   while(sz--)
-    call_out_walltime((: rehash_directory, fd["directories"][sz] :), sz * 0.1);
+    call_out_walltime((: rehash_directory, directories[sz] :), sz * 0.1);
 }
 
-private void rehash_directory(mapping directory) {
+private void rehash_directory(mapping directory_entry) {
+  mapping directory = directory_entry[0];
+  string priv = directory_entry[1];
+
   if(file_size(directory["path"]) != -2)
     return;
 
-  mapping fd = read_directory(directory["path"], "*.help");
+  mapping fd = read_directory(directory["path"]);
   mapping *files = fd["files"];
-  mapping help = ([]);
+  mapping help = ([
+    "priv" : priv,
+  ]);
 
   if(!sizeof(files))
     return;
@@ -111,15 +153,17 @@ mapping *query_help(string topic, object who) {
   mapping *result = ({});
 
   foreach(string cat, mapping helps in __cache) {
-    if(cat == "all" || !includes(groups, cat)) {
-      if(helps[topic]) {
-        push(ref result, ({ cat, helps[topic] }));
-      }
-    } else {
-      if(helps[topic] && is_member(name, cat)) {
-        push(ref result, ({ cat, helps[topic] }));
-      }
-    }
+    if(!helps[topic])
+      continue;
+
+    // Includes carry an explicit priv; plain directories fall back to the
+    // directory name acting as its own priv.
+    string priv = helps["priv"] ?? cat;
+
+    if(priv == "all" || !includes(groups, priv))
+      push(ref result, ({ cat, helps[topic] }));
+    else if(is_member(name, priv))
+      push(ref result, ({ cat, helps[topic] }));
   }
 
   return result;

--- a/adm/etc/default.lpml
+++ b/adm/etc/default.lpml
@@ -133,6 +133,11 @@
     HELP: {
       ROOT: "help/",
       EXCLUDE: [],
+      INCLUDE: [
+        ["../driver/apply", "developer"],
+        ["../driver/efun", "developer"],
+        ["../sefun", "developer"],
+      ]
     }
   }
 }

--- a/adm/simul_efun/file.c
+++ b/adm/simul_efun/file.c
@@ -500,6 +500,8 @@ mapping as_directory(string str) {
 
   assert_arg(stringp(str) && truthy(str), 1, "Invalid path: "+sprintf("%O", str));
 
+  str = chop(str, "/", -1);
+
   info = get_dir(str, -1);
   if(!sizeof(info))
     return 0;


### PR DESCRIPTION
## Help Daemon: Support Explicit Include Directories with Privilege Control

The help daemon previously only served files from directories under the help root, with an exclusion list to filter out specific paths. This adds support for explicitly included directories that can live outside the help root (such as driver apply/efun docs and sefun docs), each with an associated privilege string controlling who can see those help entries.

### Changes

- Renames `__excludes` to `__excluded_directories` for clarity and resolves both excluded and included paths through `resolve_dir` at setup time.
- Introduces `__included_directories`, populated from a new `DOC.HELP.INCLUDE` config key. Each entry is either a plain string (path relative to help root) or a two-element array of `[path, priv]`. If no privilege is specified, it defaults to `"all"`.
- During `rehash`, included directories are merged into the directory list before exclusions are applied. Each directory entry now carries its privilege alongside the directory mapping.
- `rehash_directory` stores the privilege in the help cache under a `"priv"` key. At query time, `query_help` reads this stored privilege rather than relying solely on the category name, so directories outside the normal help root can still enforce access control correctly.
- Adds `../driver/apply`, `../driver/efun`, and `../sefun` as default included directories restricted to the `developer` group in `default.lpml`.
- Fixes `as_directory` in `file.c` to strip a trailing slash before calling `get_dir`, preventing lookup failures on paths that include one.

Lastly, the help daemon no longer filters on `*.help`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the help daemon to support explicitly included directories outside the help root, each with an associated access privilege, and wires in three developer-restricted doc directories (`../driver/apply`, `../driver/efun`, `../sefun`) as defaults. It also fixes `as_directory` in `file.c` to strip a trailing slash before `get_dir`.

- `help.c`: introduces `__included_directories`, merges them into the directory list at `rehash` time, stores a `\"priv\"` key in the cache per directory, and reads that key at query time rather than relying on the category name for access control.
- `file.c`: `chop(str, \"/\", -1)` strips a trailing slash before `get_dir`, preventing lookup failures on paths that already include one.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: a single-character correction in the priv-extraction ternary prevents a crash when a 1-element array config entry is supplied.

The `sizeof($1)` guard in the priv-extraction ternary is truthy for a 1-element array, causing an unconditional `$1[1]` out-of-bounds access and a runtime error in `setup()`. All other functional paths — the `as_directory` zero-filtering, the exclusion filter, and the access-control rewrite in `query_help` — look correct.

adm/daemons/help.c line 45 (the priv-extraction ternary in setup)

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aadm%2Fdaemons%2Fhelp.c%3A45%0AThe%20priv-extraction%20guard%20%60sizeof%28%241%29%60%20is%20truthy%20for%20a%20single-element%20array%2C%20so%20it%20falls%20through%20to%20%60%241%5B1%5D%60%20which%20is%20an%20out-of-bounds%20access%20and%20a%20runtime%20error.%20The%20intent%20appears%20to%20be%20%22use%20%60%241%5B1%5D%60%20only%20when%20a%20second%20element%20exists%2C%22%20so%20the%20check%20should%20be%20%60sizeof%28%241%29%20%3E%201%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20pointerp%28%241%29%20%26%26%20sizeof%28%241%29%20%3E%201%20%3F%20%241%5B1%5D%20%3A%20%22all%22%0A%60%60%60%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=223&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fleshing out excludes but also adding ap..."](https://github.com/gesslar/oxidus-mudlib/commit/c6161ad0b00200571618a5b1a064b5d5bd5d54c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36634029)</sub>

<!-- /greptile_comment -->