### PR TITLE
minor update

### DIFF
--- a/adm/dist/config.mud
+++ b/adm/dist/config.mud
@@ -16,10 +16,10 @@ external_port_1: telnet 1336
 #mud ip : 0.0.0.0
 
 # absolute pathname of mudlib
-mudlib directory : /home/gesslar/Oxidus
+mudlib directory : /mud/ox/lib
 
 # debug.log and author/domain stats are stored here
-log directory : /home/gesslar/Oxidus/log
+log directory : /mud/ox/lib/log
 
 # the directories which are searched by #include <...>
 # for multiple dirs, separate each path with a ':'

--- a/adm/dist/docker/README.md
+++ b/adm/dist/docker/README.md
@@ -3,8 +3,8 @@
 A self-contained image of the [Oxidus](https://oxidus.online/) mudlib plus the
 FluffOS driver. The image clones a **pristine** copy of the mudlib and compiles
 the driver from the bundled `fluffos` submodule using the canonical
-`adm/dist/rebuild` script — so a fresh container is a brand-new mudlib, ready to
-play. The first character to log in becomes Oxidus's owner with the highest
+`adm/dist/rebuild` script — so a fresh container is a brand-new mudlib, ready
+to play. The first character to log in becomes Oxidus's owner with the highest
 privileges.
 
 ## Quick start (build locally)
@@ -122,6 +122,14 @@ Runtime env (entrypoint):
 - Per the canonical `adm/dist/rebuild`, the **driver tracks fluffos `master`**:
   rebuilding the image picks up the latest FluffOS. The mudlib itself is pinned
   to whatever `OXIDUS_REF` you build (CI builds the exact pushed commit).
+- The fluffos submodule is **effectively unpinned**: `rebuild` does
+  `git reset --hard origin/master` before compiling, so the committed submodule
+  SHA never decides what's built — every rebuild rides master HEAD. The
+  submodule's *position* (its `.gitmodules` entry + gitlink path) is required so
+  the directory gets populated to compile from; its recorded *version* is
+  cosmetic. Advancing the pointer is optional housekeeping, never a build step.
+  (fluffos updates are sporadic — a year quiet, then a flurry — so if you're ever
+  unsure whether you "need to update" anything: you don't. Just rerun `rebuild`.)
 - The container runs as a non-root `oxidus` user.
 - `--init` (compose: `init: true`) is recommended so signals/zombies are handled
   cleanly and `docker stop` lets the driver shut down gracefully.

--- a/doc/bedoc/package-lock.json
+++ b/doc/bedoc/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "bedoc",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/doc/sefun/adminp.help
+++ b/doc/sefun/adminp.help
@@ -5,7 +5,9 @@
 ---
 ### NAME
 
-    adminp() - Checks if a user has admin privileges.
+    adminp() - Checks if a user has admin privileges - that is, whether they
+    hold the "admin" role, directly or by inheritance (owner inherits
+    admin).
 
 ### SYNOPSIS
 
@@ -13,7 +15,8 @@
 
 ### DESCRIPTION
 
-    Checks if a user has admin privileges.
+    Checks if a user has admin privileges - that is, whether they hold the
+    "admin" role, directly or by inheritance (owner inherits admin).
 
 ### PARAMETERS
 
@@ -23,4 +26,4 @@
 
 ### RETURN VALUES
 
-    (int) 1 if the user has admin privileges, otherwise 0.
+    (int) 1 if the user has the admin role, otherwise 0.

--- a/doc/sefun/devp.help
+++ b/doc/sefun/devp.help
@@ -5,7 +5,9 @@
 ---
 ### NAME
 
-    devp() - Checks if a user has developer privileges.
+    devp() - Checks if a user has developer privileges - that is, whether
+    they hold the "developer" role, directly or by inheritance (admin and
+    owner both inherit developer).
 
 ### SYNOPSIS
 
@@ -13,7 +15,9 @@
 
 ### DESCRIPTION
 
-    Checks if a user has developer privileges.
+    Checks if a user has developer privileges - that is, whether they hold
+    the "developer" role, directly or by inheritance (admin and owner both
+    inherit developer).
 
 ### PARAMETERS
 
@@ -23,4 +27,4 @@
 
 ### RETURN VALUES
 
-    (int) 1 if the user has developer privileges, otherwise 0.
+    (int) 1 if the user has the developer role, otherwise 0.

--- a/doc/sefun/get_roles.help
+++ b/doc/sefun/get_roles.help
@@ -1,0 +1,28 @@
+---
+{
+  title: "get_roles"
+}
+---
+### NAME
+
+    get_roles() - Returns a user's effective roles - those granted directly
+    plus those conferred by the groups they belong to and the groups those
+    inherit.
+
+### SYNOPSIS
+
+    string *get_roles( string user );
+
+### DESCRIPTION
+
+    Returns a user's effective roles - those granted directly plus those
+    conferred by the groups they belong to and the groups those inherit.
+
+### PARAMETERS
+
+    user  (string)
+          The user name or code-object priv to check.
+
+### RETURN VALUES
+
+    (string*) The user's effective role names.

--- a/doc/sefun/has_role.help
+++ b/doc/sefun/has_role.help
@@ -1,0 +1,34 @@
+---
+{
+  title: "has_role"
+}
+---
+### NAME
+
+    has_role() - Checks whether a user holds a specific role among their
+    effective roles - direct grants plus those conferred by group membership
+    and inheritance. Use this when an operation requires a particular role
+    regardless of which group confers it.
+
+### SYNOPSIS
+
+    int has_role( string user, string role );
+
+### DESCRIPTION
+
+    Checks whether a user holds a specific role among their effective roles
+    - direct grants plus those conferred by group membership and
+    inheritance. Use this when an operation requires a particular role
+    regardless of which group confers it.
+
+### PARAMETERS
+
+    user  (string)
+          The user name or code-object priv to check.
+
+    role  (string)
+          The role to test for.
+
+### RETURN VALUES
+
+    (int) 1 if the user holds the role, otherwise 0.

--- a/doc/sefun/is_member.help
+++ b/doc/sefun/is_member.help
@@ -5,7 +5,10 @@
 ---
 ### NAME
 
-    is_member() - Checks if a user is a member of a specified group.
+    is_member() - Checks if a user is a member of a specified group. This is
+    strict membership - it does not consider roles. It is the forgiving
+    access gate; for a precise "this operation requires this role" check,
+    use has_role().
 
 ### SYNOPSIS
 
@@ -13,12 +16,15 @@
 
 ### DESCRIPTION
 
-    Checks if a user is a member of a specified group.
+    Checks if a user is a member of a specified group. This is strict
+    membership - it does not consider roles. It is the forgiving access
+    gate; for a precise "this operation requires this role" check, use
+    has_role().
 
 ### PARAMETERS
 
     user   (string)
-           The username to check.
+           The username (or code-object priv) to check.
 
     group  (string)
            The group to check membership in.

--- a/doc/sefun/ownerp.help
+++ b/doc/sefun/ownerp.help
@@ -5,10 +5,10 @@
 ---
 ### NAME
 
-    ownerp() - Checks if a user has owner privileges. Owner is nested inside
-    admin, so every owner is also an admin, but not every admin is an owner.
-    Use this to guard actions an admin must not perform against an owner
-    (e.g. stripping their access).
+    ownerp() - Checks if a user has owner privileges. Owner inherits admin,
+    so every owner is also an admin, but not every admin is an owner. Use
+    this to guard actions an admin must not perform against an owner (e.g.
+    stripping their access).
 
 ### SYNOPSIS
 
@@ -16,10 +16,10 @@
 
 ### DESCRIPTION
 
-    Checks if a user has owner privileges. Owner is nested inside admin, so
-    every owner is also an admin, but not every admin is an owner. Use this
-    to guard actions an admin must not perform against an owner (e.g.
-    stripping their access).
+    Checks if a user has owner privileges. Owner inherits admin, so every
+    owner is also an admin, but not every admin is an owner. Use this to
+    guard actions an admin must not perform against an owner (e.g. stripping
+    their access).
 
 ### PARAMETERS
 
@@ -29,4 +29,4 @@
 
 ### RETURN VALUES
 
-    (int) 1 if the user has owner privileges, otherwise 0.
+    (int) 1 if the user has the owner role, otherwise 0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "@gesslar/bedoc": "*",
-        "@gesslar/lpc-mcp": "^1.6.0"
+        "@gesslar/lpc-mcp": "^1.6.1"
       }
     },
     "node_modules/@astrojs/compiler": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@gesslar/bedoc": "*",
