### PR TITLE
comment out debug log in resource daemon

### DIFF
--- a/adm/daemons/resource.c
+++ b/adm/daemons/resource.c
@@ -52,7 +52,7 @@ public mapping query_resources() {
 private void redistribute_resources() {
   // shout("Redistributing resources.\n");
 
-  debug("Loaded = %O", __loaded);
+  // debug("Loaded = %O", __loaded);
 
   each(__loaded, (: reset_room_resources :));
 }


### PR DESCRIPTION
### TL;DR

Silenced a noisy debug log statement in the resource redistribution daemon.

### What changed?

The `debug("Loaded = %O", __loaded)` call in `redistribute_resources()` has been commented out, preventing it from logging the loaded resources map on every redistribution cycle.

### How to test?

Trigger a resource redistribution cycle and confirm that the `Loaded = ...` debug output no longer appears in the logs.

### Why make this change?

The debug statement was likely left in from development and produces unnecessary log noise during normal operation, as `redistribute_resources()` is called repeatedly at runtime.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR silences a noisy debug log in `adm/daemons/resource.c` by commenting out `debug("Loaded = %O", __loaded)` inside `redistribute_resources()`, which runs repeatedly at runtime.

- The commented-out line is a pure logging side effect; the subsequent `each(__loaded, (: reset_room_resources :))` call is unaffected, leaving execution behavior unchanged.
- This is consistent with the existing commented-out `shout(...)` call a couple of lines above it in the same function.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes log noise without touching any logic or data.

The only change is commenting out a debug log call that had no effect on program state. The redistribution logic (`each(__loaded, ...)`) is completely untouched, and the pattern mirrors an already-commented `shout()` call in the same function.

No files require special attention.

<sub>Reviews (5): Last reviewed commit: ["disabling debug info"](https://github.com/gesslar/oxidus-mudlib/commit/69bbde9a8ad19554217682569037ed333ba0f9bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38060416)</sub>

<!-- /greptile_comment -->