### PR TITLE
fix wither message grammar and minor code cleanup

### DIFF
--- a/cmds/spell/embers.c
+++ b/cmds/spell/embers.c
@@ -39,7 +39,8 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
     return 1;
 
   if(!result = delay_act("embers", 2.0, assemble_call_back(
-    function(int status,
+    function(
+      int status,
       /** @type {STD_BODY} */ object tp,
       /** @type {STD_BODY} */ object victim
     ) {

--- a/cmds/spell/shock.c
+++ b/cmds/spell/shock.c
@@ -33,7 +33,10 @@ void setup() {
   );
 }
 
-mixed use(/** @type {STD_BODY} */ object tp, string arg) {
+mixed use(
+  /** @type {STD_BODY} */ object tp,
+  string arg
+) {
   /** @type {STD_BODY} */ object victim;
 
   if(!victim = local_target(tp, arg, (: living($1) && $1 != $(tp) :)))

--- a/cmds/spell/wither.c
+++ b/cmds/spell/wither.c
@@ -54,7 +54,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
         /** @type {"obj/effect/wither"} */ object eff;
 
         tp->targetted_action(
-          "{{83a}}$N $vreach out with grasping shadow toward $t!{{res}}",
+          "{{83a}}$N $vreach out with a grasping shadow toward $t!{{res}}",
           victim
         );
         tp->use_skill("arcane.discipline.shadow", 0.15);

--- a/std/cmd/act.c
+++ b/std/cmd/act.c
@@ -107,7 +107,7 @@ varargs object local_target(object tp, string arg, function f) {
   if(!objectp(tp))
     error("Bad argument 1 to local_target().\n");
 
-  if(nullp(arg)) {
+  if(falsy(arg)) {
     if(target_current) {
       if(t = tp->highest_threat())
         return t;
@@ -123,6 +123,7 @@ varargs object local_target(object tp, string arg, function f) {
 
   source = environment(tp);
 
+  _debug("%O %O %O", arg, source, f);
   if(!t = find_target(tp, arg, source, f)) {
     tell(tp, "You don't see "+add_article(arg)+" here.\n");
     return 0;


### PR DESCRIPTION
Fixes a grammar issue in the wither spell's action message ("a grasping shadow" instead of "grasping shadow") and adds a debug log to `local_target()` to trace argument, source, and filter function values. Also changes the null check for `arg` in `local_target()` from `nullp` to `falsy` to handle additional falsy values. Minor formatting adjustments were made to function signatures in the embers and shock spells.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a small grammar correction in `wither.c` (adding the missing article "a" before "grasping shadow"), changes the `arg` null-check in `local_target()` from `nullp` to the custom `falsy` simul_efun to also catch empty-string arguments, adds a debug logging call in that same function, and reformats function signatures in `embers.c` and `shock.c`.

- **wither.c**: Correct article fix ("a grasping shadow") — straightforward and accurate.
- **act.c (`local_target`)**: `falsy(arg)` is a well-defined simul_efun in this codebase (null/0/`""`) — the semantic extension from `nullp` is intentional and safe. The added `_debug` call logs `arg`, `source`, and `f` on every targeted-ability cast.
- **embers.c / shock.c**: Pure whitespace/formatting changes with no functional impact.

<h3>Confidence Score: 5/5</h3>

The functional changes are small and low-risk: a one-word grammar fix in a message string and a widened null-check using a well-established codebase simul_efun.

The grammar correction is trivially correct, the falsy() simul_efun is properly defined in adm/simul_efun/util.c and its semantics (null/0/empty-string) are appropriate for the parameter, and the formatting changes in embers and shock are purely cosmetic. No new logic paths, no data changes, no risk of breakage.

No files require special attention beyond the already-noted debug call in std/cmd/act.c.

<sub>Reviews (2): Last reviewed commit: ["fixing act.c and also some churn"](https://github.com/gesslar/oxidus-mudlib/commit/bdddd54aa7bf439e119307c1f2bb7ca8fd2e9497) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41545382)</sub>

<!-- /greptile_comment -->