### PR TITLE
fixes and update to alarm

### DIFF
--- a/adm/daemons/alarm.c
+++ b/adm/daemons/alarm.c
@@ -38,7 +38,7 @@ inherit STD_DAEMON;
 inherit CLASS_ALARM;
 
 // Functions
-public void reload_alarms();
+public void rehash_alarms();
 public varargs int add_alarm(string type, string master, string pattern,
                              string file, string func, mixed args...);
 public int remove_alarm(string id);
@@ -78,7 +78,7 @@ void setup() {
  */
 void post_restore() {
   if(!sizeof(alarms))
-    reload_alarms();
+    rehash_alarms();
 }
 
 /**
@@ -90,7 +90,7 @@ void post_restore() {
  *
  * @returns {void}
  */
-void reload_alarms() {
+void rehash_alarms() {
   string alarm_file, *alarm_files;
   string alarm_path = mud_config("ALARMS_PATH");
 
@@ -137,7 +137,7 @@ varargs int add_once(string master, string pattern, string file,
  * Builds an Alarm from the supplied parts, validates it, appends it
  * to the in-memory alarm list, and persists the list via save_data().
  * For type "O", this is the canonical add path used by add_once().
- * For recurring types, note that reload_alarms() will discard any
+ * For recurring types, note that rehash_alarms() will discard any
  * alarms not present in the on-disk config.
  *
  * @param {string} type - One-character alarm type ("O", "H", "D",
@@ -294,7 +294,11 @@ private void execute_alarm(class Alarm alarm) {
     return;
   }
 
-  err = catch(call_other(ob, alarm.func, alarm.args));
+  if(pointerp(alarm.args) && sizeof(alarm.args))
+    err = catch(call_other(ob, alarm.func, alarm.args...));
+  else
+    err = catch(call_other(ob, alarm.func));
+
   if(err) {
     log_file("system/alarm", "[%s] Error executing alarm %s: %O\n",
       ctime(), alarm.func, err);

--- a/adm/etc/alarms/alarm.txt.example
+++ b/adm/etc/alarms/alarm.txt.example
@@ -1,7 +1,7 @@
 # Format for an alarm
-# TYPE MASTER PATTERN /FILE FUNCTION [ARGUMENTS]
+# TYPE PATTERN MASTER /FILE FUNCTION [ARGUMENTS]
 #
-# Type: B O H D W Y // B: Boot, O: Once, H: Hourly, D: Daily, W: Weekly, Y: Yearly
+# Type: B O H D W M Y // B: Boot, O: Once, H: Hourly, D: Daily, W: Weekly, M: Monthly, Y: Yearly
 # Master: true, false
 # Pattern: Boot - s
 #          Once - y-m-d@H:M

--- a/cmds/wiz/alarm.c
+++ b/cmds/wiz/alarm.c
@@ -1,5 +1,5 @@
 // /cmds/wiz/alarm.c
-// Command to inspect, add, remove, and reload alarms registered with
+// Command to inspect, add, remove, and rehash alarms registered with
 // the central alarm daemon.
 //
 // Created:     2024-02-25: Gesslar
@@ -19,7 +19,7 @@ inherit CLASS_ALARM;
 
 private mixed list_alarms(object tp, string filter_type, int as_time);
 private int next_poll(object tp);
-private int reload(object tp);
+private int rehash(object tp);
 private int add_alarm_entry(object tp, string type, int root);
 private int rem_alarm_entry(object tp);
 private mixed show_info(object tp, int num);
@@ -29,13 +29,13 @@ private string generate_obj_func_line(string obj, string func);
 private string time_as_string(int number);
 
 private nosave mapping interval_colors = ([
-  "once":    "{{aea}}",
-  "hourly":  "{{efa}}",
-  "daily":   "{{dae}}",
-  "weekly":  "{{fca}}",
-  "monthly": "{{fcc}}",
-  "yearly":  "{{cef}}",
-  "boot":    "{{ace}}",
+  "once":    "{{8DD68D}}",
+  "hourly":  "{{D3E68A}}",
+  "daily":   "{{C48DD6}}",
+  "weekly":  "{{E6AE8A}}",
+  "monthly": "{{E6AEAE}}",
+  "yearly":  "{{AED3E6}}",
+  "boot":    "{{8DB1D6}}",
 ]);
 
 private nosave mapping type_to_char = ([
@@ -78,8 +78,8 @@ mixed main(object tp, string arg) {
     return list_alarms(tp, 0, 1);
   if(arg == "next")
     return next_poll(tp);
-  if(arg == "reload")
-    return reload(tp);
+  if(arg == "rehash")
+    return rehash(tp);
   if(arg == "list")
     return list_alarms(tp, 0, 0);
 
@@ -115,7 +115,7 @@ mixed main(object tp, string arg) {
   }
 
   return _error(
-    "Syntax: alarm [list [type] | time | info <#> | next | reload | "
+    "Syntax: alarm [list [type] | time | info <#> | next | rehash | "
     "add [root] <type> | remove]");
 }
 
@@ -140,16 +140,17 @@ private int next_poll(object tp) {
     return _info(tp, "No poll is currently scheduled.");
 
   return _info(tp, "Next poll in %s (at %s).",
-    time_as_string(seconds), ctime(time() + seconds));
+    time_as_string(seconds),
+    strftime("%b %d %Y %H:%M:%S", time() + seconds));
 }
 
-private int reload(object tp) {
+private int rehash(object tp) {
   if(!adminp(tp))
-    return _error("Only admin may reload alarms.");
+    return _error("Only admin may rehash alarms.");
 
-  ALARM_D->reload_alarms();
+  ALARM_D->rehash_alarms();
   return _ok(tp,
-    "Alarms reloaded. Any runtime-added alarms have been discarded.");
+    "Alarms rehashed. Any runtime-added alarms have been discarded.");
 }
 
 private int sort_by_next(class Alarm a, class Alarm b) {
@@ -200,7 +201,7 @@ private mixed list_alarms(object tp, string filter_type, int as_time) {
     else if(next_t < 0)
       fmt = "    --";
     else if(as_time)
-      fmt = ctime(next_t)[4..18];
+      fmt = strftime("%b %d %H:%M:%S", next_t);
     else
       fmt = time_as_string(next_t - time());
 
@@ -289,7 +290,7 @@ private void receive_pattern(string str, object tp, string type, int root,
     _ok(tp, "Alarm added to the \"%s\" type.", type);
 }
 
-private mixed show_info(object tp, int num) {
+private mixed show_info(object _tp, int num) {
   class Alarm *alarms = ALARM_D->query_alarms();
   class Alarm alarm;
   int next_t;
@@ -310,7 +311,8 @@ private mixed show_info(object tp, int num) {
 
   if(alarm.last_run)
     last_str = sprintf("%s (%s ago)",
-      ctime(alarm.last_run), time_as_string(time() - alarm.last_run));
+      strftime("%b %d %Y %H:%M:%S", alarm.last_run),
+      time_as_string(time() - alarm.last_run));
   else
     last_str = "never";
 
@@ -320,7 +322,8 @@ private mixed show_info(object tp, int num) {
     next_str = "--";
   else
     next_str = sprintf("%s (at %s)",
-      time_as_string(next_t - time()), ctime(next_t));
+      time_as_string(next_t - time()),
+      strftime("%b %d %Y %H:%M:%S", next_t));
 
   out += ({
     sprintf("Alarm #%d  %s (%s)", num, alarm.type,
@@ -409,14 +412,14 @@ private string time_as_string(int number) {
   return result;
 }
 
-string query_help(object tp) {
+string query_help(object _tp) {
   return
 "Syntax: alarm                       - list all alarms\n"
 "        alarm time                  - list all alarms (timestamps)\n"
 "        alarm list [type]           - list alarms (filtered)\n"
 "        alarm info <#>              - show metadata for an alarm\n"
 "        alarm next                  - seconds until next poll\n"
-"        alarm reload                - reload from config (admin)\n"
+"        alarm rehash                - rehash from config (admin)\n"
 "        alarm add [type]            - add a new alarm interactively\n"
 "        alarm add root [type]       - add as root permissions (admin)\n"
 "        alarm remove                - remove an alarm by number\n"
@@ -425,18 +428,18 @@ string query_help(object tp) {
 "              [m]onthly / [y]early\n"
 "              (any unambiguous prefix; boot is config-file only)\n"
 "\n"
-"This command inspects, adds, removes, and reloads alarms registered\n"
+"This command inspects, adds, removes, and rehashes alarms registered\n"
 "with the central alarm daemon (ALARM_D).\n"
 "\n"
 "Recurring alarms (hourly/daily/weekly/monthly/yearly) and boot alarms\n"
-"typically live in the configured ALARMS_PATH and are reloaded\n"
+"typically live in the configured ALARMS_PATH and are rehashed\n"
 "automatically at boot. One-shot (\"once\") alarms added at runtime via\n"
 "\"alarm add once\" persist across reboots.\n"
 "\n"
-"\"alarm reload\" rereads all config files and discards any runtime-added\n"
+"\"alarm rehash\" rereads all config files and discards any runtime-added\n"
 "alarms.\n"
 "\n"
-"Only an admin may add an alarm with root permissions or reload the\n"
+"Only an admin may add an alarm with root permissions or rehash the\n"
 "alarm daemon.\n"
 "\n"
 "PATTERNS BY TYPE:\n"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames `reload_alarms()` to `rehash_alarms()` throughout the alarm daemon and wizard command, fixes a bug in `execute_alarm` where `alarm.args` was passed as a single array instead of spread as individual arguments, and corrects the example config's column-order documentation.

- **Bug fix in `execute_alarm`**: The old `call_other(ob, alarm.func, alarm.args)` passed the args array as one argument; the new code correctly uses `alarm.args...` to spread individual arguments, or omits args entirely when none are present.
- **Rename `reload` → `rehash`**: Applied consistently across both `adm/daemons/alarm.c` and `cmds/wiz/alarm.c` including the daemon API, wizard command, help text, and user-facing messages.
- **`alarm.txt.example` corrections**: Column order in the format comment now matches `create_alarm()`'s actual parsing order (`TYPE PATTERN MASTER`), and the Monthly (`M`) type was added to the type list.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the functional changes are correct and the rename is applied consistently within the changed files.

The execute_alarm fix is a clean and correct bug fix, the rename is internally consistent, and no callers of the old reload_alarms name remain in executable code. Two wiki doc files reference the old function name but they are documentation only and do not affect runtime behavior.

doc/wiki/src/content/docs/daemons/alarm.mdx and doc/wiki/src/content/docs/systems/alarm.md still reference the old reload_alarms name and should be updated to rehash_alarms.

<sub>Reviews (2): Last reviewed commit: ["fixes and update to alarm"](https://github.com/gesslar/oxidus-mudlib/commit/1a7a740441dd75a3c7a4d37eff9dc5325ae938cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37807251)</sub>

<!-- /greptile_comment -->