### PR TITLE
enable cache invalidation and crawler alarms by default

### DIFF
--- a/adm/etc/alarms/alarm.txt.example
+++ b/adm/etc/alarms/alarm.txt.example
@@ -20,5 +20,8 @@
 # Boot type alarms will schedule an alarm to be called in # seconds after the
 # MUD has booted via call_out_walltime().
 
-# Every hour, invalidate cache entries older than 1h
-# H 00 true /adm/daemons/cache invalidate ">=3600"
+# Every hour, invalidate cache entries older than 1h.
+H 00 true /adm/daemons/cache invalidate ">=3600"
+
+# One second after boot, run the crawler.
+B  1 true /adm/daemons/crawler crawl


### PR DESCRIPTION
### TL;DR

Enables the cache invalidation alarm and adds a boot-time crawler alarm.

### What changed?

Two alarms are now active in the example alarm configuration:
- The hourly cache invalidation alarm (which invalidates entries older than 1 hour) has been uncommented and enabled.
- A new boot alarm has been added that triggers the crawler daemon 1 second after the MUD starts.

### How to test?

Boot the MUD and verify that the crawler runs approximately 1 second after startup. Additionally, confirm that cache entries older than 1 hour are being invalidated on the hourly schedule.

### Why make this change?

The cache invalidation alarm should be running by default to prevent stale cache entries from accumulating. The crawler needs to run automatically on boot to ensure it initializes without requiring manual intervention.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR activates two alarms in the example alarm config: it uncomments the existing hourly cache-invalidation alarm and adds a new boot alarm that triggers the crawler 1 second after startup.

- The cache invalidation alarm (`H 00 true /adm/daemons/cache invalidate ">=3600"`) is straightforward and the `invalidate` function signature matches.
- The crawler boot alarm (`B 1 true /adm/daemons/crawler crawl`) conflicts with the daemon's own `slot(SIG_SYS_BOOT, "crawl")` registration — both will fire `crawl()` at boot, spinning up two concurrent `call_out_walltime` chains over shared `todo`/`done` state with no guard.

<h3>Confidence Score: 3/5</h3>

The cache alarm change is safe, but the crawler boot alarm will trigger a second concurrent crawl that overwrites shared mapping state mid-run.

The crawler daemon already wires itself to SIG_SYS_BOOT via a signal slot, so the new boot alarm creates a second call to crawl() roughly 1 second into an already-running crawl. crawl() immediately calls COORD_D->clear() and queues a fresh call_out_walltime chain without checking whether one is already active, leaving two chains concurrently mutating the same todo and done mappings. This would produce an incorrect or incomplete coordinate grid every cold boot.

adm/etc/alarms/alarm.txt.example — the crawler boot alarm line needs re-evaluation against the existing SIG_SYS_BOOT slot in crawler.c

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aadm%2Fetc%2Falarms%2Falarm.txt.example%3A27%0A**Duplicate%20boot%20trigger%20%E2%80%94%20two%20concurrent%20crawl%20chains**%0A%0A%60%2Fadm%2Fdaemons%2Fcrawler.c%60%20already%20calls%20%60slot%28SIG_SYS_BOOT%2C%20%22crawl%22%29%60%20in%20its%20%60setup%28%29%60%2C%20so%20%60crawl%28%29%60%20is%20invoked%20once%20when%20the%20MUD%20boots%20via%20the%20signal%20bus.%20This%20alarm%20fires%20a%20second%20call%201%20second%20later.%20Because%20%60crawl%28%29%60%20has%20no%20in-progress%20guard%2C%20the%20second%20invocation%20runs%20%60COORD_D-%3Eclear%28%29%60%2C%20resets%20the%20log%20file%2C%20and%20queues%20a%20new%20%60call_out_walltime%60%20chain%20while%20the%20first%20chain's%20%60crawl_next_room%60%20loop%20is%20already%20running%20%E2%80%94%20both%20chains%20concurrently%20mutate%20the%20shared%20%60todo%60%20and%20%60done%60%20mappings%2C%20which%20can%20corrupt%20the%20final%20coordinate%20grid.%20Either%20remove%20the%20%60slot%28SIG_SYS_BOOT%2C%20%22crawl%22%29%60%20call%20from%20the%20daemon%20%28letting%20the%20alarm%20be%20the%20single%20source%20of%20truth%29%20or%20drop%20this%20alarm%20entry.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=246&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["adding crawler to example and uncommenti..."](https://github.com/gesslar/oxidus-mudlib/commit/03e5cf286061c11876826d1921c50a09d682f6ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38179563)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->