### PR TITLE
new area

### DIFF
--- a/d/maze/maze_daemon.c
+++ b/d/maze/maze_daemon.c
@@ -65,14 +65,17 @@ private nosave string *long_descriptions;
 private nosave string default_long_description;
 
 /**
- * Dimension configuration for the maze. The first element of each
- * inner array is the minimum size and is added to the result of the
- * prandom function applied to the second element to get the actual
- * size. It is in the order of z, y, x.
+ * Dimension configuration for the maze. One ({ min, spread }) pair per
+ * axis, in the order z, y, x (depth, height, width). The first element
+ * is the minimum (base) size for that axis. The second element is the
+ * random spread: it is fed to prandom() to yield a value in the range
+ * 0..spread-1, which is then added to the minimum. So the final size of
+ * an axis is min + prandom(spread), giving a result in the inclusive
+ * range min..min+spread-1.
  *
  * @type {({ int, int })*}
  */
-private nosave mixed *dimension_config = ({ ({ 25, 5 }), ({ 25, 5 }), ({ 25, 5 }),  });
+private nosave mixed *dimension_config = ({ ({ 5, 1 }), ({ 10, 1 }), ({ 10, 1 }), });
 private nosave int *dimensions;
 
 // Some constants

--- a/d/mobs/bramble_cur.lpml
+++ b/d/mobs/bramble_cur.lpml
@@ -1,0 +1,44 @@
+// d/mobs/bramble_cur.lpml
+// The thing that dens in the heart of the Thornwick blight. The closest
+// the hamlet has to a guardian, and no friend to anyone.
+
+{
+  type: "mammal",
+  name: "bramble cur",
+  short: "bramble cur",
+  long: "Once it was a dog. The blight has made it something else: a lean, "
+        "scarred hound whose matted hide has gone half to bark, with thorns "
+        "grown through the skin along its spine and a green sickly light "
+        "behind its eyes. It pulls its lips back from yellow teeth and a low "
+        "wet snarl works in its throat. This is what guards the heart of "
+        "the thicket, and it has come home to find you in it.",
+  id: [
+    "bramble cur",
+    "cur",
+    "hound",
+    "dog"
+  ],
+  adj: [
+    "bramble",
+    "blighted",
+    "scarred",
+    "mangy"
+  ],
+  weapon name: "fangs",
+  weapon type: "piercing",
+  level: [3,5],
+  gender: [
+    "male",
+    "female"
+  ],
+  race: "dog",
+  loot: [
+    ["/obj/loot/blighted_hide.loot", 60.0],
+    ["/obj/loot/cur_fang.loot", 40.0],
+  ],
+  loot chance: 60.0,
+  coins: {
+    copper: [1,80.0],
+    silver: [1,30.0],
+  },
+}

--- a/d/mobs/carrion_crow.lpml
+++ b/d/mobs/carrion_crow.lpml
@@ -1,0 +1,37 @@
+// d/mobs/carrion_crow.lpml
+// The crows of Thornwick -- bold, patient, and entirely unafraid.
+
+{
+  type: "monster",
+  name: "carrion crow",
+  short: "carrion crow",
+  long: "A big carrion crow, oily-black and bold, watches you with one "
+        "flat dark eye. It does not trouble to fly off. It has the look "
+        "of a bird that has grown used to easy pickings, and is wondering, "
+        "without much hurry, whether you might become some.",
+  id: [
+    "carrion crow",
+    "crow",
+    "bird"
+  ],
+  adj: [
+    "carrion",
+    "black",
+    "big"
+  ],
+  weapon name: "beak",
+  weapon type: "piercing",
+  level: [1,3],
+  gender: [
+    "male",
+    "female"
+  ],
+  race: "bird",
+  loot: [
+    "/obj/loot/crow_feather.loot",
+  ],
+  loot chance: 70.0,
+  coins: {
+    copper: [1,25.0],
+  },
+}

