### PR TITLE
add village tailor shop, leather armour set, and expand shop inventory

### DIFF
--- a/d/village/shop.c
+++ b/d/village/shop.c
@@ -64,7 +64,14 @@ void setup() {
 
   add_shop_inventory(
     "/obj/weapon/piercing/rusty_sword",
+    "/obj/armour/head/leather_cap.armour",
+    "/obj/armour/neck/leather_gorget.armour",
     "/obj/armour/torso/leather_jerkin.armour",
+    "/obj/armour/back/wool_cloak.armour",
+    "/obj/armour/arms/leather_bracers.armour",
+    "/obj/armour/hands/leather_gloves.armour",
+    "/obj/armour/legs/leather_leggings.armour",
+    "/obj/armour/feet/leather_boots.armour",
     ({ "/obj/general/firekit", 3 }),
   );
 

--- a/d/village/tailor.c
+++ b/d/village/tailor.c
@@ -1,0 +1,72 @@
+/**
+ * @file /d/village/tailor.c
+ * A refined tailor's shop in the affluent quarter of Olum village.
+ *
+ * @created 2026-07-02 - Gesslar
+ * @last_modified 2026-07-02 - Gesslar
+ *
+ * @history
+ * 2026-07-02 - Gesslar - Created
+ */
+
+inherit __DIR__ "village_base";
+
+inherit EXT_SHOP;
+
+void setup() {
+  set_short("The Village Tailor");
+  set_long(
+  "A hush of fine fabric fills this elegant shop, where bolts of cloth in "
+  "every hue stand shoulder to shoulder along the walls like a painter's "
+  "palette rendered in wool and silk. A long cutting table dominates the "
+  "centre of the room, its surface scarred by generations of shears and "
+  "dusted with chalk. Half-finished garments hang from a rail near the "
+  "hearth, pinned and patient, while a tall pier glass in a gilded frame "
+  "waits to flatter whoever stands before it. The tailor works quietly at a "
+  "stool by the window, needle flashing, pausing only to measure a customer "
+  "with a practised eye and a length of knotted cord.");
+
+  set_exits(([
+    "north" : "village_path3",
+  ]));
+
+  set_items(([
+    ({ "bolts of cloth", "bolts", "cloth", "fabric" }) :
+      "Wool, linen, and lustrous silk are wound tight upon their bolts and "
+      "arranged by shade, from undyed cream through deep forest greens to a "
+      "crimson so rich it seems to glow. Each is of a quality far beyond the "
+      "homespun of the village square.",
+    ({ "cutting table", "table", "long table" }) :
+      "The great cutting table is worn pale and smooth, its edges nicked by "
+      "countless passes of the shears. A dusting of tailor's chalk clings to "
+      "the grain, and pins glint here and there where they have been pressed "
+      "for safekeeping.",
+    ({ "half-finished garments", "garments", "rail" }) :
+      "Coats, gowns, and cloaks hang half-made upon the rail, bristling with "
+      "pins and basting thread. Each awaits its final fitting, the shape of a "
+      "future customer already suggested in its careful lines.",
+    ({ "pier glass", "mirror", "tall mirror", "gilded frame", "glass" }) :
+      "A tall mirror stands in a frame of gilded scrollwork, its silvered "
+      "surface clear and true. It is angled to catch the light from the "
+      "window, the better to show a garment at its finest.",
+    ({ "tailor", "shopkeeper" }) :
+      "The tailor is a slight, keen-eyed figure whose fingers never seem to "
+      "rest. A pincushion is strapped to one wrist and a length of knotted "
+      "measuring cord hangs about the neck, ready to take the measure of "
+      "anyone who lingers too long by the mirror.",
+  ]));
+
+  set_shop_org("olum_tailor");
+
+  init_shop();
+
+  add_shop_inventory(
+    "/obj/clothing/torso/cream-coloured_linen_tunic.clothing",
+    "/obj/clothing/legs/tan_leather_breeches.clothing",
+    "/obj/clothing/feet/black_leather_shoes.clothing",
+    "/obj/clothing/back/velvet_cape.clothing",
+  );
+
+  set_terrain("indoor");
+  set_room_type("shop");
+}

--- a/d/village/village_path3.c
+++ b/d/village/village_path3.c
@@ -24,11 +24,14 @@ void setup() {
   "transactions within. This path, often traversed by those seeking counsel "
   "or investment, leads directly to the financier's door, promising "
   "discretion and expertise for those navigating the complexities of wealth "
-  "and commerce.");
+  "and commerce. To the south, a tailor's shopfront completes the refined "
+  "air of the quarter, its window framing bolts of fine cloth and a gilded "
+  "mirror that catches the passing light.");
 
   set_exits(([
     "east" : "financier",
     "west" : "square",
+    "south" : "tailor",
   ]));
 
   set_distance("west", 2);

