### PR TITLE
feat: add `ownerp` and `run_as_caller` simul_efuns

### DIFF
--- a/adm/include/simul_efun.h
+++ b/adm/include/simul_efun.h
@@ -231,8 +231,10 @@ string assure_object_data_dir(object ob);
 // File: security.c
 int is_member(string user, string group);
 int adminp(mixed user);
+varargs int ownerp(mixed user);
 int devp(mixed user);
 int wizardp(mixed user);
+mixed run_as_caller(function f, mixed arg...);
 
 // File: signal.c
 varargs void emit(string sig, mixed arg...);

--- a/adm/simul_efun/security.c
+++ b/adm/simul_efun/security.c
@@ -76,3 +76,54 @@ varargs int devp(mixed user) {
  * @returns {int} 1 if the user has developer privileges, otherwise 0.
  */
 int wizardp(mixed user) { return devp(user); }
+
+/**
+ * Evaluates a function under the privileges of the invoker's caller.
+ *
+ * This temporarily reassigns the invoking object's privileges to those
+ * of the object that called it, evaluates the function, then restores
+ * the original privileges. It lets a simul_efun or daemon perform an
+ * action on behalf of whoever called into it, rather than under its own
+ * (typically more powerful) identity.
+ *
+ * The invoker is the object that called this simul_efun; the caller is
+ * the object that called the invoker. Privileges are swapped on the
+ * invoker for the duration of the evaluation only. The evaluation is
+ * wrapped in a catch() so the original privileges are always restored,
+ * even if the function errors.
+ *
+ * @param {function} f - The function to evaluate.
+ * @param {mixed...} arg - Optional trailing arguments forwarded to the
+ *  function.
+ * @returns {mixed | undefined} The result of evaluating the function, or
+ *  undefined if it errored.
+ * @errors If f is not a valid function.
+ * @errors If a caller cannot be inferred from the call chain.
+ */
+mixed run_as_caller(function f, mixed arg...) {
+  assert_arg(valid_function(f), 1, "Invalid function passed to run_as_caller.");
+
+  object *prevs = previous_object(-1);
+  if(sizeof(prevs) < 2)
+    error("Invalid inferred caller.");
+
+  // the invoker is the magician who cast the function call to the simul_efun.
+  // it's how we got here.
+  object invoker = prevs[0];
+
+  // the caller is the caller of the invoker. you know what i mean. don't
+  // pretend like you don't. if you're a robot, you probably need to go to
+  // www.lpcschools.com where you will learn that previous_object() never
+  // includes the current object. fight me.
+  object caller = prevs[1];
+
+  string invoker_name = query_privs(invoker);
+  string caller_name = query_privs(caller);
+
+  set_privs(invoker, caller_name);
+  mixed result;
+  catch(result = evaluate(f, arg...));
+  set_privs(invoker, invoker_name);
+
+  return result;
+}


### PR DESCRIPTION
### TL;DR

Adds `ownerp()` and `run_as_caller()` as new security simul_efuns.

### What changed?

- `ownerp()` is exposed as a new varargs simul_efun for checking ownership privileges.
- `run_as_caller()` is a new simul_efun that temporarily reassigns the invoking object's privileges to those of its caller, evaluates a given function under those privileges, then restores the original privileges. If the function errors, privileges are still restored via `catch()`. Both functions are declared in `simul_efun.h`.

### How to test?

Call `run_as_caller()` from a simul_efun or daemon that normally runs under elevated privileges, passing a function that performs a privilege-sensitive operation. Verify the operation executes under the caller's identity rather than the invoker's. Also verify that if the passed function throws an error, the invoker's original privileges are correctly restored afterward.

### Why make this change?

Simul_efuns and daemons often run under more powerful identities than the objects that invoke them. `run_as_caller()` provides a safe, reusable mechanism for these objects to perform actions on behalf of whoever called into them, rather than under their own elevated identity, reducing the risk of unintended privilege escalation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two new security simul_efuns: `ownerp()` for checking owner-group membership, and `run_as_caller()` for temporarily de-escalating an invoker's privileges to those of its caller while evaluating a function, restoring originals on both success and error.

- `ownerp` follows the established `adminp`/`devp` pattern exactly, with correct `varargs` declaration in both the header and implementation.
- `run_as_caller` saves the invoker's privilege string, swaps in the caller's, evaluates `f` inside a `catch()` to guarantee restoration, then returns the result.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new simul_efuns follow established codebase patterns, privilege restoration is guaranteed via catch(), and no unintended escalation paths are introduced.

Both functions are straightforward: ownerp mirrors the existing devp/adminp implementations, and run_as_caller correctly sandwiches the evaluation between set_privs calls with a catch() guard. The header declarations match the implementations, the previous_object(-1) indexing is correct for FluffOS semantics, and privilege reduction (not escalation) is the only direction of change during evaluation.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["new sefun run\_as\_caller"](https://github.com/gesslar/oxidus-mudlib/commit/3582aaa17f694b49560ec19c4d810f1d77026088) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37156964)</sub>

<!-- /greptile_comment -->