--- a/d/thornwick/bramble_thicket.c
+++ b/d/thornwick/bramble_thicket.c
@@ -1,0 +1,58 @@
+/**
+ * @file /d/thornwick/bramble_thicket.c
+ * The heart of the blight, north of the green. The hamlet's tough beast.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit __DIR__ "thornwick_base";
+
+void setup() {
+  set_short("The Bramble Thicket");
+  set_long(
+  "The green's far edge does not so much end as get eaten. The bramble "
+  "closes overhead and the day shuts off behind you, and you go forward "
+  "bent double through a tunnel of thorn that was never meant for "
+  "anything that walks upright. The canes here are thick as a wrist and "
+  "armoured in black thorn, and they do not grow at random: they wind and "
+  "knot toward a centre, as roots draw to a buried thing. The ground is a "
+  "mat of dead leaves and small white bones, picked clean. Something "
+  "denned in the heart of all this thorn has worn these runs smooth with "
+  "its passing, and it does not love visitors. The only way back is the "
+  "way you came, south, toward the light of the green.");
+
+  set_exits(([
+    "south": "thornwick_green",
+  ]));
+
+  set_room_size(({1,1,1}));
+  set_terrain("forest");
+
+  add_reset((: area_spawn, "mob/bramble_cur", 65.0, 3, 5 :));
+
+  set_items(([
+    ({ "bramble", "brambles", "canes", "thorn", "thorns" }) :
+      "Up close the bramble is monstrous: canes thick as your wrist, "
+      "black-barked, set with thorns the length of a finger-joint and "
+      "curved like fish-hooks. They are warm to the touch, very faintly, "
+      "the way a sleeper is warm. You take your hand back.",
+    ({ "bones", "white bones", "small bones" }) :
+      "The floor of the thicket is littered with small bones gnawed "
+      "white -- rabbit, crow, rat, and here and there a thing harder to "
+      "name. Whatever dens here eats well, and is not particular.",
+    ({ "runs", "tunnels", "paths" }) :
+      "Smooth-worn runs lead away into the thorn, low to the ground and "
+      "just wide enough for a big animal travelling at speed. They all "
+      "converge, further in, on a deeper dark you have no wish to crawl "
+      "toward.",
+    ({ "centre", "heart", "deeper dark" }) :
+      "The canes all lean inward toward a single point somewhere ahead, "
+      "a knot of black thorn too dense to see into. The blight has a "
+      "heart, and this is the chamber of it, and you would do well not "
+      "to be here when whatever guards it comes home.",
+  ]));
+}

--- a/d/thornwick/chapel.c
+++ b/d/thornwick/chapel.c
@@ -1,0 +1,70 @@
+/**
+ * @file /d/thornwick/chapel.c
+ * The Chapel of Saint Brae, the one kept place in a dead hamlet.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit __DIR__ "thornwick_base";
+
+void setup() {
+  set_light(1);
+  set_short("The Chapel of Saint Brae");
+  set_long(
+  "Within, the chapel is small and very still, and -- astonishingly -- "
+  "kept. The flagged floor has been swept; the few plain benches stand in "
+  "their rows; and on the stone altar beneath a narrow window a single "
+  "candle burns, its flame unwavering in the windless dark. Whoever tends "
+  "it has been at their work for years: the brass is dull but polished, "
+  "the dead flowers cleared and fresh ones -- thornless, carefully "
+  "chosen -- set in their place. Above the altar a worn relief shows a "
+  "robed figure holding back a tide of thorn with one bare upraised hand. "
+  "Here, and only here in all Thornwick, the bramble does not come; it "
+  "stops at the threshold as though it remembers being told to. The "
+  "churchyard lies back through the door to the west.");
+
+  set_exits(([
+    "west": "chapel_yard",
+  ]));
+
+  set_room_size(({2,3,1}));
+  set_terrain("indoor");
+  set_room_type("temple");
+
+  set_items(([
+    ({ "altar", "stone altar" }) :
+      "A block of plain grey stone, scrubbed clean, bearing a candle, a "
+      "dull brass bowl, and a fistful of pale flowers chosen for having "
+      "no thorns. Someone keeps this altar daily. Someone has not given "
+      "up.",
+    ({ "candle", "flame", "light" }) :
+      "One candle, burning steady. There is no draught to trouble it and "
+      "no one in sight to have lit it, yet the wax is fresh and the flame "
+      "is bright. It has the look of a thing that is never quite allowed "
+      "to go out.",
+    ({ "relief", "carving", "figure" }) :
+      "The carving above the altar is worn nearly smooth, but the story "
+      "survives: a robed figure -- Saint Brae, the Olum folk would say -- "
+      "stands with one bare hand raised, and against that hand a tide of "
+      "carved thorn breaks and is held. The Saint's face has been rubbed "
+      "featureless by centuries of grateful, frightened thumbs.",
+    ({ "flowers", "fresh flowers" }) :
+      "Pale flowers, set fresh in the brass bowl, every one of them "
+      "chosen or stripped to have no thorn. The choosing of them must "
+      "take patience. Patience, here, seems to be the whole of the "
+      "work.",
+    ({ "benches", "pews", "bench" }) :
+      "A handful of plain oak benches, swept and straight in their rows, "
+      "waiting for a congregation that has been a generation in the "
+      "ground. Someone dusts them all the same.",
+    ({ "threshold", "door", "doorway" }) :
+      "At the very threshold the bramble stops dead, as cleanly as if a "
+      "line had been drawn. One thorn-tip actually touches the stone "
+      "and comes no further. Whatever holds it back is old, and patient, "
+      "and tired.",
+  ]));
+}

--- a/d/thornwick/chapel_yard.c
+++ b/d/thornwick/chapel_yard.c
@@ -1,0 +1,63 @@
+/**
+ * @file /d/thornwick/chapel_yard.c
+ * The overgrown churchyard, east of the green. Crows haunt the stones.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit __DIR__ "thornwick_base";
+
+void setup() {
+  set_short("The Churchyard");
+  set_long(
+  "Through the lych-gate the churchyard lies under long wet grass, its "
+  "headstones leaning every way like a mouthful of bad teeth. Most are "
+  "too worn or too lichened to read; here and there a name still surfaces "
+  "from the stone, a date, a carved hand pointing upward at a sky that "
+  "promised better. The graves are oddly many for so small a place -- "
+  "row on row of them, and a long raw mound near the wall, unmarked, "
+  "where the grass grows greenest of all. Crows stud the headstones like "
+  "black fruit and regard you without alarm. The chapel door stands open "
+  "to the east; the green lies west beyond the gate.");
+
+  set_exits(([
+    "west": "thornwick_green",
+    "east": "chapel",
+  ]));
+
+  set_room_size(({2,2,1}));
+  set_terrain("grass");
+
+  add_reset((: area_spawn, "mob/carrion_crow", 50.0, 2, 3 :));
+
+  set_items(([
+    ({ "headstones", "gravestones", "stones", "graves" }) :
+      "Slate and sandstone, leaning and sunk, furred with grey-green "
+      "lichen. The older ones keep their dead anonymously; the newer "
+      "ones, near the wall, all share a single year cut deep into the "
+      "stone, as though the carver had no time to spare on flourishes.",
+    ({ "mound", "raw mound", "long mound" }) :
+      "A long low mound runs along the foot of the wall, unmarked by any "
+      "stone, the turf over it greener and ranker than anywhere else. It "
+      "is the shape of a thing dug in haste and large enough for many. "
+      "You do not need a headstone to read it.",
+    ({ "crows", "crow" }) :
+      "The crows sit the headstones in ones and twos, hunched and "
+      "patient, their feathers oily-black. They turn their heads to "
+      "follow you with a flat curiosity that is almost worse than malice. "
+      "This is their churchyard now, and they know it.",
+    ({ "grass", "long grass" }) :
+      "The grass grows long and wet and unscythed, drowning the lower "
+      "stones entirely. Where it grows greenest, you have learned by "
+      "now, is where you should least wish to dig.",
+    ({ "chapel", "church", "door" }) :
+      "The chapel stands sound and four-square to the east, its oak door "
+      "open. Alone of all Thornwick it shows a sign of tending: the path "
+      "to its door has been kept clear of bramble, recently, and by "
+      "hand.",
+  ]));
+}

--- a/d/thornwick/controller.c
+++ b/d/thornwick/controller.c
@@ -1,0 +1,12 @@
+/**
+ * @file /d/thornwick/controller.c
+ * Virtual server for the Thornwick zone.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit STD_VIRTUAL_SERVER;

--- a/d/thornwick/hollow_road1.c
+++ b/d/thornwick/hollow_road1.c
@@ -1,0 +1,56 @@
+/**
+ * @file /d/thornwick/hollow_road1.c
+ * The foot of the Hollow Road, where Olum's tended verges give out.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit __DIR__ "thornwick_base";
+
+void setup() {
+  set_short("The Foot of the Hollow Road");
+  set_long(
+  "Past the field-edge the way drops into the lane proper, narrowing and "
+  "sinking between earthen banks until Olum is lost behind the rise and "
+  "only the open sky goes with you. The surface underfoot is a memory of "
+  "ruts long since gone to grass. A worm-eaten finger-post leans at the "
+  "verge, one arm pointing back south toward warmth and lamplight, the "
+  "other northward into a quiet that feels deliberate. Few footprints "
+  "trouble the mud in that direction. The hedges here are still kept after "
+  "a fashion, but with every pace north they grow ranker, taller, and more "
+  "inward-looking, as though the land itself would rather not be walked.");
+
+  set_exits(([
+    "south": "../village/village_path7",
+    "north": "hollow_road2",
+  ]));
+
+  set_room_size(({2,2,1}));
+  set_terrain("grass");
+
+  set_items(([
+    ({ "finger-post", "fingerpost", "post", "sign", "signpost" }) :
+      "The post is grey with weather and split along its grain. Its "
+      "southern arm still bears a faint painted 'OLUM'; the northern one "
+      "has been scoured almost blank, but tilt your head and you can just "
+      "make out four letters that might once have read 'WICK'.",
+    ({ "earthen banks", "banks", "bank" }) :
+      "The banks rise to either side, crowned with unkempt hedge and "
+      "knotted root. They press the road into a hollow, so that a "
+      "traveller walks a little below the level of the fields, hidden "
+      "from the wider country.",
+    ({ "hedges", "hedge", "hedgerow" }) :
+      "Hawthorn and blackthorn, once laid and trimmed, now run wild. "
+      "Their lower branches are dead and grey; only the crowns still "
+      "leaf, and those grudgingly.",
+    ({ "village", "olum", "south" }) :
+      "Southward the banks fall away to the field-edge and the last "
+      "track back into Olum, and beyond that the honest chimney-smoke of "
+      "the village smudges the sky. It looks, from here, very far off "
+      "and very warm.",
+  ]));
+}

--- a/d/thornwick/hollow_road2.c
+++ b/d/thornwick/hollow_road2.c
@@ -1,0 +1,55 @@
+/**
+ * @file /d/thornwick/hollow_road2.c
+ * The Sunken Lane, deep between its banks. Crows keep this stretch.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit __DIR__ "thornwick_base";
+
+void setup() {
+  set_short("The Sunken Lane");
+  set_long(
+  "Here the road runs at its deepest, a green trench roofed over by the "
+  "meeting branches of the hedges. The light comes down thin and dim, "
+  "stained the colour of old bottle-glass, and the air holds a cellar's "
+  "chill even at noon. Exposed roots claw from the banks like the ribs of "
+  "something half-buried. Now and again a black shape shifts in the "
+  "tangle overhead and a single dry caw drops into the hush, and then the "
+  "silence closes over it again, deeper for the interruption. The lane "
+  "climbs gently onward to the north, toward a glimpse of grey stone, and "
+  "falls away south to easier ground.");
+
+  set_exits(([
+    "south": "hollow_road1",
+    "north": "old_bridge",
+  ]));
+
+  set_room_size(({1,2,1}));
+  set_terrain("grass");
+
+  add_reset((: area_spawn, "mob/carrion_crow", 40.0, 1, 2 :));
+
+  set_items(([
+    ({ "roots", "exposed roots" }) :
+      "The banks have crumbled enough to bare the hedges' roots, which "
+      "hang into the lane pale and twisted. Walk too close and they snag "
+      "at sleeve and hair like importunate fingers.",
+    ({ "branches", "canopy", "tangle" }) :
+      "Overhead the hedges have grown together into a low, knotted roof. "
+      "Somewhere up in that gloom the crows roost, only their droppings "
+      "and the occasional dropped feather betraying how many.",
+    ({ "crows", "crow", "black shape", "black shapes" }) :
+      "You catch only glimpses: a wing, a wet black eye, the sidewise "
+      "cock of a head. They watch the lane the way toll-keepers once "
+      "watched the road, and they do not seem afraid.",
+    ({ "light", "glow" }) :
+      "What light reaches the lane floor is filtered through layer on "
+      "layer of leaf, and arrives green and exhausted, with no warmth "
+      "left in it at all.",
+  ]));
+}

--- a/d/thornwick/hollow_road3.c
+++ b/d/thornwick/hollow_road3.c
@@ -1,0 +1,56 @@
+/**
+ * @file /d/thornwick/hollow_road3.c
+ * The Rise, where the road crests and Thornwick lies revealed.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit __DIR__ "thornwick_base";
+
+void setup() {
+  set_short("The Rise");
+  set_long(
+  "The road climbs its last short pull and crests the rise, and there "
+  "Thornwick lies open below you. It was a fair place once: you can read "
+  "it still in the orderly tumble of cottages about a green, in the squat "
+  "tower of the chapel keeping its eastern watch. But no smoke stands from "
+  "any chimney. The orchards have gone to thicket, the thatch to moss and "
+  "ruin, and over all of it the bramble has come down from the hills in a "
+  "slow dark tide, swallowing wall and lane and garden alike. A blight "
+  "took this hamlet a generation gone, the Olum folk will tell you, and "
+  "the land has been settling its account ever since. The way runs down "
+  "into the green to the north.");
+
+  set_exits(([
+    "south": "old_bridge",
+    "north": "thornwick_green",
+  ]));
+
+  set_room_size(({2,2,1}));
+  set_terrain("grass");
+
+  set_items(([
+    ({ "thornwick", "hamlet", "cottages", "village" }) :
+      "From the rise the whole sad shape of the hamlet is plain: a "
+      "double handful of cottages set about a green, a chapel to the "
+      "east, orchards behind. Every roof is broken. Nothing moves down "
+      "there but crows and the wind in the bramble.",
+    ({ "chapel", "tower", "squat tower" }) :
+      "The chapel's stone tower still stands four-square above the ruin, "
+      "the one roof in Thornwick the blight and the weather have not yet "
+      "brought down. A thread of something -- smoke? -- seems to waver "
+      "above it, but at this distance you cannot be sure.",
+    ({ "bramble", "brambles", "thicket", "tide" }) :
+      "The bramble has come down off the high ground in a great dark "
+      "sweep, and where it has passed there is nothing left but thorn. "
+      "It does not look like ordinary briar. It looks purposeful.",
+    ({ "orchards", "orchard" }) :
+      "Behind the cottages the old orchards have run to tangle, their "
+      "trees half-strangled in bramble, their fruit -- if they still "
+      "fruit at all -- left to fall and rot unwanted.",
+  ]));
+}

--- a/d/thornwick/old_bridge.c
+++ b/d/thornwick/old_bridge.c
@@ -1,0 +1,60 @@
+/**
+ * @file /d/thornwick/old_bridge.c
+ * The toll bridge over Bramble Brook, where the hollow opens to the sky.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit __DIR__ "thornwick_base";
+
+void setup() {
+  set_short("The Old Toll Bridge");
+  set_long(
+  "The banks fall back and the sky returns, wide and pale, as the road "
+  "lifts onto a humped bridge of grey stone. Below it Bramble Brook slides "
+  "brown and unhurried between beds of cress and rusting iron, talking to "
+  "itself over the stones. A ruined toll-house squats at the bridge's far "
+  "end, no more now than three walls and a hearth open to the weather; the "
+  "chain that once barred the way still hangs from its post, red with rust "
+  "and grown fast into the bramble. This was the boundary, once -- pay "
+  "your copper here and pass on to Thornwick. The roofs of the hamlet show "
+  "now beyond the rise to the north, broken-backed against the cloud.");
+
+  set_exits(([
+    "south": "hollow_road2",
+    "north": "hollow_road3",
+  ]));
+
+  set_room_size(({2,3,1}));
+  set_terrain("road");
+
+  set_items(([
+    ({ "bridge", "stone bridge", "humped bridge" }) :
+      "Three spans of dressed grey stone, mossed and dipping in the "
+      "middle where a thousand cart-wheels wore it. The parapet is gone "
+      "in places, tumbled into the brook below, but the bridge itself "
+      "stands as stubbornly as the day it was raised.",
+    ({ "brook", "bramble brook", "stream", "water" }) :
+      "The brook runs brown and clear over a bed of pebbles, threading "
+      "between thick beds of watercress. It is shallow enough to ford, "
+      "and cold enough that you would rather not.",
+    ({ "toll-house", "tollhouse", "ruin", "walls" }) :
+      "Three walls and a cold hearth are all that remain of the "
+      "toll-house. Soot still ghosts the chimney-breast, and a row of "
+      "iron hooks waits by the door for keys and ledgers that will never "
+      "be hung there again.",
+    ({ "chain", "rusty chain", "toll chain" }) :
+      "A heavy chain, each link as thick as a thumb, hangs from a "
+      "leaning post. Rust has welded it solid and the bramble has taken "
+      "the rest, so that it bars the road still, after a fashion -- not "
+      "against travellers now, but against the years.",
+    ({ "cress", "watercress" }) :
+      "Dark green watercress crowds the slow margins of the brook. It "
+      "looks wholesome enough; the brook, at least, the blight never "
+      "touched.",
+  ]));
+}

--- a/d/thornwick/ruined_cottage.c
+++ b/d/thornwick/ruined_cottage.c
@@ -1,0 +1,65 @@
+/**
+ * @file /d/thornwick/ruined_cottage.c
+ * The soundest of the dead cottages, off the west of the green.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit __DIR__ "thornwick_base";
+
+void setup() {
+  set_light(1);
+  set_short("A Ruined Cottage");
+  set_long(
+  "Enough of the roof remains to call this inside, though the light comes "
+  "through in a dozen places and the floor is drifted with leaves and "
+  "fallen thatch. It was a single room, a home: a hearth at one end black "
+  "with old fire, a table still standing on three and a half legs, a "
+  "bedstead in the corner stripped to its ropes. Somebody left in a "
+  "hurry, or did not get the chance to pack -- a bowl sits on the table "
+  "with the ghost of a meal dried hard inside it, and a child's shoe lies "
+  "by the cold hearth, its pair nowhere to be found. Rats have the run "
+  "of the place now; you hear them in the thatch, bold and unbothered. "
+  "The green lies back to the east through the sagging door.");
+
+  set_exits(([
+    "east": "thornwick_green",
+  ]));
+
+  set_room_size(({2,2,1}));
+  set_terrain("indoor");
+
+  add_reset((: area_spawn, "mob/rat", 55.0, 1, 2 :));
+
+  set_items(([
+    ({ "hearth", "fireplace", "fire" }) :
+      "The hearth is a cave of cold soot. A blackened pot-hook still "
+      "swings from it, and the ash beneath has never been cleared, only "
+      "rained on and dried and rained on again into a grey crust.",
+    ({ "table" }) :
+      "A plain deal table, missing the foot of one leg, propped level "
+      "on a stone. The grain is scrubbed pale at its centre where some "
+      "vanished hand wore it down with years of honest work.",
+    ({ "bowl" }) :
+      "A wooden bowl on the table, and dried in the bottom of it the "
+      "black remnant of whatever was its last meal -- porridge, perhaps. "
+      "It has been waiting a very long time to be washed.",
+    ({ "shoe", "child's shoe" }) :
+      "A small shoe of cracked leather lies on its side by the hearth, "
+      "laces still tied. Its fellow is gone. You find you would rather "
+      "not think about which.",
+    ({ "bedstead", "bed" }) :
+      "A wooden bedstead stripped to its rope lattice, the mattress long "
+      "since rotted or carried off. Mice -- or worse -- have made a nest "
+      "of what little ticking remains.",
+    ({ "rats", "rat" }) :
+      "You do not see them so much as sense them: a scurry in the "
+      "thatch, a tail across a beam, eyes catching the light from the "
+      "dark beneath the bedstead. They are not afraid of you. Nothing "
+      "in Thornwick is.",
+  ]));
+}

--- a/d/thornwick/thornwick.c
+++ b/d/thornwick/thornwick.c
@@ -1,0 +1,12 @@
+/**
+ * @file /d/thornwick/thornwick.c
+ * Zone object for Thornwick, the abandoned hamlet up the Hollow Road.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit STD_ZONE;

--- a/d/thornwick/thornwick_base.c
+++ b/d/thornwick/thornwick_base.c
@@ -1,0 +1,62 @@
+/**
+ * @file /d/thornwick/thornwick_base.c
+ * General inherit for the Thornwick area. Sets the shared zone and the
+ * default terrain (the road that threads the whole hamlet together), and
+ * provides a lightweight per-room spawner registered via add_reset.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit STD_ROOM;
+
+public void area_spawn(string file, float chance, int lo, int hi);
+
+/** @type {STD_NPC*} */
+private nosave object *__mobs = ({});
+
+void pre_setup_1() {
+  set_zone(__DIR__ "thornwick");
+  set_terrain("road");
+}
+
+/**
+ * Lightweight per-room spawner. Rooms register it during setup with the
+ * mob and level range bound in, e.g.
+ *
+ *   add_reset((: area_spawn, "mob/carrion_crow", 35.0, 1, 2 :));
+ *
+ * At most one mob lives in a room at a time; a fresh one is only rolled
+ * once the previous has been killed and a reset has come around.
+ *
+ * @param {string} file - Virtual mob path, e.g. "mob/carrion_crow".
+ * @param {float} chance - Percentage chance to spawn when the room is empty.
+ * @param {int} lo - Minimum level (inclusive).
+ * @param {int} hi - Maximum level (inclusive).
+ */
+public void area_spawn(string file, float chance, int lo, int hi) {
+  /** @type {STD_NPC} */ object mob;
+
+  __mobs -= ({ 0 });
+
+  if(sizeof(__mobs) > 0)
+    return;
+
+  if(random_float(100.0) >= chance)
+    return;
+
+  mob = add_inventory(file);
+  if(!objectp(mob))
+    return;
+
+  mob->set_level(random_clamp(lo, hi));
+  __mobs += ({ mob });
+}
+
+void event_object_spawned(object _caller, object ob) {
+  if(npcp(ob))
+    query_zone()->add_mob(ob);
+}

