### PR TITLE
Consolidate save triggers and apply coding style to living subsystem

### DIFF
--- a/adm/obj/login.c
+++ b/adm/obj/login.c
@@ -549,8 +549,6 @@ private void enter_world(string name, int reconnecting) {
   if(reconnecting)
     body->reconnect();
 
-
-
   body->setup_body();
   body->clear_gmcp_data();
   body->set_gmcp_client(__login_gmcp_data["client"]);

--- a/std/living/advancement.c
+++ b/std/living/advancement.c
@@ -82,8 +82,6 @@ float set_level(float l) {
     ]));
   }
 
-  save_body();
-
   return __level;
 }
 
@@ -118,9 +116,8 @@ float query_level_mod() {
 }
 
 /**
- * Replace the temporary level modifier. Routes through
- * adjust_level_mod() so any future side-effect logic lives in one
- * place.
+ * Replace the temporary level modifier. Routes through adjust_level_mod() so
+ * any future side-effect logic lives in one place.
  *
  * @param {float} l - The desired modifier value.
  * @returns {float} The new modifier value.
@@ -137,8 +134,6 @@ float set_level_mod(float l) {
  */
 float adjust_level_mod(float l) {
   __level_mod += to_float(l);
-
-  save_body();
 
   return __level_mod;
 }
@@ -160,8 +155,6 @@ int adjust_xp(int amount) {
       GMCP_LBL_CHAR_STATUS_LEVEL: __level,
     ]));
   }
-
-  save_body();
 
   return __xp;
 }

--- a/std/living/body.c
+++ b/std/living/body.c
@@ -4,10 +4,11 @@
  * Body object that is shared by players and NPCs.
  *
  * @created 2024-07-29 - Gesslar
- * @last_modified 2024-07-29 - Gesslar
+ * @last_modified 2026-07-04 - Gesslar
  *
  * @history
  * 2024-07-29 - Gesslar - Created
+ * 2026-07-04 - Gesslar - Applied coding style and documentation
  */
 
 #include <body.h>
@@ -40,8 +41,6 @@ inherit __DIR__ "wealth";
 
 inherit EXT_ACTION;
 inherit EXT_LOG;