--- a/obj/armour/arms/leather_bracers.lpml
+++ b/obj/armour/arms/leather_bracers.lpml
@@ -1,0 +1,22 @@
+// obj/armour/arms/leather_bracers.lpml
+
+{
+  id: ["bracers", "vambraces", "armour"],
+  adj: ["sturdy", "leather"],
+  name: "sturdy leather bracers",
+  short: "pair of sturdy leather bracers",
+  long: "These matched bracers are cut from thick, supple leather and shaped"
+        " to guard the forearm from wrist to elbow. Dyed a rich, earthy brown"
+        " to match their jerkin, each is fastened by three adjustable straps"
+        " and reinforced with an extra layer of stitched leather along the"
+        " outer edge, where a blow is most likely to land.",
+  mass: 40,
+  value: 15,
+  slot: "arms",
+  ac: 1.0,
+  defence: {
+    slashing: 1.0,
+    piercing: 0.5,
+    bludgeoning: 0.5,
+  },
+}

--- a/obj/armour/back/wool_cloak.lpml
+++ b/obj/armour/back/wool_cloak.lpml
@@ -1,0 +1,21 @@
+// obj/armour/back/wool_cloak.lpml
+
+{
+  id: ["cloak", "armour"],
+  adj: ["woollen", "wool"],
+  name: "woollen cloak",
+  short: "heavy woollen cloak",
+  long: "This heavy cloak is woven from thick, undyed wool in a natural"
+        " greyish-brown, its weave dense enough to turn a cold wind or a"
+        " passing rain. It falls well past the knee and is gathered at the"
+        " throat by a simple bronze clasp. The wool is layered and quilted"
+        " across the shoulders, thick enough to soften a glancing blow, and a"
+        " deep hood can be drawn up against the weather.",
+  mass: 70,
+  value: 16,
+  slot: "back",
+  ac: 0.5,
+  defence: {
+    bludgeoning: 0.5,
+  },
+}

--- a/obj/armour/feet/leather_boots.lpml
+++ b/obj/armour/feet/leather_boots.lpml
@@ -1,0 +1,22 @@
+// obj/armour/feet/leather_boots.lpml
+
+{
+  id: ["boots", "armour"],
+  adj: ["sturdy", "leather"],
+  name: "sturdy leather boots",
+  short: "pair of sturdy leather boots",
+  long: "These boots rise to mid-calf, built from thick, earthy-brown leather"
+        " that matches the rest of the set. The soles are heavy and stitched"
+        " twice over for the road, and a hardened leather guard shields the"
+        " shin and instep. Broad straps and a snug buckle at the top keep"
+        " them firmly in place.",
+  mass: 55,
+  value: 15,
+  slot: "feet",
+  ac: 1.0,
+  defence: {
+    slashing: 1.0,
+    piercing: 0.5,
+    bludgeoning: 0.5,
+  },
+}

