### PR TITLE
feat: add file caching daemon

### DIFF
--- a/adm/daemons/cache.c
+++ b/adm/daemons/cache.c
@@ -1,0 +1,177 @@
+/**
+ * @file /adm/daemons/cache.c
+ *
+ * A daemon that reads files and caches the result for later consumption.
+ * Cached records are keyed by resolved path and invalidated automatically
+ * when the underlying file's modification time changes. Both the raw file
+ * contents and a decoded form (LPML or save-string) are retained per path.
+ *
+ * Note: the "skip cache" option in default_options is reserved and not yet
+ * honoured by the lookup path.
+ *
+ * @created 2026-06-11 - Gesslar
+ * @last_modified 2026-06-11 - Gesslar
+ *
+ * @history
+ * 2026-06-11 - Gesslar - Created
+ */
+
+#include <stat.h>
+
+inherit STD_DAEMON;
+
+private nomask void clean(string path);
+private nomask mixed load_from_cache(string file_name, string kind);
+public nomask mixed load_data(string file_name, mapping options);
+public nomask varargs void invalidate(string ttl);
+
+/**
+ * Cache store keyed by resolved file path. Each record holds the file's
+ * last-modified timestamp, the raw file contents, and the decoded form.
+ *
+ * @type {([ string: ([ string: mixed ]) ])}
+ */
+private nomask nosave mapping __cache = ([]);
+
+/**
+ * Default options applied to load_data when no options mapping is supplied.
+ * "skip cache" is reserved and not yet honoured by the lookup path.
+ * "reparse" is reserved and not yet honoured by the lookup path.
+ *
+ * @type {([ string: mixed ])}
+ */
+private nomask nosave mapping default_options = ([
+  "kind": "string",
+  "skip cache": false,
+  "reparse": false,
+]);
+
+void setup() {
+  set_no_clean();
+}
+
+/**
+ * Removes a single path's record from the cache.
+ *
+ * @private
+ * @param {string} path - The resolved file path to evict.
+ */
+private nomask void clean(string path) {
+  map_delete(__cache, path);
+}
+
+/**
+ * Returns the cached data for a path, reading and decoding the file when no
+ * valid record exists. A record is valid only while its stored modification
+ * timestamp matches the file's current timestamp; otherwise the file is
+ * re-read and re-decoded. The raw contents are read under the caller's
+ * privileges. For "string" kind the raw contents are returned; for "lpml"
+ * the contents are decoded via lpml_decode (failures are swallowed, leaving
+ * the resolved value undefined); any other kind (ex: "auto") decodes via
+ * from_string.
+ *
+ * @private
+ * @param {string} path - The resolved file path to load.
+ * @param {string} kind - The decode mode: "string", "lpml", or other.
+ * @returns {mixed} The raw string, the decoded value, or undefined.
+ */
+private nomask mixed load_from_cache(string path, string kind) {
+  mixed *stats = stat(path, -1);
+  if(!sizeof(stats))
+    return undefined;
+
+  int last_modified = stats[STAT_LAST_MODIFIED];
+
+  mapping record = __cache[path] ?? ([
+    "modified": last_modified,
+    "raw": undefined,
+    "resolved": undefined,
+  ]);
+
+  record["last checked"] = time();
+
+  if(record["modified"] == last_modified) {
+    if(kind == "string" && !nullp(record["raw"])) {
+      return record["raw"];
+    }
+
+    if(!nullp(record["resolved"]))
+      return record["resolved"];
+  }
+
+  __cache[path] = record;
+
+  record["modified"] = last_modified;
+  record["raw"] = run_as_caller(read_file, path);
+  record["resolved"] = undefined;
+
+  if(kind == "string")
+    return record["raw"];
+
+  if(kind == "lpml")
+    catch(record["resolved"] = lpml_decode(record["raw"]));
+  else
+    record["resolved"] = from_string(record["raw"]);
+
+  return record["resolved"];
+}
+
+/**
+ * Loads a file through the cache, resolving and validating the path first.
+ *
+ * @public
+ * @param {string} file_name - The file to load, relative to the caller.
+ * @param {([ string: mixed ])} [options] - Lookup options; defaults to
+ *  default_options. "kind" selects the decode mode ("string", "lpml", or
+ *  "auto").
+ * @returns {mixed} The cached data, or undefined if the path is invalid.
+ * @errors If file_name is not a non-empty string.
+ * @errors If options["kind"] is not "string", "lpml", or "auto".
+ */
+public nomask mixed load_data(string file_name, mapping options: (: $(default_options) :)) {
+  assert_arg(stringp(file_name) && truthy(file_name), 1, "File name must be a non-empty string.");
+  assert_arg(options["kind"] == "string" || options["kind"] == "lpml" || options["kind"] == "auto", 2, "Kind must be 'string|lpml|auto'");
+
+  string path = valid_file("", file_name);
+  string kind = options["kind"] ?? "string";
+
+  if(nullp(path))
+    return undefined;
+
+  return load_from_cache(path, kind);
+}
+
+/**
+ * Evicts a file's cached record, forcing a fresh read on the next load.
+ *
+ * @public
+ * @param {string} file_name - The file to evict, relative to the caller.
+ * @errors If file_name is not a non-empty string.
+ */
+public nomask void reset_cache(string file_name) {
+  assert_arg(stringp(file_name) && truthy(file_name), 1, "File name must be a non-empty string.");
+
+  string path = valid_file("", file_name);
+
+  if(!path)
+    return;
+
+  clean(path);
+}
+
+public nomask varargs void invalidate(string ttl) {
+  if(!alarmp(previous_object()))
+    return;
+
+  int now = time();
+
+  foreach(string path, mapping data in __cache) {
+    if(stringp(ttl)) {
+      if(evaluate_number(now - data["last checked"], ttl)) {
+        clean(path);
+      }
+    } else {
+      clean(path);
+    }
+  }
+}

