### PR TITLE
require shop org to be set explicitly before init_shop()

### DIFF
--- a/d/village/shop.c
+++ b/d/village/shop.c
@@ -60,6 +60,7 @@ void setup() {
       "gleam with newness, while others bear the patina of age and use.",
   ]));
 
+  set_shop_org("olum/village shop");
   init_shop();
 
   add_shop_inventory(
@@ -77,4 +78,5 @@ void setup() {
 
   set_terrain("indoor");
   set_room_type("shop");
+
 }

--- a/d/village/tailor.c
+++ b/d/village/tailor.c
@@ -56,8 +56,7 @@ void setup() {
       "anyone who lingers too long by the mirror.",
   ]));
 
-  set_shop_org("olum_tailor");
-
+  set_shop_org("olum/village tailor");
   init_shop();
 
   add_shop_inventory(

--- a/std/ext/shop.c
+++ b/std/ext/shop.c
@@ -41,12 +41,9 @@ protected nosave string __shop_keep_file;
  * general store; call set_shop_org() before init_shop() to give a
  * shop its own private storage and avoid commingling inventory.
  *
- * Defaulting to "olum_general_store" so at least there's some place for
- * objects to land by default.
- *
  * @type {string}
  */
-protected nosave string __shop_org = "olum_general_store";
+protected nosave string __shop_org = undefined;
 /**
  * The persistent storage object holding the shop's inventory for
  * sale. Created lazily by create_storage().
@@ -70,12 +67,22 @@ private nosave mixed *__shop_inventory = ({});
  * init_shop() so create_storage() loads the correct storage object.
  * Shops that omit this share the default village general store.
  *
+ * @protected
  * @param {string} org - The storage namespace for this shop.
+ * @returns {string} The new storage namespace.
  */
-void set_shop_org(string org) {
+protected string set_shop_org(string org) {
   assert_arg(stringp(org) && strlen(org), 1, "Invalid or missing shop org.");
 
-  __shop_org = org;
+  assert(!objectp(__store), "set_shop_org() must be called before init_shop()");
+
+  org = replace_string(org, " ", "");
+  org = replace_string(org, "/", "");
+  org = safe_string(org, "");
+
+  assert(truthy(org), "Sanitised shop org is empty.");
+
+  return __shop_org = org;
 }
 
 /**
@@ -427,6 +434,8 @@ private nomask object create_storage() {
 
   if(objectp(__store))
     return __store;
+
+  assert(stringp(__shop_org) && truthy(__shop_org), "Shop org has not been set.");
 
   storage_options = new(class StorageOptions,
     storage_type: "public",


### PR DESCRIPTION
Adds `set_shop_org()` to the village shop, which was previously missing and would have caused it to fail when attempting to create storage. Also updates the tailor's org identifier to use a consistent naming convention.

Changes to `std/ext/shop.c` tighten up the `set_shop_org()` behavior:

- Removes the default org value (`"olum_general_store"`), requiring shops to explicitly declare their own org before calling `init_shop()`
- Adds a guard to prevent calling `set_shop_org()` after `init_shop()` has already run
- Sanitizes the org string by stripping spaces and slashes, allowing a more readable slash-separated format (e.g. `"olum/village shop"`) to be passed in without affecting the underlying storage key
- Adds an assertion in `create_storage()` to catch any shop that fails to set an org before storage is needed
- Makes the method `protected` and returns the resulting org string

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enforces explicit org declaration for shops by removing the silent `"olum_general_store"` default from `__shop_org`, requiring every shop to call `set_shop_org()` before `init_shop()` — a missing call now fails fast in `create_storage()`. It also adds the previously absent `set_shop_org()` call to the village shop and updates the tailor's org identifier to the slash-separated naming convention.

- **`std/ext/shop.c`**: `set_shop_org()` is now `protected`, sanitizes spaces and slashes from the input, guards against post-init calls, and asserts a non-empty result; `create_storage()` gains an assertion so any shop that forgets the call fails immediately rather than silently sharing the wrong storage.
- **`d/village/shop.c`**: Adds the missing `set_shop_org("olum/village shop")` before `init_shop()`, which would have caused a storage failure at runtime.
- **`d/village/tailor.c`**: Renames the org from `"olum_tailor"` to `"olum/village tailor"` (sanitized key: `"olumvillagetailor"`) for consistency; the shop was just created, so no persistent inventory is orphaned.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the changes correctly enforce explicit org setup and the only findings are two stale doc strings that describe removed default behaviour.

All three files make targeted, well-guarded changes. The village shop gets a critical missing call, the tailor's org key is updated consistently, and the extension module's new guards (post-init check, sanitisation, assertion in create_storage) behave as intended. The only issues are two doc comments in std/ext/shop.c that still describe the old fallback-to-default behaviour rather than the new fail-fast behaviour.

std/ext/shop.c — two doc comments still reference the old default-fallback behaviour and should be updated to reflect the new assertion-on-omission contract.

<sub>Reviews (3): Last reviewed commit: ["fixing shop org stuff"](https://github.com/gesslar/oxidus-mudlib/commit/16c061cf6a6bc054866f9f88f03710f052dac843) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41552132)</sub>

<!-- /greptile_comment -->