### PR TITLE
add FIRST_USER default config entry

### DIFF
--- a/adm/etc/default.lpml
+++ b/adm/etc/default.lpml
@@ -14,6 +14,7 @@
   ALLOW_SHUTDOWN: [
     "/adm/daemons/shutdown_d",
   ],
+  FIRST_USER: "adm/etc/first_user",
   LOOK_HIGHLIGHT: "on",
   LOOK_HIGHLIGHT_COLOUR: "669",
   COLOUR_TOO_DARK: "on",


### PR DESCRIPTION
Adds a `FIRST_USER` default configuration entry pointing to `"adm/etc/first_user"` in the default LPML settings.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `FIRST_USER` default configuration entry to `adm/etc/default.lpml`, pointing to `"adm/etc/first_user"`. The corresponding code in `adm/obj/login.c` already calls `mud_config("FIRST_USER")` to check for and write the first-admin marker file, so this change plugs the missing default that was preventing that logic from finding the configured path.

- Adds one line to `default.lpml`; no functional logic is changed elsewhere.
- The path format (no leading slash) matches the existing `LOGO` entry, keeping the file internally consistent.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change fills in a missing default config value that existing login code already depends on.

The single-line addition wires up a config key that `first_admin_login()` in `login.c` already reads via `mud_config("FIRST_USER")`. Without this entry the function would receive an empty/nil path, so the marker-file check and write would fail silently on a fresh install. The fix is minimal and straightforward, the path format is consistent with `LOGO`, and the marker file is intentionally absent from the repo since it is created at first login.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["oops, i guess i removed this value at so..."](https://github.com/gesslar/oxidus-mudlib/commit/1fa2b331dc1e15f34544189c500c648ddc58cb49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41184606)</sub>

<!-- /greptile_comment -->