### PR TITLE
fixing where room exits are determined by their full name

### DIFF
--- a/std/object/command.c
+++ b/std/object/command.c
@@ -387,6 +387,13 @@ public int command_hook(string arg) {
     // }
   };
 
+  /** @type {STD_ROOM} */ object room = environment();
+
+  if(room && room->valid_exit(verb)) {
+    arg = verb;
+    verb = "go";
+  }
+
   cmds = map(__cmdPaths, (: $1 + $(verb) + ".c" :));
   cmds = filter(cmds, (: file_exists :));
 
@@ -395,13 +402,6 @@ public int command_hook(string arg) {
     if(sz > 1) {
       tell("Ambiguous command.\n");
       return 1;
-    }
-
-    /** @type {STD_ROOM} */ object room = environment();
-
-    if(room && room->valid_exit(verb)) {
-      arg = verb;
-      verb = "go";
     }
 
     err = catch(cmd = load_object(cmds[0]));


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where typing a room exit name directly (e.g., `north`) would silently fail rather than redirecting to the `go` command. The exit-validity check was previously nested inside the `if(sz > 0)` block that only executed when a matching command file (e.g., `north.c`) was found — meaning exits with no corresponding command file were never reachable.

- Moves the `room->valid_exit(verb)` check to before the command-file lookup, so the redirect to `go <exit>` fires regardless of whether a matching command file exists.
- When an exit match is found, `verb` is set to `"go"` and `arg` is set to the original verb (the exit name), so the `go.c` command is correctly loaded and called with the exit as its argument.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused, correct reordering of the exit-redirect logic that makes the previously dead code path functional.

The old exit check was guarded inside `if(sz > 0)`, which only entered when a command file matching the typed verb existed. Because no `north.c`/`south.c` etc. command files exist in the normal command paths, the check never fired. Moving it before the command-file search is the minimal, correct fix and has no negative side effects: the room and null guards are preserved, and the subsequent `cmds` lookup now correctly resolves to `go.c` rather than a non-existent directional command file.

No files require special attention.

<sub>Reviews (7): Last reviewed commit: ["fixing where room exits are determined b..."](https://github.com/gesslar/oxidus-mudlib/commit/eb2d30f9157b3b61576d4e2701d20e94b6ca3dea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37807268)</sub>

<!-- /greptile_comment -->