### PR TITLE
add safe_string() simul_efun for filename-safe strings

### DIFF
--- a/adm/include/simul_efun.h
+++ b/adm/include/simul_efun.h
@@ -266,6 +266,7 @@ int is_numeric(string str);
 int starts_with(string str, string starting_string);
 int ends_with(string str, string ending_string);
 string sanitize_regex(string msg);
+varargs string safe_string(string str, string replacement);
 
 // File: system.c
 int port();

--- a/adm/simul_efun/string.c
+++ b/adm/simul_efun/string.c
@@ -627,3 +627,41 @@ string sanitize_regex(string msg) {
 
   return msg;
 }
+
+private nomask string illegal_filename_chars = "[<>:\"/\\\\|?*\x01-\x1F\x7F]";
+
+/**
+ * Sanitises a string so that it is safe to use as a filename.
+ *
+ * Every character that is illegal in a filename is replaced with
+ * replacement, and any leading or trailing dots are stripped so the
+ * result cannot be a hidden, or extension-only name.
+ *
+ * This is not intended to be fully robust, but used in places where a string
+ * may be used as an identifier and also double-duty as a file name. Do your
+ * own testing at the call-site if you need additional criteria met.
+ *
+ * @param {string} str - The string to sanitise.
+ * @param {string} [replacement=""] - The string to substitute for
+ *                                    each illegal character.
+ * @returns {string} The sanitised, filename-safe string.
+ * @errors If str is not a string.
+ * @errors If replacement itself contains illegal filename characters.
+ */
+varargs string safe_string(string str, string replacement) {
+  replacement ??= "";
+
+  assert_arg(stringp(str), 1, "Bad argument 1 to safe_string(). Expected string, got "+typeof(str));
+  assert_arg(!pcre_match(replacement, illegal_filename_chars), 2, "Bad argument 2 to safe_string, contains illegal characters.");
+
+  while(pcre_match(str, illegal_filename_chars))
+    str = pcre_replace(str, illegal_filename_chars, ({replacement}));
+
+  while(ends_with(str, "."))
+    str = str[0..<2];
+
+  while(starts_with(str, "."))
+    str = str[1..];
+
+  return str;
+}


### PR DESCRIPTION
Adds a `safe_string()` simul-efun that sanitizes a string for use as a filename. Illegal filename characters (such as `<>:"/\|?*` and control characters) are replaced with an optional replacement string (defaulting to an empty string), and any leading or trailing dots are stripped to prevent empty, hidden, or extension-only names.

The function validates that the input is a string and that the replacement string does not itself contain illegal characters, erroring on either condition.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `safe_string()` simul-efun to `adm/simul_efun/string.c` that sanitizes an input string for use as a filename, plus its declaration in `adm/include/simul_efun.h`.

- The illegal-character PCRE class `[<>:"/\\|?*\x01-\x1F\x7F]` is correctly constructed in LPC: four backslashes in the literal produce two in the compiled string, which PCRE interprets as a single literal backslash; `\x01-\x1F` covers C0 control characters, and `\x7F` covers DEL as a standalone entry (not as a range endpoint).
- Input validation errors on a non-string first argument and on a replacement string that itself contains illegal characters; dot-stripping loops handle both leading and trailing dots correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The regex pattern, argument validation, and dot-stripping logic are all correct; previously flagged issues with backslash matching, the DEL character, and the over-broad hex range have been resolved.

The function correctly constructs its PCRE character class, validates both arguments before use, and delegates empty-result responsibility to callers (as documented). No incorrect behaviour was found.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["new safe\_string sefun"](https://github.com/gesslar/oxidus-mudlib/commit/8b79b562df8bd149d7f437ab99643ff210c774db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41552126)</sub>

<!-- /greptile_comment -->