### PR TITLE
add configurable storage namespace to shops

### DIFF
--- a/std/ext/shop.c
+++ b/std/ext/shop.c
@@ -36,6 +36,18 @@ protected nosave float __sell_factor = 0.5; // when a player sells, use this
                                             // factor to determine the price
 protected nosave string __shop_keep_file;
 /**
+ * The storage namespace for this shop. Determines which persistent
+ * storage object holds the shop's inventory. Defaults to the village
+ * general store; call set_shop_org() before init_shop() to give a
+ * shop its own private storage and avoid commingling inventory.
+ *
+ * Defaulting to "olum_general_store" so at least there's some place for
+ * objects to land by default.
+ *
+ * @type {string}
+ */
+protected nosave string __shop_org = "olum_general_store";
+/**
  * The persistent storage object holding the shop's inventory for
  * sale. Created lazily by create_storage().
  *
@@ -52,6 +64,28 @@ protected nosave object __store;
  * @type {mixed*}
  */
 private nosave mixed *__shop_inventory = ({});
+
+/**
+ * Sets the storage namespace for this shop. Must be called before
+ * init_shop() so create_storage() loads the correct storage object.
+ * Shops that omit this share the default village general store.
+ *
+ * @param {string} org - The storage namespace for this shop.
+ */
+void set_shop_org(string org) {
+  assert_arg(stringp(org) && strlen(org), 1, "Invalid or missing shop org.");
+
+  __shop_org = org;
+}
+
+/**
+ * Returns the storage namespace for this shop.
+ *
+ * @returns {string} The shop's storage namespace.
+ */
+string query_shop_org() {
+  return __shop_org;
+}
 
 /**
  * Initialises the shop module. Adds the buy, sell, and list
@@ -396,7 +430,7 @@ private nomask object create_storage() {
 
   storage_options = new(class StorageOptions,
     storage_type: "public",
-    storage_org: "olum_general_store"
+    storage_org: __shop_org
   );
 
   __store = load_object(sprintf("storage/%s", storage_options.storage_org));


### PR DESCRIPTION
Adds a `set_shop_org()` function to the shop module, allowing individual shops to specify their own storage namespace before calling `init_shop()`. Previously, all shops shared the hardcoded `"olum_general_store"` storage object, causing inventory to commingle across shops. The namespace now defaults to `"olum_general_store"` to preserve existing behavior, but shops can call `set_shop_org()` to isolate their inventory into a private storage object.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a configurable storage namespace (`__shop_org`) to the shop module, replacing the previously hardcoded `"olum_general_store"` string so that individual shops can isolate their inventories. The default value is preserved for backward compatibility.

- Adds `set_shop_org(string org)` and `query_shop_org()` accessors; `create_storage()` now reads `__shop_org` instead of the literal string.
- `set_shop_org()` is declared without an access modifier (public) rather than `protected`, allowing any external object to mutate the namespace; it also does not validate that `org` is slash-free, which could create unexpected nested storage paths.
- Calling `set_shop_org()` after `init_shop()` silently has no effect on the live store — the docstring warns about this but there is no runtime guard.

<h3>Confidence Score: 4/5</h3>

The change is small and the core wiring is correct; the main concerns are the public access modifier on `set_shop_org()` and the lack of slash validation on the org string.

The feature works as described and backward compatibility is preserved. The `set_shop_org()` function being public rather than protected means any external object could mutate the shop's namespace, and slash characters in the org value would silently create unexpected nested storage paths. Neither issue causes data loss in the happy path, but both represent gaps that could trip up future shop authors.

std/ext/shop.c — specifically the access modifier on `set_shop_org()` and the input validation logic.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Astd%2Fext%2Fshop.c%3A75-76%0A%60set_shop_org%28%29%60%20is%20declared%20without%20an%20access%20modifier%2C%20making%20it%20public.%20Any%20external%20object%20in%20the%20MUD%20can%20call%20this%20on%20a%20live%20shop%20and%20alter%20%60__shop_org%60.%20If%20%60__store%60%20later%20gets%20destructed%20%28e.g.%2C%20via%20%60remove_shop%28%29%60%20followed%20by%20a%20reload%29%2C%20%60create_storage%28%29%60%20would%20load%20the%20modified%20org%20%E2%80%94%20potentially%20cross-contaminating%20storage%20between%20shops.%20Marking%20it%20%60protected%60%20restricts%20the%20call%20to%20the%20shop%20itself%20and%20its%20subclasses%2C%20which%20is%20the%20intended%20usage%20pattern.%0A%0A%60%60%60suggestion%0Aprotected%20void%20set_shop_org%28string%20org%29%20%7B%0A%20%20assert_arg%28stringp%28org%29%20%26%26%20strlen%28org%29%2C%201%2C%20%22Invalid%20or%20missing%20shop%20org.%22%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Astd%2Fext%2Fshop.c%3A76%0AThe%20non-empty%20check%20in%20%60assert_arg%60%20does%20not%20prevent%20slash%20characters%20in%20%60org%60%2C%20so%20a%20value%20like%20%60%22foo%2Fbar%22%60%20would%20result%20in%20the%20storage%20path%20%60%22storage%2Ffoo%2Fbar%22%60%2C%20which%20is%20likely%20unintended.%20A%20simple%20check%20that%20the%20value%20contains%20no%20%60%2F%60%20would%20keep%20paths%20flat%20and%20predictable.%0A%0A%60%60%60suggestion%0A%20%20assert_arg%28stringp%28org%29%20%26%26%20strlen%28org%29%20%26%26%20!strsrch%28org%2C%20%22%2F%22%29%2C%201%2C%20%22Invalid%20or%20missing%20shop%20org.%22%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Astd%2Fext%2Fshop.c%3A68-79%0A**Post-%60init_shop%28%29%60%20call%20is%20silently%20ignored**%0A%0A%60create_storage%28%29%60%20short-circuits%20when%20%60__store%60%20is%20already%20set%2C%20so%20a%20call%20to%20%60set_shop_org%28%29%60%20after%20%60init_shop%28%29%60%20changes%20%60__shop_org%60%20but%20leaves%20%60__store%60%20pointing%20to%20the%20original%20storage%20object.%20The%20discrepancy%20persists%20until%20%60__store%60%20is%20destructed.%20The%20docstring%20documents%20the%20%22call%20before%20init_shop%28%29%22%20requirement%2C%20but%20adding%20a%20runtime%20guard%20%28e.g.%2C%20raising%20an%20error%20or%20at%20minimum%20logging%20a%20warning%20when%20%60__store%60%20is%20already%20set%29%20would%20prevent%20silent%20misconfiguration%20in%20shops%20that%20call%20%60set_shop_org%28%29%60%20too%20late.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=5"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=5"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=5"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["setting shop up to allow for more shops"](https://github.com/gesslar/oxidus-mudlib/commit/0bca292f3c2060c465cf79c4209d9c4058191e7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41545373)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->