--- a/d/thornwick/thornwick_green.c
+++ b/d/thornwick/thornwick_green.c
@@ -1,0 +1,74 @@
+/**
+ * @file /d/thornwick/thornwick_green.c
+ * Thornwick Green, the dead heart of the hamlet. The area hub.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit __DIR__ "thornwick_base";
+
+void setup() {
+  set_short("Thornwick Green");
+  set_long(
+  "This was the heart of the hamlet, and the heart of it still beats "
+  "faintly here, the way a stopped clock keeps the time it died at. A "
+  "green opens about a dry stone well -- out of which, oddly, a cold "
+  "underground breath keeps rising -- ringed by leaning cottages whose "
+  "doorways gape and whose windows are nothing but dark. Grass has come "
+  "up through the packed earth where markets stood; a child's hoop, "
+  "perished to a brown circle, lies where it was dropped and never "
+  "fetched. To the west a cottage stands a little sounder than its "
+  "fellows. Eastward a lych-gate and the chapel's wall mark holy ground. "
+  "North the green gives way to bramble, a wall of thorn higher than a "
+  "rider, from which the crows come and go. The road south climbs back "
+  "toward the living world.");
+
+  set_exits(([
+    "south": "hollow_road3",
+    "west" : "ruined_cottage",
+    "east" : "chapel_yard",
+    "north": "bramble_thicket",
+    "down" : "../tunnels/0,0,-1",
+  ]));
+
+  set_room_size(({3,3,1}));
+  set_terrain("grass");
+
+  set_items(([
+    ({ "well", "stone well", "dry well", "shaft" }) :
+      "The well is dry, and has been dry for years -- but lean over the "
+      "lip and you understand why. It does not end in the cool gleam of "
+      "water but in a ragged blackness where the bottom long ago fell "
+      "clean away into some hollow beneath, and out of that dark a slow "
+      "cold breath of earth and old stone comes sighing up. Iron rungs, "
+      "rusted but sound, ladder down the shaft into the under-dark. The "
+      "windlass has rotted from its frame and the bucket-chain lies "
+      "coiled in the grass like a shed skin. Someone scratched a word "
+      "into the coping-stone once; weather has taken all of it now save "
+      "a single letter B.",
+    ({ "cottages", "houses", "leaning cottages" }) :
+      "They lean together like mourners, these cottages, their thatch "
+      "gone green and sunken, their doors hanging or fallen. You could "
+      "step into any of them; there would be nothing inside but the "
+      "weather and the smell of wet ash, and the sense of having "
+      "interrupted something.",
+    ({ "hoop", "child's hoop" }) :
+      "A child's wooden hoop, lying in the grass, gone soft and brown "
+      "with rot. It is a small thing. It is, somehow, the worst thing "
+      "on the green.",
+    ({ "lych-gate", "lychgate", "gate" }) :
+      "To the east a roofed lych-gate of grey oak still stands, the path "
+      "beneath it worn into a hollow by generations of funerals. Its "
+      "timbers are sound. Of everything in Thornwick, the dead seem "
+      "best provided for.",
+    ({ "bramble", "brambles", "thorn", "wall of thorn" }) :
+      "Northward the bramble rears in a black thicket twice the height "
+      "of a man, and the crows pour in and out of it ceaselessly, like "
+      "smoke from a fire that gives no warmth. Whatever the heart of "
+      "the blight is, it is in there.",
+  ]));
+}

--- a/d/tunnels/tunnels_daemon.c
+++ b/d/tunnels/tunnels_daemon.c
@@ -135,9 +135,11 @@ public void setup_long(object room) {
 
 /**
  * Virtual-map apply that assigns exits to a generated room. Uses
- * the map's computed exits for the room's coordinates, with a
- * special-case "up" exit at coordinate (0,0,-1) leading out to the
- * village square.
+ * the map's computed exits for the room's coordinates, with special-
+ * case "up" exits at the two surface shafts: (8,-9,-1) climbs out to
+ * the well in the village square of Olum, and (0,0,-1) climbs out to
+ * the dry well on Thornwick green. The tunnel network between them
+ * forms the subsurface link between the two hamlets.
  *
  * @param {STD_ROOM} room - The virtual room being populated.
  * @param {string} file - The virtual file identifier for the room
@@ -154,8 +156,10 @@ public void setup_exits(object room, string file) {
   room_type = get_room_type(coords[0], coords[1], coords[2]);
   exits = get_exits(coords[0], coords[1], coords[2]);
 
-  if(file == "0,0,-1")
+  if(file == "8,-9,-1")
     exits["up"] = "../village/square";
+  else if(file == "0,0,-1")
+    exits["up"] = "../thornwick/thornwick_green";
 
   room->set_exits(exits);
 }

--- a/d/village/square.c
+++ b/d/village/square.c
@@ -27,7 +27,7 @@ void setup() {
     "west" : "village_path2",
     "east" : "village_path3",
     "south": "village_path4",
-    "down" : "../tunnels/0,0,-1",
+    "down" : "../tunnels/8,-9,-1",
   ]));
 
   set_room_size(({2,2,1}));

--- a/d/village/village_path5.c
+++ b/d/village/village_path5.c
@@ -22,12 +22,15 @@ void setup() {
   "and activity around it. The path, free of dwellings, emphasizes this lone "
   "building's significance. The air carries scents of old wood, fresh ink, "
   "and excitement, hinting at the building's role as a gathering place for "
-  "newcomers to the village and beyond.");
+  "newcomers to the village and beyond. Westward the bricks straggle on "
+  "past the last of the houses, toward the ragged edge of the village where "
+  "the kept ground gives out to field and weed.");
 
   set_exits(([
     "north": "centre",
     "east" : "village_path2",
     "south": "../forest/2,0,0",
+    "west" : "village_path6",
   ]));
 
   set_items(([
@@ -51,6 +54,11 @@ void setup() {
       "Small weeds occasionally sprout between the bricks, their "
       "presence a testament to the less rigorous maintenance of this "
       "quieter part of the village.",
+    ({ "ragged edge", "edge", "west" }) :
+      "To the west the houses thin and stop, and the brickwork with "
+      "them, until the path is little more than a track running out to "
+      "where the village frays into open field. Folk do not go that way "
+      "much; there is nothing out there now but old country.",
     "air" :
       "The air here carries a mix of domestic scents - freshly baked "
       "bread, laundry drying in the breeze, and the earthy smell of "

--- a/d/village/village_path6.c
+++ b/d/village/village_path6.c
@@ -1,0 +1,61 @@
+/**
+ * @file /d/village/village_path6.c
+ * The fraying western edge of Olum, out past the last kept houses.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit __DIR__ "village_base";
+
+void setup() {
+  set_short("The Western Edge of the Village");
+  set_long(
+  "Here the village begins to let go of itself. The brick path gives way "
+  "to a mend of cracked cobble and packed dirt, and the houses to either "
+  "side are humbler and further apart, their kitchen gardens half gone to "
+  "seed and their fences leaning companionably into the weeds. A shuttered "
+  "outbuilding stands closed and quiet to the north, its business long "
+  "since moved elsewhere. It is not an unfriendly place -- a dog barks "
+  "somewhere, washing snaps on a line -- only a forgotten one, the part of "
+  "Olum that faces away from the square and toward the open country "
+  "beyond. The path runs on west toward that emptiness, and back east into "
+  "the warmth of the village.");
+
+  set_exits(([
+    "east": "village_path5",
+    "west": "village_path7",
+  ]));
+
+  set_room_size(({2,2,1}));
+
+  set_items(([
+    ({ "houses", "cottages", "dwellings" }) :
+      "The last houses of the village stand here, modest and a little "
+      "careworn, set well apart with room between them for a goat or a "
+      "vegetable plot. Smoke stands from one or two of the chimneys; the "
+      "rest seem to be drowsing.",
+    ({ "kitchen gardens", "gardens", "garden" }) :
+      "Once-tidy kitchen gardens have been let go a season too long, "
+      "their cabbages bolted and their bean-rows tangled. Nobody is "
+      "starving for it; it is only that out here, on the quiet edge, "
+      "nobody hurries.",
+    ({ "shuttered outbuilding", "outbuilding", "building" }) :
+      "A low building stands shut up to the north, its shutters barred "
+      "and its door padlocked. Whatever trade it housed has gone to "
+      "better premises nearer the square, and it waits, patient and "
+      "empty, for a tenant that has not come.",
+    ({ "fences", "fence", "weeds" }) :
+      "Split-rail fences lean every which way, half-swallowed by nettle "
+      "and dock and cow-parsley. They mark boundaries nobody troubles to "
+      "dispute any more.",
+    ({ "open country", "country", "west", "emptiness" }) :
+      "Westward the houses give out altogether and the land opens, grey-"
+      "green and rolling, under a wide and uncommitted sky. There is a "
+      "track that way, and not much else, and the few who take it do not "
+      "speak much of where it goes.",
+  ]));
+}

--- a/d/village/village_path7.c
+++ b/d/village/village_path7.c
@@ -1,0 +1,59 @@
+/**
+ * @file /d/village/village_path7.c
+ * The last of Olum, where the track meets open field and the road north.
+ *
+ * @created 2026-06-15 - Gesslar
+ * @last_modified 2026-06-15 - Gesslar
+ *
+ * @history
+ * 2026-06-15 - Gesslar - Created
+ */
+
+inherit __DIR__ "village_base";
+
+void setup() {
+  set_short("The End of the Village");
+  set_long(
+  "This is the last of Olum, and it knows it. The dirt track widens into a "
+  "patch of trodden grass and then simply stops, hemmed by hedgerow and the "
+  "first of the open fields, which roll away pale and empty to the west. No "
+  "house stands beyond this point. To the north the ground lifts a little, "
+  "and there the field-edge is broken by the mouth of an old sunken lane "
+  "that drops away between high earthen banks -- the hollow road, the "
+  "village folk call it, on the rare occasions they call it anything at "
+  "all. They will tell you, if pressed, that it goes up to Thornwick, that "
+  "was a hamlet once. They will not, as a rule, offer to walk you there. "
+  "The way back east leads home into the village.");
+
+  set_exits(([
+    "east" : "village_path6",
+    "north": "../thornwick/hollow_road1",
+  ]));
+
+  set_room_size(({2,2,1}));
+  set_terrain("grass");
+
+  set_items(([
+    ({ "fields", "field", "open fields" }) :
+      "The fields run west to the edge of seeing, fallow and unfenced, "
+      "the grass silvering when the wind moves over it. Nobody seems to "
+      "work them this far out. They are not so much farmed as left.",
+    ({ "hedgerow", "hedge", "hedges" }) :
+      "A thick old hedgerow marks the boundary of the village's reach, "
+      "hawthorn and bramble grown tall and dense. It is greener and more "
+      "vigorous toward the north, toward the hollow road, as though "
+      "something up that way agreed with it.",
+    ({ "sunken lane", "hollow road", "lane", "mouth", "north" }) :
+      "To the north the field-edge opens on a sunken lane that drops "
+      "between earthen banks and is quickly lost beneath the meeting "
+      "of its hedges. A cold breath seems to come up out of it, even on "
+      "a warm day. That is the hollow road, and it goes to Thornwick, "
+      "and few who live take it without good reason.",
+    ({ "thornwick", "hamlet" }) :
+      "Thornwick, the elders say, was a fair enough hamlet in their "
+      "grandparents' time -- Olum's small sister up the road. Then a "
+      "blight came into it, and the people went out of it, and now it is "
+      "spoken of the way one speaks of a grave: quietly, and not for "
+      "long.",
+  ]));
+}

