### PR TITLE
the LSP is confused

### DIFF
--- a/adm/simul_efun/predicates.c
+++ b/adm/simul_efun/predicates.c
@@ -4,7 +4,7 @@
  * Determine if an object is a room or not.
  *
  * @param {object} ob - The object to test.
- * @returns {ob as STD_ROOM} 1 if the object is a room, otherwise 0.
+ * @returns {int} 1 if the object is a room, otherwise 0.
  */
 int roomp(object ob) {
   return objectp(ob) && call_if(ob, "is_room");

--- a/doc/sefun/roomp.help
+++ b/doc/sefun/roomp.help
@@ -22,4 +22,4 @@
 
 ### RETURN VALUES
 
-    (ob as STD_ROOM) 1 if the object is a room, otherwise 0.
+    (int) 1 if the object is a room, otherwise 0.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the return-type annotation for `roomp` in both the source comment and the documentation file. The original annotation `{ob as STD_ROOM}` was misleading the LSP into thinking the function returns the object itself, when in reality it returns `1` or `0`.

- `adm/simul_efun/predicates.c`: Updates `@returns` tag from `{ob as STD_ROOM}` to `{int}`.
- `doc/sefun/roomp.help`: Mirrors the same correction in the help document.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only documentation and comment annotations are touched; no runtime logic is changed.

The change is confined to two annotation strings (one in a JSDoc comment, one in a help file) that describe the return type of roomp. The function body is untouched and continues to return an int correctly. The new annotation {int} accurately matches the actual return value.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["the LSP is confused"](https://github.com/gesslar/oxidus-mudlib/commit/1334278e74e330528e6a5dc7f86e42c86629bfc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37807255)</sub>

<!-- /greptile_comment -->