### PR TITLE
fix: handle whitespace after opening paren in `from_string`

### DIFF
--- a/adm/simul_efun/string.c
+++ b/adm/simul_efun/string.c
@@ -192,10 +192,11 @@ varargs mixed from_string(string str, int flag) {
     str = replace_string(str, "\"\"", "");
 
     if(str[0] == '(') {
-        switch(str[1]) {
+        string inner = ltrim(str[1..]);
+        switch(inner[0]) {
             case '{':
                 ret[0] = ({});
-                str = ltrim(str[2..]);
+                str = ltrim(inner[1..]);
                 if(str[0] == '}') {
                     // Empty array case
                     str = str[1..];

--- a/adm/simul_efun/string.c
+++ b/adm/simul_efun/string.c
@@ -244,7 +244,7 @@ varargs mixed from_string(string str, int flag) {
                 return ret;
             case '[':
                 ret[0] = ([]);
-                str = str[2..];
+                str = ltrim(inner[1..]);
                 while(str[0] != ']') {
                     mixed *tmp;
                     mixed cle;


### PR DESCRIPTION
### TL;DR

Fixed `from_string` to handle whitespace between the opening `(` and collection type characters (`{`, `[`).

### What changed?

The `from_string` function now trims leading whitespace from the character immediately following the opening `(` before checking for array (`{`) or mapping (`[`) delimiters. Previously, the code directly indexed into the string at position `[1]` without accounting for any whitespace, which could cause incorrect parsing. The trimmed inner string is now reused consistently for both array and mapping cases when advancing past the opening delimiter.

### How to test?

Attempt to parse string representations of arrays and mappings that contain whitespace after the opening parenthesis, such as `"( {1,2,3})"` or `"( [\"key\":\"value\"])"`, and verify they are correctly deserialized into their respective LPC data structures.

### Why make this change?

The previous implementation assumed no whitespace between `(` and the collection type character, making parsing fragile for strings that include such whitespace. This fix makes `from_string` more robust and consistent in how it handles leading whitespace within collection literals.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `ltrim` to the `from_string` simul_efun to tolerate optional whitespace between an opening `(` and the `{` or `[` type delimiter when parsing arrays and mappings.

- For both array `({` and mapping `([` forms, a new `inner = ltrim(str[1..])` strips any spaces between `(` and the delimiter before the `switch`, so inputs like `( { ... })` are now parsed correctly.
- The mapping case also gains a `ltrim` call after `[` (previously `str = str[2..]` had no trim), making it consistent with the array case.

<h3>Confidence Score: 5/5</h3>

Small, focused change that adds whitespace tolerance to the parser — safe to merge.

The change is minimal and surgical: introducing inner = ltrim(str[1..]) unifies both the array and mapping branches, fixing a latent inconsistency where the mapping branch was missing ltrim entirely. No existing code paths regress — when there is no whitespace between ( and the delimiter, ltrim is a no-op and the behavior is identical to before.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["from\_string: ltrim inner for mapping cas..."](https://github.com/gesslar/oxidus-mudlib/commit/54d110e54162174081f9eb08d683c907a2b8fbad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37156661)</sub>

<!-- /greptile_comment -->