--- a/obj/loot/blighted_hide.lpml
+++ b/obj/loot/blighted_hide.lpml
@@ -1,0 +1,16 @@
+{
+  id: ["hide"],
+  additional ids: ["skin","pelt"],
+  adj: ["blighted","matted","mangy"],
+  name: "blighted hide",
+  short: "a matted, blighted hide",
+  long: "The hide of a bramble cur, matted and half gone to something like "
+        "bark. Thorns have grown clean through it in places. A tanner of "
+        "strong stomach might still make something of it, blight and all.",
+  mass: 40,
+  material: ["leather"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/crow_feather.lpml
+++ b/obj/loot/crow_feather.lpml
@@ -1,0 +1,16 @@
+{
+  id: ["feather"],
+  additional ids: ["plume","quill"],
+  adj: ["crow","black","oily","ragged"],
+  name: "crow feather",
+  short: "an oily black crow feather",
+  long: "A long flight-feather from a carrion crow, black as wet slate and "
+        "faintly iridescent where the light catches it. The quill is sound "
+        "and would take an ink well enough.",
+  mass: 1,
+  material: ["feather"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/cur_fang.lpml
+++ b/obj/loot/cur_fang.lpml
@@ -1,0 +1,16 @@
+{
+  id: ["fang"],
+  additional ids: ["tooth","tusk"],
+  adj: ["yellowed","curved","cur"],
+  name: "cur fang",
+  short: "a yellowed cur fang",
+  long: "A curved fang the length of a finger, prised from the jaw of a "
+        "bramble cur. It is yellowed and cracked, and a faint green stain "
+        "lingers in the root where the blight got into the bone.",
+  mass: 3,
+  material: ["bone"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Thornwick, an abandoned blighted hamlet connected to Olum via a hollow road and to the existing tunnel network via a dry well on the green. It introduces zone infrastructure (`thornwick.c`, `controller.c`, `thornwick_base.c`), eight new rooms, two new mob types, three loot items, and two new village path rooms bridging Olum to the hollow road.

- The new Thornwick area is well-structured: `thornwick_base.c`'s `area_spawn` correctly enforces one live mob per room, cleans up dead references, and registers NPCs with the zone via `event_object_spawned`. Exits, terrain, and mob paths all follow existing area conventions.
- The tunnel network's \"up\" exit mapping was updated so `(0,0,-1)` now leads to Thornwick green; however, the village square's \"down\" exit was moved to `(8,-9,-1)`, a coordinate whose y=−9 falls outside the valid range of `tunnels_map.txt` (y 0–21). This leaves the village well as a dead-end room with no connection to the tunnel body.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the tunnel coordinate for the village well is corrected or the tunnel map is extended.

The Thornwick area itself is complete and well-connected. The single blocking issue is the village-square tunnel entrance: its new coordinate (8,−9,−1) is outside the valid cell range of the unchanged tunnel map, so descending from the village well drops players into a featureless dead-end room with no exits into the tunnel network.

d/village/square.c and d/tunnels/tunnels_daemon.c — the tunnel coordinate change requires either updating tunnels_map.txt or choosing a valid in-range coordinate for the village well shaft.

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `d/maze/maze_daemon.c`, line 24 ([link](https://github.com/gesslar/oxidus-mudlib/blob/1bcb2cc5382053db20feefd95171253cf530b022/d/maze/maze_daemon.c#L24)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Maze size drastically reduced; spread=1 removes all randomness**

   With `spread=1`, `prandom(1)` always yields 0 (range `0..spread-1` = `0..0`), so the dimensions become fixed at exactly z=5, y=10, x=10 — a drop from the previous ~25–29 per axis. The old volume was roughly 15,000–25,000 rooms; the new volume is capped at 500. If the maze area is still reachable by players, this will silently collapse it. If the intent is to make the tunnels deterministic, it might be worth confirming this daemon controls the right system and that no existing maze content depends on the larger size.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20d%2Fmaze%2Fmaze_daemon.c%0ALine%3A%2024%0A%0AComment%3A%0A**Maze%20size%20drastically%20reduced%3B%20spread%3D1%20removes%20all%20randomness**%0A%0AWith%20%60spread%3D1%60%2C%20%60prandom%281%29%60%20always%20yields%200%20%28range%20%600..spread-1%60%20%3D%20%600..0%60%29%2C%20so%20the%20dimensions%20become%20fixed%20at%20exactly%20z%3D5%2C%20y%3D10%2C%20x%3D10%20%E2%80%94%20a%20drop%20from%20the%20previous%20~25%E2%80%9329%20per%20axis.%20The%20old%20volume%20was%20roughly%2015%2C000%E2%80%9325%2C000%20rooms%3B%20the%20new%20volume%20is%20capped%20at%20500.%20If%20the%20maze%20area%20is%20still%20reachable%20by%20players%2C%20this%20will%20silently%20collapse%20it.%20If%20the%20intent%20is%20to%20make%20the%20tunnels%20deterministic%2C%20it%20might%20be%20worth%20confirming%20this%20daemon%20controls%20the%20right%20system%20and%20that%20no%20existing%20maze%20content%20depends%20on%20the%20larger%20size.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gesslar%2Foxidus-mudlib&pr=238&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ad%2Fvillage%2Fsquare.c%3A27%0A**Dead-end%20tunnel%20coordinate%20%E2%80%94%20village%20entrance%20unreachable**%0A%0AThe%20%22down%22%20exit%20now%20points%20to%20%60..%2Ftunnels%2F8%2C-9%2C-1%60.%20The%20virtual%20map%20system%20parses%20this%20as%20x%3D8%2C%20y%3D%E2%88%929%2C%20z%3D%E2%88%921%20and%20calls%20%60get_room_type%28z%3D-1%2C%20y%3D-9%2C%20x%3D8%29%60%2C%20which%20computes%20%60y*2%20%3D%20-18%60%20and%20returns%20an%20empty%20string%20because%20no%20character%20exists%20at%20%60map_lines%5B26%5D%5B16%5D%60%20%28a%2015-char%20line%29.%20%60is_valid_room%60%20therefore%20returns%20false.%0A%0A%60get_exits%60%20also%20short-circuits%20for%20negative%20y%3A%20every%20%60ny%20%3D%20-18%20%2B%20dy%5Bi%5D%60%20is%20negative%2C%20so%20%60ny%20%3E%3D%200%60%20fails%20for%20every%20direction.%20The%20resulting%20room%20has%20only%20the%20%22up%22%20exit%20back%20to%20the%20square%20and%20no%20short%20or%20long%20description%20%E2%80%94%20the%20tunnel%20network%20is%20unreachable%20from%20Olum.%0A%0AThe%20tunnels_map.txt%20was%20not%20changed%20in%20this%20PR.%20Either%20the%20map%20needs%20a%20new%20room%20at%20%288%2C%20y%E2%89%A50%2C%20%E2%88%921%29%20that%20connects%20into%20the%20network%2C%20or%20the%20village%20well%20should%20reuse%20an%20existing%20map%20coordinate%20whose%20natural%20exits%20lead%20into%20the%20tunnel%20body.%0A%0A%23%23%23%20Issue%202%20of%202%0Ad%2Ftunnels%2Ftunnels_daemon.c%3A159-163%0A**Matching%20side%20of%20the%20dead-end%20coordinate**%0A%0AThis%20condition%20correctly%20adds%20%22up%22%20%E2%86%92%20%60..%2Fvillage%2Fsquare%60%20when%20the%20file%20is%20%60%228%2C-9%2C-1%22%60%2C%20but%20because%20%608%2C-9%2C-1%60%20is%20not%20a%20reachable%20room%20in%20the%20current%20%60tunnels_map.txt%60%20%28valid%20y%20range%20is%200%E2%80%9321%29%2C%20this%20branch%20is%20never%20triggered%20in%20practice.%20See%20the%20companion%20comment%20on%20%60d%2Fvillage%2Fsquare.c%60%20for%20the%20full%20analysis.%20The%20%60%220%2C0%2C-1%22%60%20%E2%86%92%20Thornwick%20side%20works%20correctly%20since%20%280%2C0%29%20is%20the%20map's%20origin.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=238&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["new area"](https://github.com/gesslar/oxidus-mudlib/commit/969735493797dd4a3c7f2262cb94e17be74aea56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37807266)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->