### PR TITLE
increase dimension ranges for cavern, maze, and wastes

### DIFF
--- a/d/cavern/cavern_daemon.c
+++ b/d/cavern/cavern_daemon.c
@@ -57,7 +57,6 @@ private void determine_exit_and_entrance();
 int *find_a_path(int z);
 int *find_a_wall(int z);
 
-
 // Constants
 private nosave int DEPTH = 0, HEIGHT = 1, WIDTH = 2;
 private nosave int MIN_Z, MAX_Z, MIN_Y, MAX_Y, MIN_X, MAX_X;
@@ -88,14 +87,14 @@ private nosave mapping long_descriptions;
 
 private nosave int *dimensions;
 // Dimension configuration {min, range} for z, y, x
-private nosave mixed *dimension_config = ({ ({ 3, 1 }), ({ 50, 1 }), ({ 50, 1 }) });
+private nosave mixed *dimension_config = ({ ({ 3, 3 }), ({ 50, 10 }), ({ 50, 10 }) });
 private nosave float coverage_percentage = 0.10 ; // 5%
 private nosave int min_room_size = 1;
 private nosave int max_room_size = 3;
 private mixed *neighbour_excludes = ({});
 private mixed *all_paths, *all_walls;
 private nosave mixed *all_connections;
-private nosave mixed seed = 42;
+private nosave mixed seed = BOOT_D->query_boot_number();
 
 // The cavern map
 private nosave mixed *cavern_map;

--- a/d/maze/maze_daemon.c
+++ b/d/maze/maze_daemon.c
@@ -75,7 +75,7 @@ private nosave string default_long_description;
  *
  * @type {({ int, int })*}
  */
-private nosave mixed *dimension_config = ({ ({ 5, 1 }), ({ 10, 1 }), ({ 10, 1 }), });
+private nosave mixed *dimension_config = ({ ({ 5, 10 }), ({ 10, 10 }), ({ 10, 10 }), });
 private nosave int *dimensions;
 
 // Some constants

--- a/d/wastes/wastes_daemon.c
+++ b/d/wastes/wastes_daemon.c
@@ -45,7 +45,7 @@ private nosave int *dimensions;
 // private nosave mixed *dimension_config = ({ ({ 25, 1 }), ({ 25, 1 }),  });
 // private nosave mixed *dimension_config = ({ ({ 30, 1 }), ({ 50, 1 }),  });
 // private nosave mixed *dimension_config = ({ ({ 30, 1 }), ({ 30, 1 }) });
-private nosave mixed *dimension_config = ({ ({ 10, 5 }), ({ 10, 5 }) });
+private nosave mixed *dimension_config = ({ ({ 10, 20 }), ({ 10, 20 }) });
 private nosave int WIDTH = 0, HEIGHT = 1;
 
 // The seed is used to ensure that every time the daemon runs, it uses the same


### PR DESCRIPTION
### TL;DR

Increases the size variability of procedurally generated areas (cavern, maze, and wastes) and makes the cavern seed dynamic.

### What changed?

The dimension configuration ranges for the cavern, maze, and wastes procedural generation daemons have been significantly increased, allowing for much larger and more varied area generation. Additionally, the cavern daemon's random seed has been changed from a hardcoded value of `42` to a dynamic value derived from `BOOT_D->query_boot_number()`, meaning the cavern layout will differ between server boots.

### How to test?

Visit the cavern, maze, and wastes areas and verify that they generate correctly at the new, larger scales. Reboot the server and confirm that the cavern generates a different layout each time, while remaining navigable and functional.

### Why make this change?

The previous dimension ranges were very small, resulting in minimal variation in the generated areas. Expanding the ranges creates more interesting and diverse environments for players to explore. Using the boot number as the cavern seed ensures players encounter a fresh layout after each reboot rather than the same static one every time.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores dimensional variability to the three procedural-generation daemons by widening the `dimension_config` spread for the cavern, maze, and wastes areas so that map sizes are randomised on each boot rather than fixed. The cavern seed is also switched from the hard-coded value `42` to `BOOT_D->query_boot_number()`, matching the pattern already in place for the maze and wastes.

- **Cavern** (`cavern_daemon.c`): depth spread 1→3, height/width spread 1→10; seed now boot-number-derived.
- **Maze** (`maze_daemon.c`): depth spread 1→10, height/width spread 1→10 — maze can now be up to 14 layers deep and 19×19 cells per layer.
- **Wastes** (`wastes_daemon.c`): width/height spread 5→20, allowing maps up to 29×29.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the generation logic handles variable dimensions correctly across all three daemons and cross-daemon queries are runtime rather than hardcoded.

The dimension changes are straightforward and all three daemons already query each other's dimensions at runtime, so no cross-area assumptions break. The main concern is that maze_daemon.c's generate_layer now processes up to 14 layers without the reset_eval_cost() guard that cavern_daemon.c uses for the same class of loop — worth watching if the driver has a tight eval-cost budget.

