### PR TITLE
move TLS certs to adm/custom/certs and bind-mount state to host with uid/gid ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ log
 !/log/.keep
 !/log/*/.keep
 .rgignore
-/adm/etc/certs/*
-!/adm/etc/certs/*/.keep
 trace_lpcc.json
 /home/*
 !/home/*/.keep
@@ -53,6 +51,10 @@ journal.*
 /adm/dist/bin/
 /adm/dist/run.log
 /include/driver/
+
+# Docker per-host compose overrides (OXIDUS_STATE_PARENT/UID/GID/TLS); the
+# tracked .env.example documents the knobs.
+/adm/dist/docker/.env
 
 lpc-language-server
 node_modules

--- a/adm/custom/README.md
+++ b/adm/custom/README.md
@@ -19,6 +19,7 @@ up in the repository and `git pull` never clobbers them.
 | `security/groups.lpml` | `/adm/etc/security/groups_base.lpml` | master security | per-group list merge (`-name` removes) |
 | `security/roles.map` | — (runtime state) | master security | direct role grants, written by `add_role`/`remove_role` |
 | `security/access.local.lpml` | `/adm/etc/security/access.lpml` | master security | prepended to the base table (checked first) |
+| `certs/{cert,key}.pem` | — (drop-in) | `STD_HTTP_SERVER` via `TLS_CERT`/`TLS_KEY` config; telnet TLS | your TLS cert + key |
 
 ## Adding a customisation
 
@@ -52,6 +53,6 @@ overrides are safe even if a future image drops or renames a template.
 ## Not yet migrated
 
 Some customisation points still read from `/adm/etc` directly and haven't
-been moved into this tree yet (mssp, tls certs, secrets, and the various
-edit-in-place files like `logo`, `preload`, aliases and time config). They
-will migrate here over time.
+been moved into this tree yet (mssp, secrets, and the various edit-in-place
+files like `logo`, `preload`, aliases and time config). They will migrate
+here over time.

--- a/adm/dist/docker/.env.example
+++ b/adm/dist/docker/.env.example
@@ -1,0 +1,22 @@
+# Copy to `.env` (next to docker-compose.yml) and uncomment/edit as needed.
+# Compose auto-loads .env for ${VAR} interpolation. A file avoids the per-shell
+# differences of exporting variables (bash `export`, cmd `set`, PowerShell
+# `$env:`), so it is the cross-platform way to set these.
+
+# Where persistent state lives on the host: <parent>/oxidus-state. Defaults to
+# your home directory ($HOME) if unset. The oxidus-state leaf is always
+# appended, so the final path is predictable. On Windows, run compose from WSL,
+# Cygwin, or Git-Bash (which set $HOME), or set this explicitly.
+#OXIDUS_STATE_PARENT=/srv/oxidus
+
+# Host uid/gid that should own the bind-mounted state, so you can edit it
+# without sudo (and certbot/etc. can write to it). Default 1000 = the usual
+# single-user Linux desktop. Set to your `id -u` / `id -g` if different.
+# Ignored on Docker Desktop (mac/Windows), which handles ownership itself.
+#OXIDUS_UID=1000
+#OXIDUS_GID=1000
+
+# TLS telnet (off by default). Uses the bundled FluffOS test certs unless you
+# drop your own cert.pem/key.pem into adm/custom/certs/ in the state mount.
+#OXIDUS_TLS=1
+#OXIDUS_TLS_PORT=1338

--- a/adm/dist/docker/Dockerfile
+++ b/adm/dist/docker/Dockerfile
@@ -104,6 +104,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       neovim \
       nano \
       ripgrep \
