### PR TITLE
fix: use `undefined` instead of `0` in `valid_file`

### DIFF
--- a/adm/simul_efun/resolve_path.c
+++ b/adm/simul_efun/resolve_path.c
@@ -81,12 +81,12 @@ string valid_path(string base_dir, string path) {
  *
  * @param {string} base_dir - The base directory to resolve relative paths from.
  * @param {string} path - The file path to resolve and validate.
- * @returns {string|int} The resolved absolute file path if valid, or 0 if invalid.
+ * @returns {string | undefined} The resolved absolute file path if valid, or undefined if invalid.
  */
 string valid_file(string base_dir, string path) {
   string resolved = resolve_path(base_dir, path);
 
-  return file_exists(resolved) ? resolved : 0;
+  return file_exists(resolved) ? resolved : undefined;
 }
 
 /**


### PR DESCRIPTION
### TL;DR

Updated `valid_file` to return `undefined` instead of `0` when a file path is invalid.

### What changed?

The `valid_file` function now returns `undefined` rather than `0` when the resolved path does not correspond to an existing file. The JSDoc return type annotation was also updated from `{string|int}` to `{string | undefined}` to reflect this behavior.

### How to test?

Call `valid_file` with a path that does not exist and verify the return value is `undefined` rather than `0`. Also confirm that valid paths still return the resolved absolute file path as expected.

### Why make this change?

Returning `undefined` is more semantically accurate and consistent with modern conventions for representing the absence of a value, making the function's intent clearer and reducing potential confusion with a numeric `0` return.

Note that downsteram callers relying on `!result` will still function as they have.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `valid_file` in `adm/simul_efun/resolve_path.c` to return `undefined` instead of `0` when the resolved path does not correspond to an existing file, and updates the JSDoc return type annotation accordingly.

- The change is minimal and targeted: only the failure-path return value and JSDoc of `valid_file` are affected; sibling functions `valid_path` and `valid_dir` are untouched.
- Callers using falsy checks (`!result`) continue to work correctly since `undefined` is falsy in LPC, matching the pre-existing behavior of `0`.

<h3>Confidence Score: 5/5</h3>

The change is isolated to the failure-return path of a single function and does not affect valid-path logic or callers using falsy checks.

Only one line of logic changes — the falsy return value of `valid_file` moves from `0` to `undefined`. Both are falsy in LPC, so callers relying on `!result` are unaffected. No control-flow, type-coercion, or compilation concerns are introduced by the change itself.

No files require special attention beyond the already-noted inconsistency between `valid_file` (now `undefined`) and its siblings `valid_path`/`valid_dir` (still `0`).

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `adm/simul_efun/resolve_path.c`, line 75-103 ([link](https://github.com/gesslar/oxidus-mudlib/blob/2ee70cc3da89f121aab20554919e93240cc71a0a/adm/simul_efun/resolve_path.c#L75-L103)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Inconsistent failure return across sibling functions**

   `valid_path` (line 75) and `valid_dir` (line 103) still return `0` on failure, while `valid_file` now returns `undefined`. Any caller pattern-matching on `== 0` will work for `valid_path`/`valid_dir` but silently fail for `valid_file`, since `undefined != 0` in LPC. Keeping all three sibling functions consistent (either all `0` or all `undefined`) would avoid this subtle divergence.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20adm%2Fsimul_efun%2Fresolve_path.c%0ALine%3A%2075-103%0A%0AComment%3A%0A**Inconsistent%20failure%20return%20across%20sibling%20functions**%0A%0A%60valid_path%60%20%28line%2075%29%20and%20%60valid_dir%60%20%28line%20103%29%20still%20return%20%600%60%20on%20failure%2C%20while%20%60valid_file%60%20now%20returns%20%60undefined%60.%20Any%20caller%20pattern-matching%20on%20%60%3D%3D%200%60%20will%20work%20for%20%60valid_path%60%2F%60valid_dir%60%20but%20silently%20fail%20for%20%60valid_file%60%2C%20since%20%60undefined%20!%3D%200%60%20in%20LPC.%20Keeping%20all%20three%20sibling%20functions%20consistent%20%28either%20all%20%600%60%20or%20all%20%60undefined%60%29%20would%20avoid%20this%20subtle%20divergence.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gesslar%2Foxidus-mudlib&pr=229&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["minor update to valid\_file"](https://github.com/gesslar/oxidus-mudlib/commit/e5460cd4f8579698d1b23873587b3a18d390db5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37156886)</sub>

<!-- /greptile_comment -->