--- a/obj/armour/hands/leather_gloves.lpml
+++ b/obj/armour/hands/leather_gloves.lpml
@@ -1,0 +1,22 @@
+// obj/armour/hands/leather_gloves.lpml
+
+{
+  id: ["gloves", "armour"],
+  adj: ["sturdy", "leather"],
+  name: "sturdy leather gloves",
+  short: "pair of sturdy leather gloves",
+  long: "Crafted from the same supple, earthy-brown leather as their matching"
+        " set, these gloves fit close to the hand without hindering the"
+        " fingers. The backs are reinforced with an additional layer of"
+        " leather, and the palms are textured for a firm grip. Snug cuffs"
+        " buckle at the wrist to keep them from slipping.",
+  mass: 15,
+  value: 10,
+  slot: "hands",
+  ac: 0.5,
+  defence: {
+    slashing: 0.5,
+    piercing: 0.5,
+    bludgeoning: 0.25,
+  },
+}

--- a/obj/armour/head/leather_cap.lpml
+++ b/obj/armour/head/leather_cap.lpml
@@ -1,0 +1,23 @@
+// obj/armour/head/leather_cap.lpml
+
+{
+  id: ["cap", "armour"],
+  adj: ["sturdy", "leather"],
+  name: "sturdy leather cap",
+  short: "sturdy leather cap",
+  long: "This close-fitting cap is boiled from a single piece of sturdy"
+        " leather, moulded to hug the crown of the head. Dyed the same rich,"
+        " earthy brown as its matching jerkin, it is stitched along a central"
+        " ridge with reinforced thread and lined inside with a softer padding"
+        " for comfort. A thin chin strap keeps it seated snugly during"
+        " movement.",
+  mass: 30,
+  value: 12,
+  slot: "head",
+  ac: 1.0,
+  defence: {
+    slashing: 1.0,
+    piercing: 0.5,
+    bludgeoning: 0.5,
+  },
+}

--- a/obj/armour/legs/leather_leggings.lpml
+++ b/obj/armour/legs/leather_leggings.lpml
@@ -1,0 +1,22 @@
+// obj/armour/legs/leather_leggings.lpml
+
+{
+  id: ["leggings", "greaves", "armour"],
+  adj: ["sturdy", "leather"],
+  name: "sturdy leather leggings",
+  short: "pair of sturdy leather leggings",
+  long: "These leggings are layered from thick, treated leather and fitted to"
+        " protect the thigh and shin without restricting stride. Dyed a rich,"
+        " earthy brown to match their jerkin, the seams are double-stitched"
+        " and the leather is boiled harder over the knees and shins. A row of"
+        " side straps allows the fit to be drawn snug against the leg.",
+  mass: 80,
+  value: 18,
+  slot: "legs",
+  ac: 1.5,
+  defence: {
+    slashing: 1.5,
+    piercing: 1.0,
+    bludgeoning: 0.5,
+  },
+}

--- a/obj/armour/neck/leather_gorget.lpml
+++ b/obj/armour/neck/leather_gorget.lpml
@@ -1,0 +1,22 @@
+// obj/armour/neck/leather_gorget.lpml
+
+{
+  id: ["gorget", "armour"],
+  adj: ["sturdy", "leather"],
+  name: "sturdy leather gorget",
+  short: "sturdy leather gorget",
+  long: "This gorget is boiled from thick leather and shaped into a stiff"
+        " collar that guards the throat and the base of the neck. Dyed the"
+        " same rich, earthy brown as its matching set, it is cut in two"
+        " overlapping plates that buckle at the side, allowing the head to"
+        " turn freely while still warding off a thrust aimed at the throat.",
+  mass: 25,
+  value: 13,
+  slot: "neck",
+  ac: 1.0,
+  defence: {
+    slashing: 1.0,
+    piercing: 1.0,
+    bludgeoning: 0.5,
+  },
+}

--- a/obj/armour/torso/leather_jerkin.lpml
+++ b/obj/armour/torso/leather_jerkin.lpml
@@ -13,7 +13,7 @@
         " lined with a softer material for added comfort. The jerkin"
         " features adjustable straps along the sides and shoulders, allowing"
         " for a snug fit.",
-  mass: 200,
+  mass: 120,
   value: 25,
   slot: "torso",
   ac: 2.0,