+      gosu \
  && rm -rf /var/lib/apt/lists/* \
  && useradd -r -m -d /home/oxidus -s /bin/bash oxidus
 
@@ -111,13 +112,15 @@ COPY --from=builder ${OXIDUS_HOME} ${OXIDUS_HOME}
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # state/ is the single persistence root; the entrypoint symlinks all mutable
-# mudlib paths into it. chown before declaring the VOLUME so a fresh named
-# volume initialises with the right ownership.
+# mudlib paths into it. The image starts as root (no USER line) so the
+# entrypoint can chown a host bind mount to the operator's uid and rewire the
+# baked tree, then it drops to OXIDUS_UID:OXIDUS_GID via gosu to run the driver
+# unprivileged. The build-time chown seeds sane ownership for the baked tree and
+# any anonymous-volume fallback.
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
  && mkdir -p ${OXIDUS_HOME}/state \
  && chown -R oxidus:oxidus ${OXIDUS_HOME}
 
-USER oxidus
 WORKDIR ${OXIDUS_HOME}
 
 # Plain telnet on 1336; TLS telnet on 1338 is opt-in via OXIDUS_TLS=1 (see

--- a/adm/dist/docker/README.md
+++ b/adm/dist/docker/README.md
@@ -23,7 +23,7 @@ telnet localhost 1336
 
 Create a character — the first one to log in is made an admin.
 
-Stop it (game state is preserved in the `oxidus-state` volume):
+Stop it (game state is preserved in the state mount on your host):
 
 ```bash
 docker compose down
@@ -34,15 +34,23 @@ docker compose down
 ```bash
 docker run -d --name oxidus --init \
   -p 1336:1336 \
-  -v oxidus-state:/oxidus/state \
+  -e OXIDUS_UID=$(id -u) -e OXIDUS_GID=$(id -g) \
+  -v "${OXIDUS_STATE_PARENT:-$HOME}/oxidus-state:/oxidus/state" \
   ghcr.io/gesslar/oxidus:latest
 ```
+
+State lives on the host at `$HOME/oxidus-state` (override the parent dir with
+`OXIDUS_STATE_PARENT`; the `oxidus-state` leaf is always appended). The
+`OXIDUS_UID`/`OXIDUS_GID` flags make that directory owned by you, so you can
+edit config/certs directly and tools like certbot can write into it. On Docker
+Desktop (mac/Windows) the uid flags are unnecessary — it handles ownership.
 
 ## What persists
 
 Code is baked into the image (pristine); only runtime state lives in the
-`/oxidus/state` volume. On first boot the entrypoint symlinks every mutable
-mudlib path into that volume, so it survives restarts **and** image upgrades:
+`/oxidus/state` mount (a host directory — see above). On first boot the
+entrypoint symlinks every mutable mudlib path into that mount, so it survives
+restarts **and** image upgrades:
 
 | Path                  | Contents                                  |
 | --------------------- | ----------------------------------------- |
@@ -50,12 +58,12 @@ mudlib path into that volume, so it survives restarts **and** image upgrades:
 | `home/`               | player / wizard home directories          |
 | `log/`                | driver + mudlib logs                       |
 | `open/`, `tmp/`       | scratch / open data                       |
-| `adm/etc/certs/`      | TLS certs                                  |
 | `adm/etc/secret/`     | secrets                                    |
-| `adm/custom/`         | per-MUD overrides: config, security (groups/roles/access), alarms, first_user |
+| `adm/custom/`         | per-MUD overrides: config, security (groups/roles/access), alarms, certs, first_user |
 | `adm/etc/mssp.lpml`   | MSSP config                                |
 
-To start completely fresh, remove the volume: `docker volume rm oxidus-state`.
+To start completely fresh, delete the host state directory:
+`rm -rf "${OXIDUS_STATE_PARENT:-$HOME}/oxidus-state"`.
 
 ## Upgrading
 
@@ -95,8 +103,9 @@ ports:
   - "1338:1338"
 ```
 
-To use your own certificates instead, drop `cert.pem` / `key.pem` into the
-volume at `adm/etc/certs/` before first boot.
+To use your own certificates instead, drop `cert.pem` / `key.pem` into
+`adm/custom/certs/` in the state mount (e.g. certbot renews there). The HTTP
+server reads the same pair via the `TLS_CERT` / `TLS_KEY` config keys.
 
 ## Configuration knobs
 
@@ -110,10 +119,17 @@ Build args (Dockerfile):
 
 Runtime env (entrypoint):
 
-| Env              | Default | Purpose                          |
-| ---------------- | ------- | -------------------------------- |
-| `OXIDUS_TLS`     | `0`     | `1` enables TLS telnet           |
-| `OXIDUS_TLS_PORT`| `1338`  | TLS telnet port                  |
+| Env              | Default | Purpose                                            |
+| ---------------- | ------- | -------------------------------------------------- |
+| `OXIDUS_UID`     | `1000`  | host uid that owns the state mount (chowned at boot) |
+| `OXIDUS_GID`     | `1000`  | host gid that owns the state mount                 |
+| `OXIDUS_TLS`     | `0`     | `1` enables TLS telnet                             |
+| `OXIDUS_TLS_PORT`| `1338`  | TLS telnet port                                    |
+
+Host-side (compose interpolation / `docker run`, **not** passed into the
+container): `OXIDUS_STATE_PARENT` — parent dir of the `oxidus-state` state
+directory on the host (default: your home dir). Set it, and `OXIDUS_UID`/`GID`,
+in a `.env` file beside the compose file (see `.env.example`).
 
 ## Notes
 
@@ -128,6 +144,8 @@ Runtime env (entrypoint):
   cosmetic. Advancing the pointer is optional housekeeping, never a build step.
   (fluffos updates are sporadic — a year quiet, then a flurry — so if you're ever
   unsure whether you "need to update" anything: you don't. Just rerun `rebuild`.)
-- The container runs as a non-root `oxidus` user.
+- The container **starts as root** to set up the state mount (chown a host bind
+  mount, rewire the baked tree), then drops to `OXIDUS_UID:OXIDUS_GID` (default
+  `1000`) via `gosu` and runs the driver unprivileged.
 - `--init` (compose: `init: true`) is recommended so signals/zombies are handled
   cleanly and `docker stop` lets the driver shut down gracefully.

--- a/adm/dist/docker/docker-compose.yml
+++ b/adm/dist/docker/docker-compose.yml
@@ -3,7 +3,7 @@
 #   docker compose up -d         # build locally and start
 #   docker compose up -d --build # force a rebuild (gets latest fluffos master)
 #   docker compose logs -f       # watch the driver
-#   docker compose down          # stop (state persists in the named volume)
+#   docker compose down          # stop (state persists in the host bind mount)
 #
 # To run the published image instead of building, comment out `build:` and
 # uncomment the ghcr image line.
@@ -24,11 +24,22 @@ services:
     ports:
       - "1336:1336"            # plain telnet
       # - "1338:1338"          # TLS telnet (also set OXIDUS_TLS=1 below)
-    # environment:
-    #   OXIDUS_TLS: "1"        # enable TLS telnet using the FluffOS test certs
-    #   OXIDUS_TLS_PORT: "1338"
+    environment:
+      # Host uid/gid that should own the bind-mounted state, so you can edit it
+      # without sudo and certbot/etc. can write to it. Default 1000 = the usual
+      # single-user Linux desktop; set OXIDUS_UID/OXIDUS_GID (in .env) to your
+      # `id -u`/`id -g` if different. Ignored on Docker Desktop (mac/Windows).
+      OXIDUS_UID: ${OXIDUS_UID:-1000}
+      OXIDUS_GID: ${OXIDUS_GID:-1000}
+      # OXIDUS_TLS: "1"        # enable TLS telnet using the FluffOS test certs
+      # OXIDUS_TLS_PORT: "1338"
     volumes:
-      - oxidus-state:/oxidus/state
-
-volumes:
-  oxidus-state:
+      # Persistent state lives on the host at <parent>/oxidus-state, where
+      # <parent> = OXIDUS_STATE_PARENT if set, else your home directory ($HOME).
+      # The oxidus-state leaf is always appended, so the final path is
+      # predictable. On Windows, run compose from WSL, Cygwin, or Git-Bash (all
+      # set $HOME); from bare PowerShell/cmd, set OXIDUS_STATE_PARENT explicitly.
+      # Set OXIDUS_STATE_PARENT (and OXIDUS_UID/GID above) in a .env file beside
+      # this compose file — export syntax differs per shell, a .env does not.
+      # See .env.example.
+      - ${OXIDUS_STATE_PARENT:-${HOME}}/oxidus-state:/oxidus/state

--- a/adm/dist/docker/docker-entrypoint.sh
+++ b/adm/dist/docker/docker-entrypoint.sh
@@ -2,12 +2,19 @@
 #
 # Container entrypoint for the Oxidus image.
 #
-#   1. Symlinks every runtime-mutable mudlib path into the persistent volume at
-#      $OXIDUS_HOME/state, so the baked image stays pristine while game state
+# The image starts as root so it can (1) take ownership of the (possibly
+# host-bind-mounted) state for the operator's uid and (2) shuffle symlinks in
+# the baked mudlib tree, then it drops privileges via gosu to run the driver
+# unprivileged. Concretely:
+#
+#   1. Symlinks every runtime-mutable mudlib path into the persistent state mount
+#      at $OXIDUS_HOME/state, so the baked image stays pristine while game state
 #      (players, data, logs, certs, ...) survives container/image upgrades.
-#   2. Optionally enables TLS telnet using the FluffOS test certs.
-#   3. Runs the driver in a reboot loop, mirroring adm/dist/run but with proper
-#      signal handling for PID 1.
+#   2. chowns the state to OXIDUS_UID:OXIDUS_GID (default 1000:1000) so a host
+#      bind mount is writable by - and editable as - the operator's user.
+#   3. Optionally enables TLS telnet using the FluffOS test certs.
+#   4. Drops to OXIDUS_UID:OXIDUS_GID and runs the driver in a reboot loop, with
+#      proper signal handling for PID 1.
 #
 # The set of persisted paths is derived from the mudlib .gitignore (everything
 # the lib writes at runtime). Add to PERSIST_DIRS / PERSIST_FILES if the lib
@@ -20,107 +27,131 @@ STATE="${OXIDUS_HOME}/state"
 DIST="${OXIDUS_HOME}/adm/dist"
 DRIVER="${DIST}/bin/driver"
 CONFIG="${DIST}/config.mud"
+PUID="${OXIDUS_UID:-1000}"
+PGID="${OXIDUS_GID:-1000}"
 
 cd "${OXIDUS_HOME}"
 
-# Directories whose *contents* are runtime state. adm/custom is the
-# consolidated per-MUD override tree (config, security groups/roles/access,
-# alarms, first_user, ...); persisting it as a unit means any override slot
-# added under it survives upgrades without touching this list again.
-PERSIST_DIRS=(
-  data
-  open
-  home
-  log
-  tmp
-  adm/etc/certs
-  adm/etc/secret
-  adm/custom
-)
+# --- Phase 1: privileged setup (root only) -------------------------------
+# Runs once per boot as root: wire persistence, own the state mount, then
+# re-exec this script under gosu as the unprivileged target uid (the re-exec
+# is non-root, so it skips this block and falls through to the driver loop).
+if [ "$(id -u)" = "0" ]; then
+  # Directories whose *contents* are runtime state. adm/custom is the
+  # consolidated per-MUD override tree (config, security groups/roles/access,
+  # alarms, certs, first_user, ...); persisting it as a unit means any override
+  # slot added under it survives upgrades without touching this list again.
+  PERSIST_DIRS=(
+    data
+    open
+    home
+    log
+    tmp
+    adm/etc/secret
+    adm/custom
+  )
 
-# Individual files written at runtime (may not exist in a pristine clone).
-# Most per-MUD state now lives under adm/custom (above); mssp.lpml is the
-# last hold-out still read from adm/etc.
-PERSIST_FILES=(
-  adm/etc/mssp.lpml
-)
+  # Individual files written at runtime (may not exist in a pristine clone).
+  # Most per-MUD state now lives under adm/custom (above); mssp.lpml is the
+  # last hold-out still read from adm/etc.
+  PERSIST_FILES=(
+    adm/etc/mssp.lpml
+  )
 
-# Move a directory's pristine contents into the volume on first boot, then
-# replace it with a symlink into the volume.
-link_dir() {
-  local rel="$1"
-  local src="${OXIDUS_HOME}/${rel}"
-  local dst="${STATE}/${rel}"
+  # Move a directory's pristine contents into the state mount on first boot,
+  # then replace it with a symlink into the mount.
+  link_dir() {
+    local rel="$1"
+    local src="${OXIDUS_HOME}/${rel}"
+    local dst="${STATE}/${rel}"
 
-  if [ ! -e "${dst}" ]; then
+    if [ ! -e "${dst}" ]; then
+      mkdir -p "$(dirname "${dst}")"
+      if [ -d "${src}" ] && [ ! -L "${src}" ]; then
+        cp -a "${src}" "${dst}"   # seed from the pristine image copy (.keep files etc.)
+      else
+        mkdir -p "${dst}"
+      fi
+    fi
+
+    rm -rf "${src}"
+    mkdir -p "$(dirname "${src}")"
+    ln -s "${dst}" "${src}"
+  }
+
+  # Symlink a single file into the mount. A dangling link is fine: the first
+  # write the lib makes lands in the mount.
+  link_file() {
+    local rel="$1"
+    local src="${OXIDUS_HOME}/${rel}"
+    local dst="${STATE}/${rel}"
+
     mkdir -p "$(dirname "${dst}")"
-    if [ -d "${src}" ] && [ ! -L "${src}" ]; then
-      cp -a "${src}" "${dst}"   # seed from the pristine image copy (.keep files etc.)
-    else
-      mkdir -p "${dst}"
+    if [ ! -e "${dst}" ] && [ -f "${src}" ] && [ ! -L "${src}" ]; then
+      cp -a "${src}" "${dst}"
+    fi
+
+    rm -f "${src}"
+    mkdir -p "$(dirname "${src}")"
+    ln -s "${dst}" "${src}"
+  }
+
+  echo "[entrypoint] wiring persistent state into ${STATE}"
+  for d in "${PERSIST_DIRS[@]}"; do link_dir "${d}"; done
+  for f in "${PERSIST_FILES[@]}"; do link_file "${f}"; done
+
+  # Refresh image-managed scaffolding into the (now symlinked) adm/custom mount.
+  # README, the .keep skeleton, and *.example templates are baked reference
+  # files, not editable state - so they flow one-directionally, image -> mount,
+  # on every boot, and an upgrade always lands the current versions. Live per-MUD
+  # data (config.lpml, security/*, alarms/*.txt, first_user, ...) is not part of
+  # the baked stash, so it is left untouched.
+  #
+  # Add and overwrite only, never delete. Removing a file from the image does not
+  # remove it from the mount: pruning downstream would be a bidirectional sync,
+  # and that is deliberately out of scope.
+  if [ -d "${DIST}/custom.dist" ]; then
+    cp -a "${DIST}/custom.dist/." "${OXIDUS_HOME}/adm/custom/"
+    echo "[entrypoint] refreshed adm/custom scaffolding from the image"
+  fi
+
+  # Optional TLS telnet. Default off (plain telnet on 1336 only).
+  if [ "${OXIDUS_TLS:-0}" = "1" ]; then
+    tls_port="${OXIDUS_TLS_PORT:-1338}"
+    certdir="${OXIDUS_HOME}/adm/custom/certs"   # under adm/custom, symlinked into the mount above
+    if [ ! -f "${certdir}/cert.pem" ] || [ ! -f "${certdir}/key.pem" ]; then
+      cp -a "${DIST}/certs.dist/cert.pem" "${certdir}/cert.pem"
+      cp -a "${DIST}/certs.dist/key.pem"  "${certdir}/key.pem"
+      echo "[entrypoint] installed FluffOS test certs into ${certdir}"
+    fi
+    if ! grep -q "external_port_2_tls" "${CONFIG}"; then
+      {
+        echo ""
+        echo "external_port_2: telnet ${tls_port}"
+        echo "external_port_2_tls: cert=adm/custom/certs/cert.pem key=adm/custom/certs/key.pem"
+      } >> "${CONFIG}"
+      echo "[entrypoint] enabled TLS telnet on port ${tls_port}"
     fi
   fi
 
-  rm -rf "${src}"
-  mkdir -p "$(dirname "${src}")"
-  ln -s "${dst}" "${src}"
-}
+  # Take ownership of the whole state mount for the target uid, so the operator
+  # can read/write it on the host without sudo (and certbot/etc. can drop files
+  # in). Unconditional and recursive: phase 1 runs once per container start (not
+  # per in-game reboot), so re-owning the tree is cheap - and a uid-only guard on
+  # the mount root would leave stale root-/old-uid-owned children (a newly seeded
+  # persist path, an externally created file) unwritable by the driver.
+  chown -R "${PUID}:${PGID}" "${STATE}"
 
-# Symlink a single file into the volume. A dangling link is fine: the first
-# write the lib makes lands in the volume.
-link_file() {
-  local rel="$1"
-  local src="${OXIDUS_HOME}/${rel}"
-  local dst="${STATE}/${rel}"
-
-  mkdir -p "$(dirname "${dst}")"
-  if [ ! -e "${dst}" ] && [ -f "${src}" ] && [ ! -L "${src}" ]; then
-    cp -a "${src}" "${dst}"
-  fi
-
-  rm -f "${src}"
-  mkdir -p "$(dirname "${src}")"
-  ln -s "${dst}" "${src}"
-}
-
-echo "[entrypoint] wiring persistent state into ${STATE}"
-for d in "${PERSIST_DIRS[@]}"; do link_dir "${d}"; done
-for f in "${PERSIST_FILES[@]}"; do link_file "${f}"; done
-
-# Refresh image-managed scaffolding into the (now symlinked) adm/custom volume.
-# README, the .keep skeleton, and *.example templates are baked reference files,
-# not editable state - so they flow one-directionally, image -> volume, on every
-# boot, and an upgrade always lands the current versions. Live per-MUD data
-# (config.lpml, security/*, alarms/*.txt, first_user, ...) is not part of the
-# baked stash, so it is left untouched.
-#
-# Add and overwrite only, never delete. Removing a file from the image does not
-# remove it from the volume: pruning downstream would be a bidirectional sync,
-# and that is deliberately out of scope.
-if [ -d "${DIST}/custom.dist" ]; then
-  cp -a "${DIST}/custom.dist/." "${OXIDUS_HOME}/adm/custom/"
-  echo "[entrypoint] refreshed adm/custom scaffolding from the image"
-fi
-
-# Optional TLS telnet. Default off (plain telnet on 1336 only).
-if [ "${OXIDUS_TLS:-0}" = "1" ]; then
-  tls_port="${OXIDUS_TLS_PORT:-1338}"
-  certdir="${OXIDUS_HOME}/adm/etc/certs"   # symlinked into the volume above
-  if [ ! -f "${certdir}/cert.pem" ] || [ ! -f "${certdir}/key.pem" ]; then
-    cp -a "${DIST}/certs.dist/cert.pem" "${certdir}/cert.pem"
-    cp -a "${DIST}/certs.dist/key.pem"  "${certdir}/key.pem"
-    echo "[entrypoint] installed FluffOS test certs into ${certdir}"
-  fi
-  if ! grep -q "external_port_2_tls" "${CONFIG}"; then
-    {
-      echo ""
-      echo "external_port_2: telnet ${tls_port}"
-      echo "external_port_2_tls: cert=adm/etc/certs/cert.pem key=adm/etc/certs/key.pem"
-    } >> "${CONFIG}"
-    echo "[entrypoint] enabled TLS telnet on port ${tls_port}"
+  # Drop privileges and re-enter as the target uid (skips this whole block).
+  # If the operator explicitly asked to run as root (OXIDUS_UID=0), stay root
+  # rather than re-exec into an infinite loop.
+  if [ "${PUID}" != "0" ]; then
+    echo "[entrypoint] state owned by ${PUID}:${PGID}; dropping privileges"
+    exec gosu "${PUID}:${PGID}" "$0" "$@"
   fi
 fi
 
+# --- Phase 2: unprivileged driver loop (we are now PUID:PGID) -------------
 # Reboot loop with signal handling (mirrors adm/dist/run; exit 0 == reboot).
 set +e
 child=""

--- a/adm/etc/default.lpml
+++ b/adm/etc/default.lpml
@@ -14,6 +14,8 @@
     "/adm/daemons/shutdown_d",
   ],
   FIRST_USER: "adm/custom/first_user",
+  TLS_CERT: "adm/custom/certs/cert.pem",
+  TLS_KEY: "adm/custom/certs/key.pem",
   SECURITY_ENFORCE_PATHS: false,
   LOOK_HIGHLIGHT: "on",
   LOOK_HIGHLIGHT_COLOUR: "669",

--- a/std/daemon/http_server.c
+++ b/std/daemon/http_server.c
@@ -78,8 +78,8 @@ protected nomask void start_server() {
   }
 
   if(get_option("tls")) {
-    socket_set_option(fd, SO_TLS_CERT, "adm/certs/cert.pem");
-    socket_set_option(fd, SO_TLS_KEY, "adm/certs/key.pem");
+    socket_set_option(fd, SO_TLS_CERT, mud_config("TLS_CERT"));
+    socket_set_option(fd, SO_TLS_KEY, mud_config("TLS_KEY"));
   }
 
   int bind_status = socket_bind(fd, LISTEN_PORT);


### PR DESCRIPTION
TLS certificates have been consolidated under `adm/custom/certs/` (moved from `adm/etc/certs/`), making them part of the unified per-MUD override tree that persists across image upgrades. The HTTP server now reads cert and key paths from `mud_config("TLS.CERT")` / `mud_config("TLS.KEY")`, with defaults pointing to `adm/custom/certs/cert.pem` and `adm/custom/certs/key.pem` via `adm/etc/default.lpml`.

The Docker setup has been reworked to use a host bind mount instead of a named volume for persistent state. The container now starts as root, chowns the state directory to `OXIDUS_UID:OXIDUS_GID` (default `1000:1000`), then drops privileges via `gosu` before running the driver. This lets the operator read and write state files directly on the host — and allows tools like certbot to renew certs into `adm/custom/certs/` — without needing `sudo`. A `.env.example` file documents `OXIDUS_STATE_PARENT`, `OXIDUS_UID`, `OXIDUS_GID`, `OXIDUS_TLS`, and `OXIDUS_TLS_PORT` as the cross-platform way to configure these without per-shell export syntax differences.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves TLS certificates and Docker state into operator-owned persistent locations. The main changes are:

- TLS cert/key defaults now point at `adm/custom/certs`.
- The HTTP server reads TLS paths from mud config.
- Docker state now uses a host bind mount.
- The entrypoint chowns state and drops privileges with `gosu`.
- Docker docs and `.env.example` describe the new runtime knobs.

<h3>Confidence Score: 4/5</h3>

This is close, but the Compose default path should be fixed before merging.

- The ownership repair now recursively updates the state mount before the driver starts.
- The TLS config keys are flat, so partial nested overrides no longer remove the paired default.
- The Compose bind mount can still resolve to the wrong host path when `HOME` is unavailable.

adm/dist/docker/docker-compose.yml

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aadm%2Fdist%2Fdocker%2Fdocker-compose.yml%3A45%0A**Windows%20Default%20Misbinds**%0A%0AWhen%20this%20compose%20file%20is%20run%20from%20bare%20PowerShell%20or%20cmd%20without%20%60OXIDUS_STATE_PARENT%60%2C%20%60%24%7BHOME%7D%60%20is%20often%20unset.%20That%20expands%20the%20bind%20source%20to%20%60%2Foxidus-state%60%2C%20so%20state%20is%20not%20mounted%20from%20the%20user's%20Windows%20home%20directory.%20The%20container%20can%20start%20with%20state%20in%20the%20wrong%20place%2C%20and%20users%20can%20appear%20to%20lose%20persisted%20data%20after%20cleanup%20or%20recreation.%20The%20compose%20file%20should%20fail%20clearly%20or%20require%20an%20explicit%20host%20path%20instead%20of%20silently%20falling%20back%20to%20an%20empty%20%60HOME%60.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=259&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["making files ~~great~~ editable (not edi..."](https://github.com/gesslar/oxidus-mudlib/commit/a54c2d2712956281e967a85f448d3031eaa01302) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41571701)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))

<!-- /greptile_comment -->