### PR TITLE
add DIR_LOG constant and use in log_dir()

### DIFF
--- a/adm/simul_efun/system.c
+++ b/adm/simul_efun/system.c
@@ -138,7 +138,7 @@ mixed mud_config(string str) {
  * @returns {string} The log directory.
  */
 string log_dir() {
-  return CONFIG_D->get_mud_config("LOG_DIR");
+  return DIR_LOG;
 }
 
 /**

--- a/include/dirs.h
+++ b/include/dirs.h
@@ -17,6 +17,7 @@
 #define DIR_ETC                 "/etc/"
 #define DIR_ETC_RESOURCE        DIR_ETC "resource/"
 #define DIR_LIB                 "/lib/"
+#define DIR_LOG                 "/log/"
 #define DIR_OBJ                 "/obj/"
 #define DIR_OBJ_MUDLIB          DIR_OBJ "mudlib/"
 #define DIR_OBJ_NODE            DIR_OBJ "node/"


### PR DESCRIPTION
Adds a `DIR_LOG` constant to `dirs.h` and updates `log_dir()` to use it directly instead of fetching the value from `CONFIG_D`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `DIR_LOG` constant (`"/log/"`) to `dirs.h` and updates `log_dir()` to return it directly instead of querying `CONFIG_D->get_mud_config("LOG_DIR")`. The change is safe because the default config (`adm/etc/default.lpml`) already defines `LOG_DIR: "/log/"`, so the two values agree.

- `include/dirs.h`: adds `DIR_LOG "/log/"` in alphabetical position, consistent with the other directory constants.
- `adm/simul_efun/system.c`: replaces the runtime config lookup with the new constant; the function docstring is now stale and still references "driver runtime configuration."

<h3>Confidence Score: 5/5</h3>

Safe to merge — the constant value matches the default config entry, so behavior is unchanged in practice.

Both changed files are minimal and straightforward. The new constant matches the existing mud config value, so no functional regression is introduced. The only thing left behind is a stale docstring phrase.

The log_dir() docstring in adm/simul_efun/system.c could use a minor update.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aadm%2Fsimul_efun%2Fsystem.c%3A135-138%0AThe%20docstring%20still%20says%20the%20value%20is%20%22configured%20by%20the%20driver%20runtime%20configuration%2C%22%20but%20the%20function%20now%20returns%20a%20compile-time%20constant%20from%20%60dirs.h%60.%20This%20will%20mislead%20any%20caller%20expecting%20the%20path%20to%20be%20sourced%20from%20the%20driver%20config%20or%20%60CONFIG_D%60.%0A%0A%60%60%60suggestion%0A%20*%20Returns%20the%20directory%20where%20log%20files%20are%20stored.%0A%20*%0A%20*%20%40returns%20%7Bstring%7D%20The%20log%20directory%20%28%60DIR_LOG%60%29.%0A%60%60%60%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=251&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=5"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=5"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=5"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["updating logging"](https://github.com/gesslar/oxidus-mudlib/commit/d7d3fca3033ea81269102c3c0cb3575fb9f6cdae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41545368)</sub>

<!-- /greptile_comment -->