-
-/* Prototypes */
 
 void mudlib_setup() {
   if(!clonep() &&
@@ -76,15 +75,33 @@ private nosave string *weapon_slots = ({
   "right hand", "left hand"
 });
 
-string *query_body_slots() {
+/**
+ * Returns the armour slots this body provides.
+ *
+ * @returns {string*} A copy of the body slot names.
+ */
+protected string *query_body_slots() {
   return copy(body_slots);
 }
 
-string *query_weapon_slots() {
+/**
+ * Returns the weapon slots this body provides.
+ *
+ * @returns {string*} A copy of the weapon slot names.
+ */
+protected string *query_weapon_slots() {
   return copy(weapon_slots);
 }
 
-void die() {
+/**
+ * Handles this body's death. Stops all attacks, ejects any switched-user
+ * occupant, spawns a corpse and transfers inventory and wealth into it,
+ * then either raises a ghost (for players) or awards kill experience (for
+ * NPCs) before removing the body.
+ *
+ * @returns {void}
+ */
+protected void die() {
   object
   /** @type {STD_BODY} */   body,
   /** @type {LIB_CORPSE} */ corpse,
@@ -156,7 +173,14 @@ void die() {
   remove();
 }
 
-varargs int move(mixed ob) {
+/**
+ * Moves this body to a destination, recording the previous environment as
+ * the last location when the move succeeds.
+ *
+ * @param {mixed} ob - The destination object or path to move into.
+ * @returns {int} 0 on success, or a non-zero move failure code.
+ */
+public varargs int move(mixed ob) {
   int result;
   object env;
 
@@ -169,12 +193,17 @@ varargs int move(mixed ob) {
   if(env)
     set_last_location(env);
 
-  save_body();
-
   return result;
 }
 
-void event_remove(object _prev) {
+/**
+ * Disperses this body's inventory when it is removed, dropping items into
+ * the environment where possible and removing those that prevent dropping.
+ *
+ * @param {object} _prev - The previous environment before removal.
+ * @returns {void}
+ */
+protected void event_remove(object _prev) {
   object
   /** @type {STD_ITEM} */ ob,
   /** @type {STD_ITEM} */ next;
@@ -195,7 +224,21 @@ void event_remove(object _prev) {
   }
 }
 
-varargs int move_living(mixed dest, string dir, string depart_message, string arrive_message) {
+/**
+ * Moves a living body between environments, cancelling any in-progress
+ * actions and broadcasting departure and arrival messages to the rooms
+ * involved. A message of "SILENT" suppresses that half of the narration.
+ *
+ * @param {mixed} dest - The destination object or path.
+ * @param {string} [dir="somewhere"] - The direction of travel, used in the
+ *                                     departure message.
+ * @param {string} [depart_message] - Departure message override, or
+ *                                    "SILENT" to suppress it.
+ * @param {string} [arrive_message] - Arrival message override, or
+ *                                    "SILENT" to suppress it.
+ * @returns {int} 0 on success, or a non-zero move failure code.
+ */
+public varargs int move_living(mixed dest, string dir, string depart_message, string arrive_message) {
   int result;
   object curr = environment();
   string tmp;
@@ -251,21 +294,34 @@ varargs int move_living(mixed dest, string dir, string depart_message, string ar
  * TODO: For now, just returns 1 until more is implemented that will affect
  * this.
  *
- * @returns {1|string} Returns 1 if passes ability check, otherwise a string error message.
+ * @returns {int | string} 1 if the body passes the ability check,
+ *                         otherwise a string error message.
  */
-int is_able() {
+public int is_able() {
   return 1;
 }
 
-//Misc functions
-void write_prompt() {
+// Misc functions
+
+/**
+ * Writes this body's configured prompt to its connection.
+ *
+ * @returns {void}
+ */
+protected void write_prompt() {
   string prompt = query_pref("prompt");
 
   receive(prompt + " ");
 }
 
-int query_log_level() {
-  if(!query_pref("log_level")) return 0;
+/**
+ * Returns this body's logging verbosity level, read from preferences.
+ *
+ * @returns {int} The configured log level, or 0 when unset.
+ */
+public int query_log_level() {
+  if(!query_pref("log_level"))
+    return 0;
 
   return to_int(query_pref("log_level"));
 }
@@ -277,14 +333,14 @@ int query_log_level() {
  *
  * @type {STD_BODY}
  */
-object su_body;
+private object su_body;
 
 /**
  * Register the body we have moved into.
  *
  * @param {STD_BODY} source - The body we are now inhabiting.
  */
-void set_su_body(object source) {
+public void set_su_body(object source) {
   su_body = source;
 }
 
@@ -294,13 +350,13 @@ void set_su_body(object source) {
  *
  * @returns {STD_BODY|0} The body we are currently inhabiting, or null.
  */
-object query_su_body() {
+public object query_su_body() {
   return su_body;
 }
 
 /**
  * Resets our current switch user body to null.
  */
-void clear_su_body() {
+public void clear_su_body() {
   su_body = null;
 }

--- a/std/living/env.c
+++ b/std/living/env.c
@@ -1,73 +1,139 @@
 /**
  * @file /std/living/env.c
- * Environment variables and preferences, etc.
+ *
+ * Environment variables and preferences for living objects. Environment
+ * variables hold session/shell state (working directory, current file,
+ * etc.), while preferences hold persistent player-facing settings such as
+ * colour and output options.
  *
  * @created 2024-08-17 - Gesslar
- * @last_modified 2024-08-17 - Gesslar
+ * @last_modified 2026-07-04 - Gesslar
  *
  * @history
  * 2024-08-17 - Gesslar - Created
+ * 2026-07-04 - Gesslar - Applied coding style and documentation
  */
 
 #include <env.h>
 #include <player.h>
 
+/**
+ * Environment variables for this living, keyed by variable name.
+ *
+ * @type {([ string: string ])}
+ */
 private mapping env_settings = ([]);
+
+/**
+ * Player preferences for this living, keyed by preference name.
+ *
+ * @type {([ string: string ])}
+ */
 private mapping preferences = ([]);
 
-void init_env() {
-    if(nullp(env_settings))
-        env_settings = ([]);
-    if(nullp(preferences))
-        preferences = ([]);
+/**
+ * Ensures the environment and preference mappings are initialised. Called
+ * during living setup and lazily by the accessors before first use.
+ *
+ * @returns {void}
+ */
+protected void init_env() {
+  if(nullp(env_settings))
+    env_settings = ([]);
+
+  if(nullp(preferences))
+    preferences = ([]);
 }
 
-int set_env(string var_name, string var_value) {
-    if(!env_settings)
-        init_env();
+/**
+ * Sets or clears an environment variable. Passing a null value removes the
+ * variable from the environment.
+ *
+ * @param {string} var_name - The name of the environment variable.
+ * @param {string} var_value - The value to store, or null to remove it.
+ * @returns {int} Always 1.
+ */
+public int set_env(string var_name, string var_value) {
+  if(!env_settings)
+    init_env();
 
-    if(!var_value) map_delete(env_settings, var_name);
-    else env_settings += ([var_name : var_value]);
+  if(!var_value)
+    map_delete(env_settings, var_name);
+  else
+    env_settings += ([ var_name: var_value ]);
 
-    if(userp(this_object()))
-        this_object()->save_body();
-
-    return 1;
+  return 1;
 }
 
-varargs mixed query_env(string var_name, mixed def) {
-    if(!env_settings)
-        init_env();
+/**
+ * Queries the value of an environment variable, returning a default when
+ * the variable is unset.
+ *
+ * @param {string} var_name - The name of the environment variable.
+ * @param {mixed} [def] - The value to return when the variable is unset.
+ * @returns {mixed} The stored value, or def when the variable is unset.
+ */
+public varargs mixed query_env(string var_name, mixed def) {
+  if(!env_settings)
+    init_env();
 
-    if(env_settings[var_name]) return env_settings[var_name];
-    else return def;
+  if(env_settings[var_name])
+    return env_settings[var_name];
+  else
+    return def;
 }
 
-mapping list_env() {
-    return copy(env_settings);
+/**
+ * Returns a copy of all environment variables for this living.
+ *
+ * @returns {([ string: string ])} A copy of the environment mapping.
+ */
+public mapping list_env() {
+  return copy(env_settings);
 }
 
-int set_pref(string pref_name, string pref_value) {
-    if(!preferences)
-        init_env();
+/**
+ * Sets or clears a preference. Passing a null value removes the preference.
+ *
+ * @param {string} pref_name - The name of the preference.
+ * @param {string} pref_value - The value to store, or null to remove it.
+ * @returns {int} Always 1.
+ */
+public int set_pref(string pref_name, string pref_value) {
+  if(!preferences)
+    init_env();
 
-    if(!pref_value) map_delete(preferences, pref_name);
-    else preferences += ([pref_name : pref_value]);
+  if(!pref_value)
+    map_delete(preferences, pref_name);
+  else
+    preferences += ([ pref_name: pref_value ]);
 
-    if(userp(this_object()))
-        this_object()->save_body();
-
-    return 1;
+  return 1;
 }
 
-varargs string query_pref(string pref_name, string def) {
-    if(!preferences)
-        init_env();
+/**
+ * Queries the value of a preference, returning a default when the
+ * preference is unset.
+ *
+ * @param {string} pref_name - The name of the preference.
+ * @param {string} [def] - The value to return when the preference is unset.
+ * @returns {string} The stored value, or def when the preference is unset.
+ */
+public varargs string query_pref(string pref_name, string def) {
+  if(!preferences)
+    init_env();
 
-    if(preferences[pref_name]) return preferences[pref_name];
-    else return def;
+  if(preferences[pref_name])
+    return preferences[pref_name];
+  else
+    return def;
 }
 
-mapping list_pref() {
-    return copy(preferences);
+/**
+ * Returns a copy of all preferences for this living.
+ *
+ * @returns {([ string: string ])} A copy of the preferences mapping.
+ */
+public mapping list_pref() {
+  return copy(preferences);
 }

--- a/std/living/include/body.h
+++ b/std/living/include/body.h
@@ -2,13 +2,14 @@
 #define __BODY_H__
 
 void rehash_capacity();
-void die();
-varargs int move_living(mixed dest, string dir, string depart_message, string arrive_message);
-int query_log_level();
-string *query_body_slots();
-string *query_weapon_slots();
-void set_su_body(object source);
-object query_su_body();
-void clear_su_body();
+protected void die();
+public varargs int move_living(mixed dest, string dir, string depart_message, string arrive_message);
+public int query_log_level();
+public int is_able();
+protected string *query_body_slots();
+protected string *query_weapon_slots();
+public void set_su_body(object source);
+public object query_su_body();
+public void clear_su_body();
 
 #endif // __BODY_H__

--- a/std/living/include/env.h
+++ b/std/living/include/env.h
@@ -1,12 +1,12 @@
 #ifndef __ENV_H__
 #define __ENV_H__
 
-int init_env() ;
-int set_env(string var_name, string var_value) ;
-varargs mixed query_env(string var_name, mixed def) ;
-mapping list_env() ;
-int set_pref(string pref_name, string pref_value) ;
-varargs string query_pref(string pref_name, string def) ;
-mapping list_pref() ;
+protected void init_env();
+public int set_env(string var_name, string var_value);
+public varargs mixed query_env(string var_name, mixed def);
+public mapping list_env();
+public int set_pref(string pref_name, string pref_value);
+public varargs string query_pref(string pref_name, string def);
+public mapping list_pref();
 
 #endif // __ENV_H__

--- a/std/living/include/player.h
+++ b/std/living/include/player.h
@@ -17,7 +17,7 @@ void set_environ_option(string key, mixed value) ;
 void receive_environ(string var, mixed value) ;
 void set_environ(mapping data) ;
 void restore_body() ;
-void save_inventory() ;
+int save_inventory() ;
 void restore_inventory() ;
 void wipe_inventory() ;
 int save_body() ;

--- a/std/living/player.c
+++ b/std/living/player.c
@@ -27,16 +27,14 @@ private int __last_login = 0;
 private int __ed_setup = 0;
 
 /**
- * Initialises the player body with default values and
- * preferences. Called during the login process to prepare the
- * body for play.
+ * Initialises the player body with default values and preferences. Called
+ * during the login process to prepare the body for play.
  *
  * @public
  */
 void setup_body() {
   set_living_name(query_real_name());
   set_id(({query_real_name()}));
-  set_heart_beat(mud_config("DEFAULT_HEART_RATE"));
   !query_race() && set_race(mud_config("DEFAULT_RACE"));
   !query_level() && set_level(1.0);
   !query_env("cwd") && set_env("cwd", "/doc");
@@ -52,8 +50,11 @@ void setup_body() {
   update_regen_interval();
   set_log_prefix(sprintf("(%O)", this_object()));
 
+  add_hb(save_body);
   slot(SIG_SYS_CRASH, "on_crash");
   slot(SIG_PLAYER_ADVANCED, "on_advance");
+
+  set_heart_beat(mud_config("DEFAULT_HEART_RATE"));
 }
 
 /**
@@ -174,10 +175,12 @@ void net_dead() {
  * @public
  */
 void reconnect() {
-  restore_body();
   set_last_login(time());
   tell("You have reconnected to your body.\n");
-  if(environment()) tell_them(query_name() + " has reconnected.\n");
+
+  if(environment())
+    tell_them(query_name() + " has reconnected.\n");
+
   remove_extra_short("link_dead");
   /* reconnection logged in login object */
 }
@@ -389,29 +392,48 @@ void set_environ(mapping data) {
 }
 
 /**
- * Serialises the player's inventory to a file for later
- * restoration. Requires admin privileges or self-call.
+ * Serialises the player's inventory to a file for later restoration. Requires
+ * admin privileges or self-call.
  *
  * @public
+ * @returns Returns 0 or 1 for failure or success.
  */
-void save_inventory() {
+int save_inventory() {
   string save;
 
-  if(!has_role(query_privs(previous_object() ? previous_object() : this_body()), "admin") && this_body() != this_object()) return 0;
+  if(
+    !has_role(query_privs(previous_object() ? previous_object() : this_body()), "admin")
+    && this_body() != this_object()
+    && origin() != ORIGIN_LOCAL
+  )
+    return 0;
 
   save = save_to_string(1);
-  write_file(user_inventory_data(query_privs(this_object())), save, 1);
+
+  int result = write_file(
+    user_inventory_data(query_privs()),
+    save,
+    1
+  );
+
+  return result;
 }
 
 /**
- * Restores the player body's saved variables from the save
- * file. Requires admin privileges or self-call.
+ * Restores the player body's saved variables from the save file. Requires
+ * admin privileges or self-call.
  *
  * @public
  */
 void restore_body() {
-  if(!has_role(query_privs(previous_object() ? previous_object() : this_body()), "admin") && this_body() != this_object()) return 0;
-  if(has_role(query_privs(previous_object()), "admin") || query_privs(previous_object()) == this_body()->query_real_name()) restore_object(user_body_data(query_real_name()));
+  if(
+    !has_role(query_privs(previous_object() ? previous_object() : this_body()), "admin")
+    && this_body() != this_object()
+    && origin() != ORIGIN_LOCAL
+  )
+    return;
+
+  restore_object(user_body_data(query_real_name()));
 }
 
 /**
@@ -425,7 +447,12 @@ void restore_inventory() {
   string e;
   string file, data;
 
-  if(!has_role(query_privs(previous_object() ? previous_object() : this_body()), "admin") && this_body() != this_object()) return 0;
+  if(
+    !has_role(query_privs(previous_object() ? previous_object() : this_body()), "admin")
+    && this_body() != this_object()
+  ) {
+    return 0;
+  }
 
   file = user_inventory_data(query_privs(this_object()));
 
@@ -472,9 +499,11 @@ void wipe_inventory() {
 int save_body() {
   int result;
 
-  if(!has_role(query_privs(previous_object() ? previous_object() : this_body()), "admin")
+  if(
+    !has_role(query_privs(previous_object() ? previous_object() : this_body()), "admin")
     && this_body() != this_object()
-    && base_name(previous_object()) != CMD_QUIT
+    && (previous_object() && base_name(previous_object()) != CMD_QUIT)
+    && origin() != ORIGIN_LOCAL
   ) {
     return 0;
   }

--- a/std/object/heartbeat.c
+++ b/std/object/heartbeat.c
@@ -60,9 +60,6 @@ void remove_hb(mixed f) {
 protected evaluate_heart_beat() {
   int i, sz;
 
-  if(userp())
-    return;
-
   for(i = 0, sz = sizeof(hb_events); i < sz; i++) {
     hb_events[i][0]++;
     if(hb_events[i][0] >= hb_events[i][1]) {
@@ -76,7 +73,7 @@ protected evaluate_heart_beat() {
 
         catch {
           f = bind(hb_events[i][2], this_object());
-          f();
+          evaluate(f);
         };
       }
 


### PR DESCRIPTION
## Consolidate save triggers and apply coding style to living subsystem

Removes scattered `save_body()` calls from `set_level()`, `adjust_level_mod()`, `adjust_xp()`, and `move()` in favour of a single periodic save registered via `add_hb(save_body)` during `setup_body()`. This prevents redundant disk writes on every stat change or movement.

Removes the early return in `evaluate_heart_beat()` that prevented heartbeat events from firing on player objects, and replaces direct function invocation with `evaluate()` when calling bound heartbeat functions, allowing player heartbeats to run correctly.

Tightens access control across `body.c` and `env.c` by adding explicit `public` and `protected` modifiers to functions that previously had none, and updates the corresponding header prototypes in `body.h` and `env.h` to match.

Simplifies `restore_body()` by removing the redundant double privilege check, and adds `origin() != ORIGIN_LOCAL` guards to `save_body()`, `save_inventory()`, and `restore_body()` so internal calls are always permitted regardless of caller identity.

Changes `save_inventory()` from `void` to `int` so callers can inspect whether the write succeeded.

Moves `set_heart_beat()` to after signal slots and the heartbeat callback are registered in `setup_body()`, and removes the `restore_body()` call from `reconnect()` since body state is now restored earlier in the login sequence.

save_body() through every function was interfering with inventory loading, since a player wouldn't have any inventory until after load_inventory() ran, rewriting it to an empty file, therefore restoring nothing.

The usual MUD convention is to save periodically, usually on `heart_beat()`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates player persistence into the heartbeat path and cleans up the living subsystem. The main changes are:

- Periodic player body saving through heartbeat callbacks.
- Fewer direct save calls from movement, advancement, and preference updates.
- Updated save and restore access guards for local calls.
- Player heartbeat callback execution enabled.
- Living body and environment APIs marked with explicit access modifiers.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["updating saving and other body related t..."](https://github.com/gesslar/oxidus-mudlib/commit/e0c3f8eeac837d4aefd4df98ada00fe4e566eeb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41841883)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))

<!-- /greptile_comment -->