### PR TITLE
fix: typo in description.h include guard

### DIFF
--- a/std/object/include/description.h
+++ b/std/object/include/description.h
@@ -1,5 +1,5 @@
-#ifndef __DESCRTIPTION_H__
-#define __DESCRTIPTION_H__
+#ifndef __DESCRIPTION_H__
+#define __DESCRIPTION_H__
 
 void set_long(mixed str);
 void set_short(mixed str);
@@ -14,4 +14,4 @@ void add_extra_short(string id, mixed str);
 void remove_extra_long(string id);
 void remove_extra_short(string id);
 
-#endif // __DESCRTIPTION_H__
+#endif // __DESCRIPTION_H__


### PR DESCRIPTION
### TL;DR

Fixed a typo in the header guard for `description.h`.

### What changed?

The header guard macro was misspelled as `__DESCRTIPTION_H__` in three places. It has been corrected to `__DESCRIPTION_H__`.

### How to test?

Verify that the project compiles without issues and that any files including `description.h` resolve the header guard correctly.

### Why make this change?

While the misspelled guard still functioned correctly on its own (since all three instances were consistently misspelled), correcting the typo improves code clarity and prevents potential confusion or conflicts if the header guard is ever referenced externally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects a typo in the include guard of `std/object/include/description.h`, renaming `__DESCRTIPTION_H__` to `__DESCRIPTION_H__` in all three occurrences (`#ifndef`, `#define`, and the trailing `#endif` comment).

- The misspelling was internally consistent so the guard worked in isolation, but this fix makes the macro name match the filename and removes potential confusion if the guard is ever referenced externally.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a mechanical rename of a misspelled preprocessor macro across all three of its use sites with no logic affected.

All three occurrences of the guard macro are updated consistently, the file's include-guard logic is unchanged, and no other files in the diff are touched. There is nothing here that could introduce a regression.

No files require special attention.

<sub>Reviews (4): Last reviewed commit: ["fixing typo"](https://github.com/gesslar/oxidus-mudlib/commit/4b7ce29780874564f6a2ca823beb34f3fc94747f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37156801)</sub>

<!-- /greptile_comment -->