### PR TITLE
remove debug log statement and untrack 0debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Log files
-0debug.log
 log
 !/doc/driver/efun/floats/log
 !/doc/driver/efun/all/log

--- a/d/tunnels/tunnels_daemon.c
+++ b/d/tunnels/tunnels_daemon.c
@@ -151,7 +151,6 @@ public void setup_exits(object room, string file) {
   if(!coords)
     return;
 
-  debug("coords: %O", coords);
   // string room_type = get_room_type(coords[0], coords[1], coords[2]);
   mapping exits = get_exits(coords[0], coords[1], coords[2]);
 


### PR DESCRIPTION
Removes a debug log statement from the tunnels daemon and cleans up the `.gitignore` by removing the `0debug.log` entry.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes a tunnel debug log and updates ignored log files.

- Removed a `debug()` call from `setup_exits()` in the tunnels daemon.
- Removed `0debug.log` from `.gitignore`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (4): Last reviewed commit: ["cleanup"](https://github.com/gesslar/oxidus-mudlib/commit/6883d4e98f29a02e4272b8a24fe141a9a9b89188) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41841888)</sub>

<!-- /greptile_comment -->