--- a/adm/etc/alarms/alarm.txt.example
+++ b/adm/etc/alarms/alarm.txt.example
@@ -20,5 +20,5 @@
 # Boot type alarms will schedule an alarm to be called in # seconds after the
 # MUD has booted via call_out_walltime().
 
-# H 00 true /adm/daemons/alarm test_alarm "top of the hour" 1
-# H 30 true /adm/daemons/alarm test_alarm "middle of the hour" 2
+# Every hour, invalidate cache entries older than 1h
+# H 00 true /adm/daemons/cache invalidate ">=3600"

--- a/include/daemons.h
+++ b/include/daemons.h
@@ -12,6 +12,7 @@
 #define BANK_D          DIR_DAEMONS "bank"
 #define BODY_D          DIR_DAEMONS "body"
 #define BOOT_D          DIR_DAEMONS "boot"
+#define CACHE_D         DIR_DAEMONS "cache"
 #define CHAN_D          DIR_DAEMONS "channel"
 #define COLOUR_D        DIR_DAEMONS "colour"
 #define CONFIG_D        DIR_DAEMONS "config"


### PR DESCRIPTION
### TL;DR

Introduces a new file-caching daemon (`CACHE_D`) that reads, decodes, and caches file contents keyed by resolved path, with automatic invalidation based on file modification time.

### What changed?

A new daemon at `/adm/daemons/cache.c` provides a centralized caching layer for file reads. It stores both the raw file contents and a decoded form per path, supporting three decode modes:

- `"string"` — returns raw file contents
- `"lpml"` — decodes via `lpml_decode`
- `"auto"` — decodes via `from_string`

Cached records are considered stale when the file's modification timestamp changes, triggering a fresh read on the next access. The daemon exposes:

- `load_data(file_name, options)` — loads a file through the cache
- `reset_cache(file_name)` — manually evicts a single file's cached record
- `invalidate(ttl)` — bulk-evicts entries older than a given TTL expression (intended to be called via the alarm system)

A `CACHE_D` macro has been added to `include/daemons.h` for easy reference. The alarm example file has been updated to show how to schedule hourly cache invalidation for entries older than 1 hour using `invalidate(">=36000")`.

### How to test?

1. Load `CACHE_D` and call `load_data` with a valid file path using each of the three `kind` options (`"string"`, `"lpml"`, `"auto"`).
2. Verify that a second call returns the cached result without re-reading the file.
3. Modify the underlying file and confirm the cache is invalidated and the new contents are returned on the next call.
4. Call `reset_cache` on a cached path and verify the next `load_data` performs a fresh read.
5. Trigger `invalidate` from an alarm with a TTL string and confirm that entries older than the threshold are evicted.

### Why make this change?

Repeated file reads for the same content are wasteful, especially for frequently accessed data files. This daemon provides a shared, modification-aware cache to reduce redundant disk I/O while ensuring consumers always receive up-to-date data when files change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new file-caching daemon (`/adm/daemons/cache.c`) that reads, decodes, and caches file contents keyed by resolved path, with modification-time-based invalidation. A `CACHE_D` macro is added to `include/daemons.h` and the alarm example is updated to show scheduled hourly eviction.

- `load_from_cache` validates `stat()` output before indexing, correctly returns early on a cache hit, and re-reads/re-decodes when the modification timestamp changes; three decode modes (`string`, `lpml`, `auto`) are supported with `assert_arg` guarding all three values in the public `load_data` entry point.
- `invalidate` is alarm-gated via `alarmp`, uses `"last checked"` (updated on every access) as the age anchor, and correctly evicts all entries when called without a TTL argument.
- The alarm example TTL is `">=3600"` (3 600 seconds = 1 hour), matching the accompanying comment.

<h3>Confidence Score: 5/5</h3>

The new daemon is self-contained and well-guarded; no issues were found that would affect correctness or safety on merge.

All concerns raised in prior review rounds have been addressed: stat() output is validated before indexing, the alarm TTL is >=3600 matching its 1h comment, and the error message in assert_arg correctly lists all three accepted kinds. The public surface is small and appropriately restricted — invalidate is alarm-gated, load_from_cache is private, and path resolution always goes through valid_file.

No files require special attention.

<sub>Reviews (4): Last reviewed commit: ["new cache daemon"](https://github.com/gesslar/oxidus-mudlib/commit/6578207076d6b87b82d8e2b5b15ec33a11aaebd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37157218)</sub>

<!-- /greptile_comment -->