--- a/obj/clothing/back/velvet_cape.lpml
+++ b/obj/clothing/back/velvet_cape.lpml
@@ -1,0 +1,17 @@
+// obj/clothing/back/velvet_cape.lpml
+
+{
+  id: ["cape"],
+  adj: ["velvet", "crimson"],
+  name: "crimson velvet cape",
+  short: "crimson velvet cape",
+  long: "This short cape is cut from deep crimson velvet, its nap catching the"
+        " light with a soft sheen wherever it falls. It drapes just past the"
+        " shoulders and is lined with black silk, the two fabrics meeting in a"
+        " neat rolled hem. A pair of braided gold cords fasten it at the"
+        " throat, finished with small tasselled ends that rest against the"
+        " collarbone.",
+  mass: 40,
+  value: 45,
+  slot: "back",
+}

--- a/obj/clothing/feet/black_leather_shoes.lpml
+++ b/obj/clothing/feet/black_leather_shoes.lpml
@@ -13,5 +13,6 @@
         " thick and sturdy, suggesting durability and comfort for prolonged"
         " wear.",
   mass: 15,
+  value: 16,
   slot: "feet",
 }

--- a/obj/clothing/legs/tan_leather_breeches.lpml
+++ b/obj/clothing/legs/tan_leather_breeches.lpml
@@ -12,5 +12,6 @@
         " a high waist secured by a simple leather belt, and they taper"
         " neatly to the ankle.",
   mass: 100,
+  value: 20,
   slot: "legs",
 }

--- a/obj/clothing/torso/cream-coloured_linen_tunic.lpml
+++ b/obj/clothing/torso/cream-coloured_linen_tunic.lpml
@@ -12,5 +12,6 @@
         " fastened with small, wooden toggles. The fabric has a natural,"
         " subtle texture, hinting at its fine weave.",
   mass: 50,
+  value: 18,
   slot: "torso",
 }


### PR DESCRIPTION
Adds a full leather armour set to the village shop and introduces a new tailor's shop to the village.

**Leather Armour Set**
Completes the leather armour lineup with pieces for every slot: cap (head), gorget (neck), wool cloak (back), bracers (arms), gloves (hands), leggings (legs), and boots (feet). Each piece is described as part of a matching earthy-brown set and carries appropriate AC and defence values for entry-level armour. The leather jerkin's mass has also been corrected downward. All new pieces are stocked in the village shop alongside the existing jerkin.

**Village Tailor**
A new tailor's shop has been added to the affluent quarter of Olum village, accessible from `village_path3` to the south. The shop sells civilian clothing — a linen tunic, leather breeches, leather shoes, and a crimson velvet cape — and features a fully described interior with examinable items. Missing `value` fields have been added to the tunic, breeches, and shoes so they can be properly bought and sold.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a complete leather armour set (cap, gorget, cloak, bracers, gloves, leggings, boots) to the village shop, introduces a new tailor's shop accessible from `village_path3`, and backfills missing `value` fields on three existing clothing items so they can participate in the economy.

- All seven new armour LPML files follow the established conventions of `leather_jerkin.lpml` — same id/adj/name/short/long/mass/value/slot/ac/defence structure and the same pattern of including `"armour"` in the id array.
- The tailor shop mirrors `shop.c`'s structure exactly: inherits `village_base` and `EXT_SHOP`, calls `init_shop()` before `add_shop_inventory()`, and registers the paired north/south exits correctly with `village_path3`.
- The clothing items added to the tailor's inventory use the `.clothing` extension, consistent with the `.armour` extension convention already in `shop.c`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive content with no changes to game logic or existing behaviour.

All new files follow the established LPML and room patterns exactly. The exit graph is correctly symmetric, init_shop/add_shop_inventory ordering matches shop.c, and the value-field additions to existing clothing items are the only changes to pre-existing files. No functional defects found.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["new gear"](https://github.com/gesslar/oxidus-mudlib/commit/aa65d1de474a1ac7f7b4b6d6e1c3fa062f760fd6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41545379)</sub>

<!-- /greptile_comment -->