### PR TITLE
make aliases persist across saves

### DIFF
--- a/std/living/alias.c
+++ b/std/living/alias.c
@@ -22,7 +22,7 @@
  *
  * @type {([ string: string ])}
  */
-private nosave mapping __aliases = ([]);
+private mapping __aliases = ([]);
 
 /**
  * Ensures the alias mapping exists, initialising it to an empty mapping


### PR DESCRIPTION
### TL;DR

Make aliases persist across saves and restores.

### What changed?

The `__aliases` mapping in `std/living/alias.c` had the `nosave` modifier removed, allowing it to be included when the object is saved.

### How to test?

Set one or more aliases on a character, save, and log back in. Aliases should be retained between sessions.

### Why make this change?

The `nosave` modifier was preventing aliases from being persisted when a living object was saved. This meant players would lose all their aliases whenever they logged out, which is undesirable behaviour.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `nosave` modifier from the `__aliases` mapping in `std/living/alias.c`, enabling player aliases to persist across save/restore cycles.

- The single-line change is intentional and correct: dropping `nosave` allows the LPC save system to serialise `__aliases` alongside other living data, so aliases survive logouts.
- Backward compatibility with existing save files is handled by the `??=` null-coalescing initialiser already present in `init_aliases()`, which safely resets the field to an empty mapping when it is absent from an older save.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single modifier removal with no logic altered, and the existing null-coalescing initialiser in `init_aliases()` ensures existing save files without the field load cleanly.

The change is exactly one token removed from one variable declaration. The rest of the file is untouched, existing save files that pre-date this change will have no `__aliases` field, and the `??=` guard in `init_aliases()` already handles that case by falling back to an empty mapping. There are no correctness concerns.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["aroo"](https://github.com/gesslar/oxidus-mudlib/commit/23b8cc76e4a856b63f1f83b279118fb529b51af9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38060410)</sub>

<!-- /greptile_comment -->