### PR TITLE
replace fluffos submodule with fresh clone in rebuild and update docs

### DIFF
--- a/adm/dist/docker/Dockerfile
+++ b/adm/dist/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Oxidus mudlib + FluffOS driver, containerised.
 #
 # Reuses the canonical Oxidus build/run methodology in adm/dist:
-#   * adm/dist/rebuild  -> compiles the driver from the fluffos submodule and
+#   * adm/dist/rebuild  -> clones FluffOS fresh, compiles the driver, and
 #                          rewrites config.mud with absolute paths.
 #   * adm/dist/run      -> reboot loop (mirrored by docker-entrypoint.sh so it
 #                          behaves correctly as PID 1).
@@ -50,8 +50,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN git clone "${OXIDUS_REPO}" "${OXIDUS_HOME}" \
  && git -C "${OXIDUS_HOME}" checkout "${OXIDUS_REF}"
 
-# Build the driver via the canonical script. It initialises the fluffos
-# submodule, compiles, installs binaries into adm/dist/bin, copies the driver
+# Build the driver via the canonical script. It clones FluffOS fresh (tracking
+# master), compiles, installs binaries into adm/dist/bin, copies the driver
 # headers into include/driver, and rewrites config.mud's mudlib/log paths.
 #
 # MARCH_NATIVE=OFF is critical: FluffOS defaults -march=native ON, which would

--- a/adm/dist/docker/README.md
+++ b/adm/dist/docker/README.md
@@ -2,10 +2,9 @@
 
 A self-contained image of the [Oxidus](https://oxidus.online/) mudlib plus the
 FluffOS driver. The image clones a **pristine** copy of the mudlib and compiles
-the driver from the bundled `fluffos` submodule using the canonical
-`adm/dist/rebuild` script — so a fresh container is a brand-new mudlib, ready
-to play. The first character to log in becomes Oxidus's owner with the highest
-privileges.
+the driver from a fresh clone of FluffOS using the canonical `adm/dist/rebuild`
+script — so a fresh container is a brand-new mudlib, ready to play. The first
+character to log in becomes Oxidus's owner with the highest privileges.
 
 ## Quick start (build locally)
 
@@ -21,13 +20,17 @@ Then connect:
 telnet localhost 1336
 ```
 
-Create a character — the first one to log in is made an admin.
+Create a character — the first one to log in is made the owner.
 
 Stop it (game state is preserved in the state mount on your host):
 
 ```bash
 docker compose down
 ```
+
+Your world persists on the host at `$HOME/oxidus-state`. To put it elsewhere,
+set `OXIDUS_STATE_PARENT` in a `.env` file beside the compose file (see
+[Configuration knobs](#configuration-knobs) and `.env.example`).
 
 ## Run the published image
 
@@ -126,22 +129,26 @@ Runtime env (entrypoint):
 | `OXIDUS_TLS`     | `0`     | `1` enables TLS telnet                             |
 | `OXIDUS_TLS_PORT`| `1338`  | TLS telnet port                                    |
 
-Host-side (compose interpolation / `docker run`, **not** passed into the
-container): `OXIDUS_STATE_PARENT` — parent dir of the `oxidus-state` state
-directory on the host (default: your home dir). Set it, and `OXIDUS_UID`/`GID`,
-in a `.env` file beside the compose file (see `.env.example`).
+Host-side (compose interpolation / `docker run` — resolved on the host, **not**
+passed into the container):
+
+| Var                  | Default | Purpose                                                |
+| -------------------- | ------- | ------------------------------------------------------ |
+| `OXIDUS_STATE_PARENT`| `$HOME` | parent dir of the `oxidus-state` state dir on the host |
+
+Set this (and `OXIDUS_UID`/`GID`) in a `.env` file beside the compose file (see
+`.env.example`) — that's the cross-platform way, since shell export syntax
+differs per OS.
 
 ## Notes
 
 - Per the canonical `adm/dist/rebuild`, the **driver tracks fluffos `master`**:
   rebuilding the image picks up the latest FluffOS. The mudlib itself is pinned
   to whatever `OXIDUS_REF` you build (CI builds the exact pushed commit).
-- The fluffos submodule is **effectively unpinned**: `rebuild` does
-  `git reset --hard origin/master` before compiling, so the committed submodule
-  SHA never decides what's built — every rebuild rides master HEAD. The
-  submodule's *position* (its `.gitmodules` entry + gitlink path) is required so
-  the directory gets populated to compile from; its recorded *version* is
-  cosmetic. Advancing the pointer is optional housekeeping, never a build step.
+- FluffOS is **not a submodule** — `rebuild` clones it fresh from
+  `github.com/fluffos/fluffos` (when the `fluffos/` dir is absent) and does
+  `git reset --hard origin/master` before compiling, so every rebuild rides
+  master HEAD. There's no pinned SHA to advance and nothing to keep in sync.
   (fluffos updates are sporadic — a year quiet, then a flurry — so if you're ever
   unsure whether you "need to update" anything: you don't. Just rerun `rebuild`.)
 - The container **starts as root** to set up the state mount (chown a host bind

--- a/adm/dist/rebuild
+++ b/adm/dist/rebuild
@@ -28,9 +28,9 @@ driver="${repo_root}/adm/dist/bin/driver"
 # Pull FluffOS
 
 
-# Ensure the FluffOS driver submodule is up to date
+# Ensure the FluffOS driver source is present and tracking master
 if [ ! -d "fluffos" ] || [ -z "$(ls -A fluffos)" ]; then
-    # Submodule doesn't exist or is empty
+    # fluffos/ doesn't exist or is empty - clone it fresh
     git clone https://github.com/fluffos/fluffos.git fluffos 1>/dev/null
 fi
 


### PR DESCRIPTION
Replace FluffOS submodule references with fresh-clone language throughout docs and scripts.

The `rebuild` script already clones FluffOS directly from GitHub when the `fluffos/` directory is absent, rather than initialising a submodule. Comments and documentation have been updated to reflect this accurately — FluffOS is not a submodule, there is no pinned SHA to track or advance, and every rebuild simply resets to `origin/master` HEAD.

The Docker README also gains a clearer explanation of where world state is persisted on the host (`$HOME/oxidus-state`) and how to relocate it via `OXIDUS_STATE_PARENT` in a `.env` file. The host-side configuration variables are now presented in a table consistent with the runtime env table above it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Docker and rebuild wording for the FluffOS clone flow. The main changes are:

- Replaces submodule language with fresh-clone language.
- Clarifies that rebuild tracks FluffOS `origin/master`.
- Documents host state persistence under `$HOME/oxidus-state`.
- Presents `OXIDUS_STATE_PARENT` as a host-side configuration knob.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["fixing documentation"](https://github.com/gesslar/oxidus-mudlib/commit/ca93044f0e7f0219e5d138e54921dc04892cecca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41576621)</sub>

<!-- /greptile_comment -->