### PR TITLE
replace room size with per-exit distances

### DIFF
--- a/adm/daemons/coord.c
+++ b/adm/daemons/coord.c
@@ -23,6 +23,13 @@ void setup() {
   set_persistent(1);
 }
 
+void clear() {
+  rooms = ([]);
+  rooms_array = ({});
+
+  save_data();
+}
+
 void set_coordinate_data(mapping m) {
   rooms = m;
   rooms_array = map(values(rooms), (: $1.coords :));
@@ -37,13 +44,6 @@ mapping get_coordinate_data() {
 int *get_coordinates(string room) {
   if(classp(rooms[room]))
     return rooms[room].coords;
-
-  return null;
-}
-
-int *get_size(string room) {
-  if(classp(rooms[room]))
-    return rooms[room].size;
 
   return null;
 }

--- a/adm/daemons/crawler.c
+++ b/adm/daemons/crawler.c
@@ -23,7 +23,7 @@ inherit CLASS_ROOMINFO;
 void crawl_next_room(object tp, mixed arg...);
 void process_room(object room, object tp);
 object stash_objects(string room_file, object tp);
-int *update_coordinates(int *coords, string exit, int *current_size, int *next_size);
+int *update_coordinates(int *coords, string exit, int distance);
 string log_file = "/log/crawl.log";
 
 private nosave float crawl_speed = 0.001;
@@ -42,6 +42,16 @@ private nosave mapping done = ([]);
  */
 private nosave mapping todo = ([]);
 private nosave int x, y, z;
+
+/**
+ * The directional exits that map onto the coordinate grid. Only these
+ * are checked for cross-edge consistency; other exits (portals, named
+ * passages) carry no spatial relationship.
+ */
+private nosave string *grid_dirs = ({
+  "north", "south", "east", "west", "up", "down",
+  "northeast", "northwest", "southeast", "southwest"
+});
 
 private nosave string crawl_start_room;
 
@@ -74,14 +84,15 @@ void crawl(mixed arg...) {
   if(!room)
     return;
 
+  COORD_D->clear();
+
   call_out_walltime("crawl_next_room", crawl_speed, tp, arg);
 
   todo[file_name(room)] = new(class RoomInfo,
     short: room->query_short(),
     todo: room->query_exit_ids(),
     done: ({}),
-    coords: ({0, 0, 0}),
-    size: ({1, 1, 1})
+    coords: ({0, 0, 0})
   );
 }
 
@@ -151,29 +162,43 @@ void process_room(object room, object tp) {
     exit = room_data.todo[0];
     dest = room->query_exit(exit);
 
-    if(dest && !done[dest] && !todo[dest]) {
-      object next_room;
-      string e;
+    if(dest) {
+      int distance = room->query_distance(exit);
 
-      e = catch( next_room = stash_objects(dest, tp) );
-      if(e) {
-        write_file(log_file, sprintf("Failed to load %s => %s via %s\n", file, dest, exit));
-        continue;
-      }
+      if(!done[dest] && !todo[dest]) {
+        object next_room;
+        string e;
 
-      if(next_room) {
-        int *next_size;
-        int *new_coords;
+        e = catch( next_room = stash_objects(dest, tp) );
+        if(e)
+          write_file(log_file, sprintf("Failed to load %s => %s via %s\n", file, dest, exit));
+        else if(next_room) {
+          int *new_coords = update_coordinates(room_data.coords, exit, distance);
 
-        next_size = next_room->query_room_size() || ({1, 1, 1});
-        new_coords = update_coordinates(room_data.coords, exit, room_data.size, next_size);
-        todo[dest] = new(class RoomInfo,
-          short: next_room->query_short(),
-          todo: next_room->query_exit_ids(),
-          done: ({}),
-          coords: new_coords,
-          size: next_size
-        );
+          todo[dest] = new(class RoomInfo,
+            short: next_room->query_short(),
+            todo: next_room->query_exit_ids(),
+            done: ({}),
+            coords: new_coords
+          );
+        }
+      } else if(member_array(exit, grid_dirs) != -1) {
+        // Cross-edge: the destination is already placed. Verify this
+        // exit agrees with where it sits, and log the edge if not.
+        class RoomInfo placed = done[dest];
+        int *expected = update_coordinates(room_data.coords, exit, distance);
+
+        if(!placed)
+          placed = todo[dest];
+
+        if(placed && (placed.coords[0] != expected[0] ||
+                      placed.coords[1] != expected[1] ||
+                      placed.coords[2] != expected[2]))
+          write_file(log_file, sprintf(
+            "Cross-edge conflict: %s %s -> %s expected (%d,%d,%d) but placed at (%d,%d,%d)\n",
+            file, exit, dest,
+            expected[0], expected[1], expected[2],
+            placed.coords[0], placed.coords[1], placed.coords[2]));
       }
     }
 
@@ -188,52 +213,52 @@ void process_room(object room, object tp) {
 
 /**
  * Computes the grid coordinates of an adjacent room based on the
- * direction of travel and the sizes of both rooms.
+ * direction of travel and the per-exit distance declared on the
+ * current room.
  *
- * The offset along each axis is half the sum of the two rooms' sizes
- * on that axis, so the rooms abut without overlapping. Diagonal exits
- * shift along two axes at once. The result is rounded to the nearest
- * integer grid coordinate.
+ * The destination is shifted by the whole-square distance along the
+ * relevant axis (both axes for diagonals). Distances are integers, so
+ * no rounding is involved and the grid stays exact. Non-directional
+ * exits leave the coordinates unchanged.
  *
  * @param {int*} coords - The {x, y, z} coordinates of the current
  *                        room.
  * @param {string} exit - The direction of travel (e.g. "north",
  *                        "southeast", "up").
- * @param {int*} current_size - The {width, height, depth} of the
- *                              current room.
- * @param {int*} next_size - The {width, height, depth} of the
- *                           destination room.
+ * @param {int} distance - The centre-to-centre distance in grid
+ *                         squares for this exit.
  * @returns {int*} The {x, y, z} grid coordinates of the destination
  *                 room.
  */
-int *update_coordinates(int *coords, string exit, int *current_size, int *next_size) {
-  float *new_coords = ({ to_float(coords[0]), to_float(coords[1]), to_float(coords[2]) });
+int *update_coordinates(int *coords, string exit, int distance) {
+  int *new_coords = ({ coords[0], coords[1], coords[2] });
 
   switch(exit) {
-    case "north": new_coords[1] += (current_size[1] + next_size[1]) / 2.0 ; break;
-    case "south": new_coords[1] -= (current_size[1] + next_size[1]) / 2.0 ; break;
-    case "east":  new_coords[0] += (current_size[0] + next_size[0]) / 2.0 ; break;
-    case "west":  new_coords[0] -= (current_size[0] + next_size[0]) / 2.0 ; break;
-    case "up":    new_coords[2] += (current_size[2] + next_size[2]) / 2.0 ; break;
-    case "down":  new_coords[2] -= (current_size[2] + next_size[2]) / 2.0 ; break;
+    case "north": new_coords[1] += distance; break;
+    case "south": new_coords[1] -= distance; break;
+    case "east":  new_coords[0] += distance; break;
+    case "west":  new_coords[0] -= distance; break;
+    case "up":    new_coords[2] += distance; break;
+    case "down":  new_coords[2] -= distance; break;
     case "northeast":
-      new_coords[0] += (current_size[0] + next_size[0]) / 2.0;
-      new_coords[1] += (current_size[1] + next_size[1]) / 2.0;
+      new_coords[0] += distance;
+      new_coords[1] += distance;
       break;
     case "northwest":
-      new_coords[0] -= (current_size[0] + next_size[0]) / 2.0;
-      new_coords[1] += (current_size[1] + next_size[1]) / 2.0;
+      new_coords[0] -= distance;
+      new_coords[1] += distance;
       break;
     case "southeast":
-      new_coords[0] += (current_size[0] + next_size[0]) / 2.0;
-      new_coords[1] -= (current_size[1] + next_size[1]) / 2.0;
+      new_coords[0] += distance;
+      new_coords[1] -= distance;
       break;
     case "southwest":
-      new_coords[0] -= (current_size[0] + next_size[0]) / 2.0;
-      new_coords[1] -= (current_size[1] + next_size[1]) / 2.0;
+      new_coords[0] -= distance;
+      new_coords[1] -= distance;
       break;
   }
-  return ({ to_int(round(new_coords[0])), to_int(round(new_coords[1])), to_int(round(new_coords[2])) });
+
+  return new_coords;
 }
 
 /**

--- a/d/cavern/cavern_daemon.c
+++ b/d/cavern/cavern_daemon.c
@@ -629,7 +629,7 @@ public void setup_exits(object room) {
     }
   }
 
-  if(z == exit[0] && y == exit[1] && x == exit[2])
+  if(entrance && z == exit[0] && y == exit[1] && x == exit[2])
     room->add_exit("up", sprintf("/d/wastes/%d,%d,%d", entrance[2], entrance[1], entrance[0]));
 }
 
@@ -961,8 +961,9 @@ void determine_exit_and_entrance() {
   height = /** @type {WastesDaemon} */ (wastes_daemon)->get_map_height();
   width = /** @type {WastesDaemon} */ (wastes_daemon)->get_map_width();
 
+  int max = 100;
   // Pick a random room in the wastes and set a down exit to the cavern
-  while(true) {
+  while(true && --max > 0) {
     int y, x;
     string room_type;
 

--- a/d/thornwick/bramble_thicket.c
+++ b/d/thornwick/bramble_thicket.c
@@ -29,7 +29,8 @@ void setup() {
     "south": "thornwick_green",
   ]));
 
-  set_room_size(({1,1,1}));
+  set_distance("south", 3);
+
   set_terrain("forest");
 
   add_reset((: area_spawn, "mob/bramble_cur", 65.0, 3, 5 :));

--- a/d/thornwick/chapel.c
+++ b/d/thornwick/chapel.c
@@ -31,7 +31,8 @@ void setup() {
     "west": "chapel_yard",
   ]));
 
-  set_room_size(({2,3,1}));
+  set_distance("west", 2);
+
   set_terrain("indoor");
   set_room_type("temple");
 

--- a/d/thornwick/chapel_yard.c
+++ b/d/thornwick/chapel_yard.c
@@ -29,7 +29,9 @@ void setup() {
     "east": "chapel",
   ]));
 
-  set_room_size(({2,2,1}));
+  set_distance("west", 3);
+  set_distance("east", 2);
+
   set_terrain("grass");
 
   add_reset((: area_spawn, "mob/carrion_crow", 50.0, 2, 3 :));

--- a/d/thornwick/hollow_road1.c
+++ b/d/thornwick/hollow_road1.c
@@ -25,11 +25,13 @@ void setup() {
   "inward-looking, as though the land itself would rather not be walked.");
 
   set_exits(([
-    "south": "../village/village_path7",
     "north": "hollow_road2",
+    "south": "../village/village_path7",
   ]));
 
-  set_room_size(({2,2,1}));
+  set_distance("north", 2);
+  set_distance("south", 2);
+
   set_terrain("grass");
 
   set_items(([

--- a/d/thornwick/hollow_road2.c
+++ b/d/thornwick/hollow_road2.c
@@ -25,11 +25,13 @@ void setup() {
   "falls away south to easier ground.");
 
   set_exits(([
-    "south": "hollow_road1",
     "north": "old_bridge",
+    "south": "hollow_road1",
   ]));
 
-  set_room_size(({1,2,1}));
+  set_distance("north", 3);
+  set_distance("south", 2);
+
   set_terrain("grass");
 
   add_reset((: area_spawn, "mob/carrion_crow", 40.0, 1, 2 :));

--- a/d/thornwick/hollow_road3.c
+++ b/d/thornwick/hollow_road3.c
@@ -26,11 +26,13 @@ void setup() {
   "into the green to the north.");
 
   set_exits(([
-    "south": "old_bridge",
     "north": "thornwick_green",
+    "south": "old_bridge",
   ]));
 
-  set_room_size(({2,2,1}));
+  set_distance("north", 3);
+  set_distance("south", 3);
+
   set_terrain("grass");
 
   set_items(([

--- a/d/thornwick/old_bridge.c
+++ b/d/thornwick/old_bridge.c
@@ -29,7 +29,9 @@ void setup() {
     "north": "hollow_road3",
   ]));
 
-  set_room_size(({2,3,1}));
+  set_distance("north", 3);
+  set_distance("south", 3);
+
   set_terrain("road");
 
   set_items(([

--- a/d/thornwick/ruined_cottage.c
+++ b/d/thornwick/ruined_cottage.c
@@ -30,7 +30,8 @@ void setup() {
     "east": "thornwick_green",
   ]));
 
-  set_room_size(({2,2,1}));
+  set_distance("east", 3);
+
   set_terrain("indoor");
 
   add_reset((: area_spawn, "mob/rat", 55.0, 1, 2 :));

--- a/d/thornwick/thornwick_green.c
+++ b/d/thornwick/thornwick_green.c
@@ -28,14 +28,18 @@ void setup() {
   "toward the living world.");
 
   set_exits(([
-    "south": "hollow_road3",
-    "west" : "ruined_cottage",
-    "east" : "chapel_yard",
     "north": "bramble_thicket",
+    "south": "hollow_road3",
+    "east" : "chapel_yard",
+    "west" : "ruined_cottage",
     "down" : "../tunnels/0,0,-1",
   ]));
 
-  set_room_size(({3,3,1}));
+  set_distance("north", 3);
+  set_distance("south", 3);
+  set_distance("east", 3);
+  set_distance("west", 3);
+
   set_terrain("grass");
 
   set_items(([

--- a/d/tunnels/tunnels_daemon.c
+++ b/d/tunnels/tunnels_daemon.c
@@ -136,7 +136,7 @@ public void setup_long(object room) {
 /**
  * Virtual-map apply that assigns exits to a generated room. Uses
  * the map's computed exits for the room's coordinates, with special-
- * case "up" exits at the two surface shafts: (8,-9,-1) climbs out to
+ * case "up" exits at the two surface shafts: (7,13,-1) climbs out to
  * the well in the village square of Olum, and (0,0,-1) climbs out to
  * the dry well on Thornwick green. The tunnel network between them
  * forms the subsurface link between the two hamlets.
@@ -147,16 +147,15 @@ public void setup_long(object room) {
  */
 public void setup_exits(object room, string file) {
   int *coords = room->get_virtual_coordinates();
-  string room_type;
-  mapping exits;
 
   if(!coords)
     return;
 
-  room_type = get_room_type(coords[0], coords[1], coords[2]);
-  exits = get_exits(coords[0], coords[1], coords[2]);
+  debug("coords: %O", coords);
+  // string room_type = get_room_type(coords[0], coords[1], coords[2]);
+  mapping exits = get_exits(coords[0], coords[1], coords[2]);
 
-  if(file == "8,-9,-1")
+  if(file == "7,13,-1")
     exits["up"] = "../village/square";
   else if(file == "0,0,-1")
     exits["up"] = "../thornwick/thornwick_green";

--- a/d/tunnels/tunnels_map.txt
+++ b/d/tunnels/tunnels_map.txt
@@ -22,8 +22,8 @@ O-O-O   O-O O     O O-O
   |   |     |
   O   O-O O O
   |  /   /| |
-  O-O O O-O-O O
-     \|/  |   |
+  O-O O O-O-O
+     \|/  |  \
       O-O-O-O O
       |     | |
     O-O   O-O O-O-O

--- a/d/village/square.c
+++ b/d/village/square.c
@@ -14,23 +14,27 @@ inherit __DIR__ "village_base";
 void setup() {
   set_short("Village Square of Olum");
   set_long(
-  "At the village centre lies a bustling square, surrounded by ancient, "
-  "timber-framed buildings. Cobblestone paths lead to a moss-covered stone "
-  "well, the communal heart where market stalls flaunt local produce and "
-  "crafts. Laughter and conversation ripple through the air as elders on "
-  "benches share stories, overseeing the vibrant tableau of daily life. The "
-  "well stands as a testament to the village's enduring spirit, anchoring the "
-  "square's lively exchange and community bonds.");
+    "At the village centre lies a bustling square, surrounded by ancient, "
+    "timber-framed buildings. Cobblestone paths lead to a moss-covered stone "
+    "well, the communal heart where market stalls flaunt local produce and "
+    "crafts. Laughter and conversation ripple through the air as elders on "
+    "benches share stories, overseeing the vibrant tableau of daily life. The "
+    "well stands as a testament to the village's enduring spirit, anchoring "
+    "the square's lively exchange and community bonds."
+  );
 
   set_exits(([
     "north": "village_path1",
-    "west" : "village_path2",
-    "east" : "village_path3",
     "south": "village_path4",
-    "down" : "../tunnels/8,-9,-1",
+    "east" : "village_path3",
+    "west" : "village_path2",
+    "down" : "../tunnels/7,13,-1",
   ]));
 
-  set_room_size(({2,2,1}));
+  set_distance("north", 2);
+  set_distance("south", 2);
+  set_distance("east", 2);
+  set_distance("west", 2);
 
   set_items(([
     ({ "timber-framed buildings", "buildings", "ancient buildings" }) :

--- a/d/village/village_path1.c
+++ b/d/village/village_path1.c
@@ -31,6 +31,8 @@ void setup() {
     "north": "field/0,9,0",
   ]));
 
+  set_distance("south", 2);
+
   set_items(([
     ({ "village square", "square" }) :
       "The village square lies to the south, a bustling hub of activity "

--- a/d/village/village_path2.c
+++ b/d/village/village_path2.c
@@ -31,6 +31,8 @@ set_exits(([
   "west" : "village_path5",
 ]));
 
+  set_distance("east", 2);
+
   set_items(([
     ({ "village square", "square" }) :
       "The bustling epicentre from which this path begins, fading into "

--- a/d/village/village_path3.c
+++ b/d/village/village_path3.c
@@ -31,6 +31,8 @@ void setup() {
     "west" : "square",
   ]));
 
+  set_distance("west", 2);
+
   set_items(([
     ({ "village square", "square" }) :
       "The bustling heart from which the path departs, leaving behind "

--- a/d/village/village_path4.c
+++ b/d/village/village_path4.c
@@ -31,6 +31,8 @@ void setup() {
     "north": "square",
   ]));
 
+  set_distance("north", 2);
+
   set_items(([
     ({ "village square", "square" }) :
       "The starting point of many journeys within the village, the "

--- a/d/village/village_path5.c
+++ b/d/village/village_path5.c
@@ -33,6 +33,8 @@ void setup() {
     "west" : "village_path6",
   ]));
 
+  set_distance("west", 2);
+
   set_items(([
     ({ "village square", "square" }) :
       "The bustling centre of the village, now fading into the distance "

--- a/d/village/village_path6.c
+++ b/d/village/village_path6.c
@@ -30,7 +30,8 @@ void setup() {
     "west": "village_path7",
   ]));
 
-  set_room_size(({2,2,1}));
+  set_distance("east", 2);
+  set_distance("west", 2);
 
   set_items(([
     ({ "houses", "cottages", "dwellings" }) :

--- a/d/village/village_path7.c
+++ b/d/village/village_path7.c
@@ -26,11 +26,13 @@ void setup() {
   "The way back east leads home into the village.");
 
   set_exits(([
-    "east" : "village_path6",
     "north": "../thornwick/hollow_road1",
+    "east" : "village_path6",
   ]));
 
-  set_room_size(({2,2,1}));
+  set_distance("east", 2);
+  set_distance("north", 2);
+
   set_terrain("grass");
 
   set_items(([

--- a/std/classes/roominfo.c
+++ b/std/classes/roominfo.c
@@ -6,7 +6,6 @@ class RoomInfo {
   string *todo;
   string *done;
   int *coords;
-  int *size ;  // {width, height, depth} in grid squares
 }
 
 #endif // __ROOMINFO_H__

--- a/std/room/exits.c
+++ b/std/room/exits.c
@@ -15,6 +15,7 @@
 private nosave mapping __exits = ([]);
 private nosave mapping __pre_exit_funcs = ([]);
 private nosave mapping __post_exit_funcs = ([]);
+private nosave mapping __distances = ([]);
 
 /**
  * Sets the exits for a room, replacing any existing exits.
@@ -160,6 +161,65 @@ mapping add_exit(string id, string path) {
   __exits[id] = path;
 
   return query_exits();
+}
+
+/**
+ * Sets the grid distance for an exit, in whole grid squares from this
+ * room's centre to the destination room's centre along that direction.
+ *
+ * This drives coordinate spacing in the crawler/COORD_D map and the
+ * movement cost for the exit. The builder is responsible for keeping
+ * both halves of an edge in agreement
+ * (e.g. this room's "north" and the destination's "south" should match);
+ * the crawler logs any edge that does not close.
+ *
+ * @param {string} dir - The exit direction
+ * @param {int} n - Distance in grid squares (>= 0)
+ */
+void set_distance(string dir, int n) {
+  __distances[dir] = n;
+}
+
+/**
+ * Returns the grid distance for an exit, defaulting to 1 when unset.
+ *
+ * @param {string} dir - The exit direction
+ * @returns {int} Distance in grid squares
+ */
+int query_distance(string dir) {
+  if(nullp(__distances[dir]))
+    return 1;
+
+  return __distances[dir];
+}
+
+/**
+ * Returns a copy of all explicitly set exit distances.
+ *
+ * @returns {mapping} A copy of the distances mapping
+ */
+mapping query_distances() {
+  return copy(__distances);
+}
+
+/**
+ * Checks whether a distance has been explicitly set for an exit, as
+ * opposed to falling back to the default.
+ *
+ * @param {string} dir - The exit direction
+ * @returns {int} 1 if a distance was explicitly set, 0 otherwise
+ */
+int has_distance(string dir) {
+  return !nullp(__distances[dir]);
+}
+
+/**
+ * Removes an explicitly set distance, reverting the exit to the default.
+ *
+ * @param {string} dir - The exit direction
+ */
+void remove_distance(string dir) {
+  map_delete(__distances, dir);
 }
 
 /**

--- a/std/room/include/room.h
+++ b/std/room/include/room.h
@@ -2,8 +2,6 @@
 #define __ROOM_H__
 
 mapping gmcp_room_info(object who) ;
-void set_room_size(int *size) ;
-int *query_room_size() ;
 string set_room_type(string type) ;
 string set_room_subtype(string subtype) ;
 string set_room_icon(string icon) ;

--- a/std/room/room.c
+++ b/std/room/room.c
@@ -22,8 +22,6 @@ inherit __DIR__ "terrain";
 inherit __DIR__ "zone";
 inherit __DIR__ "door";
 
-private nosave int *__size = ({1, 1, 1});
-
 /**
  * Sets up the room with default values.
  *
@@ -98,7 +96,6 @@ mapping gmcp_room_info() {
     "doors"      : doors,
     "environment": query_room_environment() || query_terrain(),
     "coords"     : COORD_D->get_coordinates(base_name()),
-    "size"       : __size,
     "type"       : room_type,
     "subtype"    : room_subtype,
     "icon"       : room_icon,
@@ -150,76 +147,37 @@ void set_room_colour(int colour) {
  */
 int query_room_colour() { return room_colour; }
 
-/**
- * Sets the room's size in three dimensions.
- *
- * Size affects movement costs and other spatial calculations.
- *
- * @param {int*} size - Array of 3 integers representing width, length, height
- */
-void set_room_size(int *size) {
-  __size = size;
-}
-
-/**
- * Returns the room's size.
- *
- * @returns {int*} Array of 3 integers representing width, length, height
- */
-int *query_room_size() { return __size; }
-
 private nosave float _base_move_cost = 2.0;
+
+private nosave mapping _diagonal_axes = ([
+  "northeast": ({ "north", "east" }),
+  "northwest": ({ "north", "west" }),
+  "southeast": ({ "south", "east" }),
+  "southwest": ({ "south", "west" }),
+]);
 
 /**
  * Calculates the movement cost for a given direction.
  *
- * Movement costs vary based on room size and direction of travel.
- * Diagonal movement combines costs of the relevant dimensions.
+ * The cost scales with the exit's grid distance, so longer exits cost
+ * proportionally more to traverse. A diagonal with no explicit distance
+ * averages its two cardinal components, preserving the old compromise;
+ * an explicit distance on the diagonal overrides that. Exits with no
+ * distance default to 1.
  *
  * @param {string} dir - The direction of movement
  * @returns {float} The calculated movement cost
  */
 float move_cost(string dir) {
-  int *size = query_room_size();
-  float cost;
+  string *axes = _diagonal_axes[dir];
+  float dist;
 
-  switch(dir) {
-    case "north":
-      cost = to_float(size[0]);
-      break;
-    case "south":
-      cost = to_float(size[0]);
-      break;
-    case "east":
-      cost = to_float(size[1]);
-      break;
-    case "west":
-      cost = to_float(size[1]);
-      break;
-    case "northeast":
-      cost = (to_float(size[0]) + to_float(size[1])) / 2.0;
-      break;
-    case "northwest":
-      cost = (to_float(size[0]) + to_float(size[1])) / 2.0;
-      break;
-    case "southeast":
-      cost = (to_float(size[0]) + to_float(size[1])) / 2.0;
-      break;
-    case "southwest":
-      cost = (to_float(size[0]) + to_float(size[1])) / 2.0;
-      break;
-    case "up":
-      cost = to_float(size[2]);
-      break;
-    case "down":
-      cost = to_float(size[2]);
-      break;
-    default:
-      cost = 1.0;
-      break;
-  }
+  if(axes && !has_distance(dir))
+    dist = (to_float(query_distance(axes[0])) + to_float(query_distance(axes[1]))) / 2.0;
+  else
+    dist = to_float(query_distance(dir));
 
-  return cost * _base_move_cost;
+  return dist * _base_move_cost;
 }
 
 /**


### PR DESCRIPTION
### TL;DR

Replaces the per-room `size` vector with a per-exit `distance` integer for driving coordinate placement and movement costs.

### What changed?

- Removed `set_room_size` / `query_room_size` and the `size` field from `RoomInfo`. Rooms no longer carry a 3-D size vector.
- Added `set_distance(dir, n)`, `query_distance(dir)`, `query_distances()`, `has_distance(dir)`, and `remove_distance(dir)` to `std/room/exits.c`. Each directional exit can now declare its own centre-to-centre grid distance (defaulting to 1 if unset).
- `update_coordinates` in the crawler now takes a single `int distance` instead of two size arrays. Coordinate arithmetic is now exact integer addition/subtraction with no floating-point rounding.
- The crawler clears `COORD_D` at the start of each crawl, detects cross-edge conflicts for grid directions, and logs any exit whose expected destination coordinates disagree with where that room was already placed.
- `get_size` was removed from `coord.c` and a `clear()` function was added.
- `move_cost` in `room.c` now scales with `query_distance(dir)`. Diagonals without an explicit distance average their two cardinal component distances, preserving previous behaviour.
- Thornwick and village rooms have been updated to use `set_distance` on their exits in place of `set_room_size`.
- The tunnel surface shaft coordinate was corrected from `8,-9,-1` to `7,13,-1`, and the tunnels map was adjusted accordingly.
- A loop-iteration cap was added to `cavern_daemon.c` to prevent an infinite loop when searching for a valid wastes room.

### How to test?

1. Run the crawler from a wizard character and confirm it completes without errors.
2. Check `/log/crawl.log` for any cross-edge conflict warnings in the Thornwick and village areas.
3. Walk between rooms that have explicit distances set and verify movement costs scale proportionally.
4. Confirm the tunnel shaft exits connect correctly at `7,13,-1` (Olum village square) and `0,0,-1` (Thornwick green).

### Why make this change?

The room-size model was ambiguous — a single size applied to all exits from a room, making it impossible to express that one exit spans a longer distance than another. Replacing it with per-exit distances makes the spatial intent explicit, keeps the coordinate grid on exact integers, and allows the crawler to detect inconsistencies where two rooms disagree about how far apart they are.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the per-room `size` vector with per-exit `distance` integers across the spatial system, making grid placement exact (integer arithmetic, no rounding) and allowing individual exits to declare different distances.

- `set_room_size`/`query_room_size` are removed from `room.c` and `room.h`; five new distance API functions (`set_distance`, `query_distance`, `query_distances`, `has_distance`, `remove_distance`) are added to `exits.c`. `move_cost` now scales with the exit's declared distance, falling back to averaging the two cardinal components for unset diagonals.
- The crawler gains a `COORD_D->clear()` call at crawl start and a cross-edge conflict detector that logs when two rooms disagree about their relative position. `update_coordinates` is simplified from float arithmetic to plain integer addition/subtraction.
- Thornwick and village room files are updated to use `set_distance` on their exits, and the tunnel shaft coordinate is corrected from `8,-9,-1` to `7,13,-1` with a matching tunnels-map update.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are well-scoped and the two findings are low-stakes edge cases that do not affect normal operation.

The nullp vs member issue in exits.c only bites when a builder explicitly calls set_distance(dir, 0), which is not done anywhere in this PR. The off-by-one in the cavern loop cap means 99 instead of 100 search iterations — still more than enough to find a rocky wastes room in practice. All core logic is correct.

std/room/exits.c for the nullp membership check, and d/cavern/cavern_daemon.c for the loop-cap pre-decrement.

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `d/cavern/cavern_daemon.c`, line 964-984 ([link](https://github.com/gesslar/oxidus-mudlib/blob/d03e2782bf94845a71de5f393545f14043ccce19/d/cavern/cavern_daemon.c#L964-L984)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Loop cap exhaustion leaves `entrance` null, causing a crash**

   If all 100 iterations fail to find a "rocky" wastes room, the loop exits silently and `entrance` stays at its default `null`/`0`. Later in `setup_exits` (line 633), the code unconditionally indexes into `entrance` via `entrance[2]` — this will produce a runtime error. Adding a guard or a log after the loop when `!entrance` would make the failure visible and safe. In practice the probability is very low, but the crash path is real.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20d%2Fcavern%2Fcavern_daemon.c%0ALine%3A%20964-984%0A%0AComment%3A%0A**Loop%20cap%20exhaustion%20leaves%20%60entrance%60%20null%2C%20causing%20a%20crash**%0A%0AIf%20all%20100%20iterations%20fail%20to%20find%20a%20%22rocky%22%20wastes%20room%2C%20the%20loop%20exits%20silently%20and%20%60entrance%60%20stays%20at%20its%20default%20%60null%60%2F%600%60.%20Later%20in%20%60setup_exits%60%20%28line%20633%29%2C%20the%20code%20unconditionally%20indexes%20into%20%60entrance%60%20via%20%60entrance%5B2%5D%60%20%E2%80%94%20this%20will%20produce%20a%20runtime%20error.%20Adding%20a%20guard%20or%20a%20log%20after%20the%20loop%20when%20%60!entrance%60%20would%20make%20the%20failure%20visible%20and%20safe.%20In%20practice%20the%20probability%20is%20very%20low%2C%20but%20the%20crash%20path%20is%20real.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gesslar%2Foxidus-mudlib&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["migrating from sizes to distances"](https://github.com/gesslar/oxidus-mudlib/commit/ffa3c1ee7373c41c1088202718ac6ed81eb8ba60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38060422)</sub>

<!-- /greptile_comment -->