-    "@gesslar/lpc-mcp": "^1.6.0"
+    "@gesslar/lpc-mcp": "^1.6.1"
   }
 }

--- a/std/object/object.c
+++ b/std/object/object.c
@@ -450,6 +450,6 @@ void set_prevent_get(mixed val) {
  */
 int query_prevent_get() {
   return valid_function(_prevent_get)
-    ? _prevent_get(this_object())
+    ? evaluate(_prevent_get, this_object())
     : _prevent_get;
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR contains minor housekeeping across the mudlib: Docker config paths are updated to match the container layout, the fluffos submodule pointer is advanced and its "effectively unpinned" behavior is documented in the README, help files gain more precise role-inheritance descriptions, and the `@gesslar/lpc-mcp` dependency is bumped to `^1.6.1`.

- `std/object/object.c`: `query_prevent_get` is corrected to invoke the stored function pointer via `evaluate(_prevent_get, this_object())` instead of the bare-call form `_prevent_get(this_object())`, aligning it with FluffOS's function-pointer calling convention and with how `evaluate()` is already used elsewhere in `living/skills.c`.
- `adm/dist/config.mud`: mudlib and log directory paths changed from the developer's home directory to the Docker container paths (`/mud/ox/lib`).
- New help files (`get_roles.help`, `has_role.help`) are added, and existing help files are updated to document role inheritance semantics more accurately.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to documentation, config paths, a dependency bump, and a straightforward function-pointer calling-convention fix.

The only runtime-affecting change is in `query_prevent_get`, where the bare invocation of a function pointer is replaced with the `evaluate()` built-in. This matches FluffOS's correct calling convention for `function`-typed values and is consistent with other call sites in the codebase. The rest of the PR is documentation, Docker config, and a minor dependency update — all low-risk.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["minor update"](https://github.com/gesslar/oxidus-mudlib/commit/0ef5fd150b03390871d6dadf4422cd7255b16857) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39488902)</sub>

<!-- /greptile_comment -->