### PR TITLE
minor tweaks

### DIFF
--- a/adm/daemons/coord.c
+++ b/adm/daemons/coord.c
@@ -1,5 +1,6 @@
 /**
  * @file /adm/daemons/coord.c
+ *
  * Coordinate daemon to hold room data
  *
  * @created 2024-08-18 - Gesslar

--- a/adm/daemons/resource.c
+++ b/adm/daemons/resource.c
@@ -50,7 +50,7 @@ public mapping query_resources() {
 }
 
 private void redistribute_resources() {
-  shout("Redistributing resources.\n");
+  // shout("Redistributing resources.\n");
 
   debug("Loaded = %O", __loaded);
 

--- a/include/objects.h
+++ b/include/objects.h
@@ -4,7 +4,7 @@
 #include <dirs.h>
 
 #define OBJ_LOOT                DIR_OBJ           "loot/loot"
-#define OBJ_NODE                DIR_OBJ_NODE      "resource_node"
+#define OBJ_NODE                DIR_OBJ_NODE      "node"
 #define OBJ_SECURITY_EDITOR     DIR_ADM_OBJ       "security_editor"
 
 #endif // __OBJECTS_H__


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Three minor housekeeping changes: a doc-comment whitespace fix in `coord.c`, silencing a `shout()` broadcast in the resource redistribution routine, and renaming the `OBJ_NODE` macro target from `"resource_node"` to `"node"` to match the actual file at `obj/node/node.c`.

- `adm/daemons/coord.c` — adds a blank line to the file-header block comment; no functional effect.
- `adm/daemons/resource.c` — the `shout()` call that broadcast "Redistributing resources." to all players is now commented out, quieting the spam.
- `include/objects.h` — `OBJ_NODE` updated to point at `obj/node/node.c`; the old `resource_node.c` no longer exists so this is a required fix.

<h3>Confidence Score: 5/5</h3>

All three changes are cosmetic or corrective; the only functional edit (silencing the shout broadcast) has no effect on game logic or data.

The macro rename aligns with the actual file on disk, the whitespace fix is trivial, and removing the player-facing shout during resource redistribution is straightforward. None of the changes touch core execution paths in a way that could cause incorrect behaviour.

No files require special attention.

<sub>Reviews (7): Last reviewed commit: ["minor tweaks"](https://github.com/gesslar/oxidus-mudlib/commit/ed5600c7a377c228a1de409a4ac9d1f255d2c9d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37807267)</sub>

<!-- /greptile_comment -->