### PR TITLE
feat: add alarmp predicate simul_efun

### DIFF
--- a/adm/include/simul_efun.h
+++ b/adm/include/simul_efun.h
@@ -196,6 +196,10 @@ varargs mixed *accessible_objects(object container, object pov);
 varargs object *accessible_objects_flat(object container, object pov);
 object shutdown_d();
 
+// File: predicates.c
+int roomp(object ob);
+int alarmp(object ob);
+
 // File: prompt.c
 varargs void prompt_colour(object body, mixed *cb, string prompt);
 void prompt_password(object user, int attempts, mixed *cb);

--- a/adm/simul_efun/predicates.c
+++ b/adm/simul_efun/predicates.c
@@ -9,3 +9,19 @@
 int roomp(object ob) {
   return objectp(ob) && call_if(ob, "is_room");
 }
+
+/**
+ * Determine whether the current call originated from the alarm
+ * daemon on behalf of a valid object.
+ *
+ * Intended as a guard inside alarm callbacks: the target object can
+ * confirm that it is genuinely being driven by ALARM_D rather than by
+ * an arbitrary caller before acting on the alarm.
+ *
+ * @param {object} ob - The object the alarm pertains to.
+ * @returns {int} 1 if ob is a valid object and the immediate caller is
+ *                the alarm daemon, otherwise 0.
+ */
+int alarmp(object ob) {
+  return objectp(ob) && file_name(ob) == ALARM_D;
+}


### PR DESCRIPTION
### TL;DR

Adds a new `alarmp()` simul-efun predicate for validating alarm daemon callbacks.

### What changed?

A new `alarmp(object ob)` function has been added to `predicates.c` and declared in `simul_efun.h`. It returns `1` if the provided object is valid and the immediate caller is the alarm daemon (`ALARM_D`), otherwise `0`.

### How to test?

Inside an alarm callback, call `alarmp(this_object())` and verify it returns `1` when invoked by `ALARM_D` and `0` when called from any other context.

### Why make this change?

Objects that register alarm callbacks need a reliable way to confirm that a callback is genuinely being driven by `ALARM_D` rather than an arbitrary or potentially malicious caller. `alarmp()` provides a simple, reusable guard for this purpose, consistent with the existing `roomp()` predicate pattern.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `alarmp(object ob)` simul-efun predicate intended to let alarm callbacks verify they are being driven by `ALARM_D` rather than an arbitrary caller, along with its header declaration in `simul_efun.h`.

- The implementation body checks `file_name(ob) == ALARM_D`, which tests whether the *argument* is the alarm daemon — not whether the *caller* is. In the intended usage (`alarmp(this_object())`), `ob` is the callback object, so the comparison is always false and the guard never approves any call.
- `adm/include/simul_efun.h` is a clean, straightforward declaration addition with no issues.

<h3>Confidence Score: 4/5</h3>

The new predicate is broken as written — it will never return `1` in its intended use — but merging it does not corrupt data or destabilize the mud; it simply adds a guard that objects cannot use until the logic is corrected.

The `alarmp` function checks the identity of the object passed as the argument rather than the identity of the caller, so the alarm-callback guard always evaluates to `0`. Any object that calls `alarmp(this_object())` will receive `0` regardless of whether it was actually invoked by `ALARM_D`, making the predicate non-functional from day one.

adm/simul_efun/predicates.c — the guard condition targets the wrong object

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aadm%2Fsimul_efun%2Fpredicates.c%3A25-27%0AThe%20guard%20checks%20%60file_name%28ob%29%60%20%E2%80%94%20the%20object%20passed%20as%20the%20parameter%20%E2%80%94%20instead%20of%20the%20caller's%20identity.%20When%20used%20as%20intended%20%28%60alarmp%28this_object%28%29%29%60%20inside%20an%20alarm%20callback%29%2C%20%60ob%60%20is%20the%20callback%20object%2C%20not%20%60ALARM_D%60%2C%20so%20the%20comparison%20always%20evaluates%20to%20%600%60%20and%20the%20predicate%20never%20approves%20any%20call.%20The%20caller-identity%20check%20needs%20to%20target%20%60previous_object%28%29%60%2C%20not%20the%20argument.%0A%0A%60%60%60suggestion%0Aint%20alarmp%28object%20ob%29%20%7B%0A%20%20return%20objectp%28ob%29%20%26%26%20base_name%28previous_object%28%29%29%20%3D%3D%20ALARM_D%3B%0A%7D%0A%60%60%60%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=227&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["predicate add"](https://github.com/gesslar/oxidus-mudlib/commit/efdbfa0305d18516cb26df28a17ff026384562ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37156759)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->