### PR TITLE
improve save command feedback

### DIFF
--- a/cmds/std/save.c
+++ b/cmds/std/save.c
@@ -13,11 +13,14 @@
 
 inherit STD_CMD;
 
-mixed main(/** @type {STD_BODY} */ object caller,
-    string _args) {
-  caller->save_body();
-  tell_me("Successful [save]: User saved.\n");
-  return 1;
+mixed main(
+  /** @type {STD_BODY} */ object caller,
+  string _args
+) {
+  if(caller->save_body())
+    return _ok("Saved.");
+
+  return _warn("Unable to save.");
 }
 
 string query_help(object _caller) {


### PR DESCRIPTION
### TL;DR

Improved feedback handling for the `save` command by returning success or warning messages based on whether the save operation succeeded.

### What changed?

The `save` command now checks the return value of `save_body()` and responds accordingly. If the save is successful, it returns an `_ok` message ("Saved."). If the save fails, it returns a `_warn` message ("Unable to save.") instead of always reporting success regardless of outcome.

### How to test?

Run the `save` command in-game under normal conditions and verify the "Saved." confirmation message appears. Then attempt to trigger a failed save (e.g., in a context where saving is not permitted) and confirm the "Unable to save." warning is returned instead.

### Why make this change?

Previously, the command always told the user their save was successful, even if `save_body()` failed. This change ensures the player receives accurate feedback about whether their character was actually saved.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The `save` command now checks the return value of `caller->save_body()` and returns an appropriate `_ok` or `_warn` message, replacing the previous behavior that always reported success regardless of outcome.

- **Correct feedback on failure**: Previously, `save_body()` was called but its return value was ignored, so the player always saw a success message even when the save failed. The new code gates the success message on the actual return value.
- **Messaging style updated**: Replaced `tell_me(...)` + `return 1` with the `_ok`/`_warn` helper pattern consistent with other commands in this codebase.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-scoped fix that correctly propagates the return value of save_body() to the player.

The only logic change is checking save_body()'s return value and branching to _ok/_warn, which is straightforwardly correct. No edge cases are introduced, and the fallback _warn path handles the failure case that was previously silently ignored.

No files require special attention.

<sub>Reviews (4): Last reviewed commit: ["minor update to save command"](https://github.com/gesslar/oxidus-mudlib/commit/a1119df6095a911d8fa604a5b6dfbf3726140373) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38060412)</sub>

<!-- /greptile_comment -->