d/maze/maze_daemon.c — the depth range increase (5→14 layers) makes the generation loop materially longer; verify the driver's eval-cost limit is not a concern at the upper end of the new range.

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `d/maze/maze_daemon.c`, line 235-308 ([link](https://github.com/gesslar/oxidus-mudlib/blob/b9515a0cf28fda9d8110b96c0d7782adfa1be6da/d/maze/maze_daemon.c#L235-L308)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No `reset_eval_cost()` guard for the now-larger depth range**

   `generate_layer` is called once per depth layer inside `generate_map`. With depth now ranging 5–14 and each layer up to 19×19 cells, the DFS while-loop at line 266 can iterate significantly more per layer than before. The analogous `cavern_daemon.c::generate_layer` uses `reset_eval_cost()` inside its inner loop explicitly to prevent hitting the driver's eval limit during generation. If the maze's DFS for a single large layer (e.g. 19×19 = 361 cells) keeps the stack deep long enough, it could bump the eval-cost ceiling. Worth adding a `reset_eval_cost()` call inside the while loop as a safety valve, matching the pattern already established in `cavern_daemon.c`.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20d%2Fmaze%2Fmaze_daemon.c%0ALine%3A%20235-308%0A%0AComment%3A%0A**No%20%60reset_eval_cost%28%29%60%20guard%20for%20the%20now-larger%20depth%20range**%0A%0A%60generate_layer%60%20is%20called%20once%20per%20depth%20layer%20inside%20%60generate_map%60.%20With%20depth%20now%20ranging%205%E2%80%9314%20and%20each%20layer%20up%20to%2019%C3%9719%20cells%2C%20the%20DFS%20while-loop%20at%20line%20266%20can%20iterate%20significantly%20more%20per%20layer%20than%20before.%20The%20analogous%20%60cavern_daemon.c%3A%3Agenerate_layer%60%20uses%20%60reset_eval_cost%28%29%60%20inside%20its%20inner%20loop%20explicitly%20to%20prevent%20hitting%20the%20driver's%20eval%20limit%20during%20generation.%20If%20the%20maze's%20DFS%20for%20a%20single%20large%20layer%20%28e.g.%2019%C3%9719%20%3D%20361%20cells%29%20keeps%20the%20stack%20deep%20long%20enough%2C%20it%20could%20bump%20the%20eval-cost%20ceiling.%20Worth%20adding%20a%20%60reset_eval_cost%28%29%60%20call%20inside%20the%20while%20loop%20as%20a%20safety%20valve%2C%20matching%20the%20pattern%20already%20established%20in%20%60cavern_daemon.c%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gesslar%2Foxidus-mudlib&pr=247&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ad%2Fwastes%2Fwastes_daemon.c%3A51-52%0A**Stale%20comment%20contradicts%20actual%20seed%20behaviour**%0A%0AThe%20comment%20directly%20above%20the%20active%20seed%20declaration%20says%20%22it%20uses%20the%20same%20seed%2C%20resulting%20in%20the%20same%20map%2C%22%20but%20%60BOOT_D-%3Equery_boot_number%28%29%60%20produces%20a%20different%20seed%20on%20every%20reboot%20%E2%80%94%20giving%20a%20different%20map%20every%20time.%20The%20PR%20intentionally%20adds%20variability%2C%20so%20a%20reader%20landing%20on%20this%20comment%20will%20be%20misled%20about%20what%20to%20expect%20from%20the%20map%20across%20reboots.%0A%0A%23%23%23%20Issue%202%20of%202%0Ad%2Fmaze%2Fmaze_daemon.c%3A235-308%0A**No%20%60reset_eval_cost%28%29%60%20guard%20for%20the%20now-larger%20depth%20range**%0A%0A%60generate_layer%60%20is%20called%20once%20per%20depth%20layer%20inside%20%60generate_map%60.%20With%20depth%20now%20ranging%205%E2%80%9314%20and%20each%20layer%20up%20to%2019%C3%9719%20cells%2C%20the%20DFS%20while-loop%20at%20line%20266%20can%20iterate%20significantly%20more%20per%20layer%20than%20before.%20The%20analogous%20%60cavern_daemon.c%3A%3Agenerate_layer%60%20uses%20%60reset_eval_cost%28%29%60%20inside%20its%20inner%20loop%20explicitly%20to%20prevent%20hitting%20the%20driver's%20eval%20limit%20during%20generation.%20If%20the%20maze's%20DFS%20for%20a%20single%20large%20layer%20%28e.g.%2019%C3%9719%20%3D%20361%20cells%29%20keeps%20the%20stack%20deep%20long%20enough%2C%20it%20could%20bump%20the%20eval-cost%20ceiling.%20Worth%20adding%20a%20%60reset_eval_cost%28%29%60%20call%20inside%20the%20while%20loop%20as%20a%20safety%20valve%2C%20matching%20the%20pattern%20already%20established%20in%20%60cavern_daemon.c%60.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=247&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["adding back in some variability"](https://github.com/gesslar/oxidus-mudlib/commit/b9515a0cf28fda9d8110b96c0d7782adfa1be6da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38179780)</sub>

<!-- /greptile_comment -->