### PR TITLE
docs: add `alarmp`, `run_as_caller` sefun help pages; fix `valid_file` return type

### DIFF
--- a/doc/sefun/alarmp.help
+++ b/doc/sefun/alarmp.help
@@ -1,0 +1,32 @@
+---
+{
+  title: "alarmp"
+}
+---
+### NAME
+
+    alarmp() - Determine whether the current call originated from the alarm
+    daemon on behalf of a valid object.
+
+### SYNOPSIS
+
+    int alarmp( object ob );
+
+### DESCRIPTION
+
+    Determine whether the current call originated from the alarm daemon on
+    behalf of a valid object.
+
+    Intended as a guard inside alarm callbacks: the target object can
+    confirm that it is genuinely being driven by ALARM_D rather than by an
+    arbitrary caller before acting on the alarm.
+
+### PARAMETERS
+
+    ob  (object)
+        The object the alarm pertains to.
+
+### RETURN VALUES
+
+    (int) 1 if ob is a valid object and the immediate caller is the alarm
+    daemon, otherwise 0.

--- a/doc/sefun/run_as_caller.help
+++ b/doc/sefun/run_as_caller.help
@@ -1,0 +1,44 @@
+---
+{
+  title: "run_as_caller"
+}
+---
+### NAME
+
+    run_as_caller() - Evaluates a function under the privileges of the
+    invoker's caller.
+
+### SYNOPSIS
+
+    mixed run_as_caller( function f, mixed arg... );
+
+### DESCRIPTION
+
+    Evaluates a function under the privileges of the invoker's caller.
+
+    This temporarily reassigns the invoking object's privileges to those of
+    the object that called it, evaluates the function, then restores the
+    original privileges. It lets a simul_efun or daemon perform an action on
+    behalf of whoever called into it, rather than under its own (typically
+    more powerful) identity.
+
+    The invoker is the object that called this simul_efun; the caller is the
+    object that called the invoker. Privileges are swapped on the invoker
+    for the duration of the evaluation only. The evaluation is wrapped in a
+    catch() so the original privileges are always restored, even if the
+    function errors.
+
+### PARAMETERS
+
+    f  (function)
+       The function to evaluate.
+
+### RETURN VALUES
+
+    (mixed | undefined) The result of evaluating the function, or undefined
+    if it errored.
+
+### ERRORS
+
+    If f is not a valid function. If a caller cannot be inferred from the
+    call chain.

--- a/doc/sefun/valid_file.help
+++ b/doc/sefun/valid_file.help
@@ -26,4 +26,5 @@
 
 ### RETURN VALUES
 
-    (string|int) The resolved absolute file path if valid, or 0 if invalid.
+    (string | undefined) The resolved absolute file path if valid, or
+    undefined if invalid.


### PR DESCRIPTION
### TL;DR

Added documentation for `alarmp` and `run_as_caller` simul_efuns, and corrected the return value description for `valid_file`.

### What changed?

- Added a help file for `alarmp`, which checks whether the current call originated from the alarm daemon on behalf of a valid object. Intended as a guard inside alarm callbacks to verify the caller is `ALARM_D`.
- Added a help file for `run_as_caller`, which evaluates a function under the privileges of the invoker's caller rather than the invoker's own (typically elevated) identity. Privileges are temporarily swapped and always restored, even on error.
- Updated the return value description for `valid_file` to use `undefined` instead of `0` for the invalid case, consistent with current conventions.

### How to test?

Review the rendered help files in-game or via the documentation system to confirm formatting, accuracy, and consistency with existing help entries.

### Why make this change?

`alarmp` and `run_as_caller` lacked any developer-facing documentation, making them harder to discover and use correctly. The `valid_file` correction brings its documented return type in line with the `undefined` convention used elsewhere.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds help pages for two undocumented sefuns (`alarmp` and `run_as_caller`) and corrects the `valid_file` return-type description from `0`/`int` to `undefined`.

- `run_as_caller.help` and `valid_file.help` are accurate and consistent with their implementations.
- `alarmp.help` contains a misleading parameter description ("The object the alarm pertains to") and a similarly imprecise return-value line; the implementation and real usage (`alarmp(previous_object())`) show that `ob` is the object being *tested* as the alarm daemon, not a subject of the alarm.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are documentation-only with no runtime impact.

The alarmp.help parameter and return-value wording conflict with the actual implementation — a developer reading only the help file would not know to pass previous_object() and would misunderstand what the check does. The other two files are correct and clean.

doc/sefun/alarmp.help — the PARAMETERS and RETURN VALUES descriptions need revision to reflect actual usage.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adoc%2Fsefun%2Falarmp.help%3A25-31%0A**Misleading%20parameter%20and%20return-value%20descriptions**%0A%0AThe%20PARAMETERS%20section%20describes%20%60ob%60%20as%20%22The%20object%20the%20alarm%20pertains%20to%2C%22%20which%20implies%20it%20is%20the%20alarm's%20subject%20or%20target%20object.%20However%2C%20the%20implementation%20returns%20%60objectp%28ob%29%20%26%26%20file_name%28ob%29%20%3D%3D%20ALARM_D%60%20%E2%80%94%20it%20tests%20whether%20%60ob%60%20itself%20is%20the%20alarm%20daemon.%20The%20real-world%20usage%20in%20%60adm%2Fdaemons%2Fcache.c%60%20confirms%20this%3A%20%60alarmp%28previous_object%28%29%29%60%20passes%20the%20*calling*%20object%20to%20verify%20it%20is%20%60ALARM_D%60%2C%20not%20any%20%22subject%22%20of%20the%20alarm.%0A%0AThe%20RETURN%20VALUES%20line%20compounds%20this%20by%20saying%20%22the%20immediate%20caller%20is%20the%20alarm%20daemon%2C%22%20implying%20the%20function%20independently%20inspects%20the%20call%20stack%2C%20when%20in%20fact%20it%20only%20tests%20whether%20%60ob%20%3D%3D%20ALARM_D%60.%20A%20developer%20reading%20the%20help%20file%20without%20knowing%20to%20pass%20%60previous_object%28%29%60%20would%20be%20left%20with%20an%20incorrect%20mental%20model%20of%20both%20the%20parameter%20semantics%20and%20what%20the%20check%20actually%20does.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=233&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["new sefun docs"](https://github.com/gesslar/oxidus-mudlib/commit/dc0c8777deacd24bb0cfe81c306626957441b3e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37168518)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->