### PR TITLE
add 'wear all' and 'remove all' support, fix equipment variable naming, and improve action messaging

### DIFF
--- a/cmds/action/remove.c
+++ b/cmds/action/remove.c
@@ -4,10 +4,11 @@
  * Command to remove worn items.
  *
  * @created 2024-07-26 - Gesslar
- * @last_modified 2024-07-26 - Gesslar
+ * @last_modified 2026-07-04 - Gesslar
  *
  * @history
  * 2024-07-26 - Gesslar - Created
+ * 2026-07-04 - Gesslar - Added 'remove all' support
  */
 
 inherit STD_ACT;
@@ -20,36 +21,81 @@ void setup() {
     usage_text = "remove <item>";
 }
 
-mixed main(/** @type {STD_BODY} */ object tp,
-    string str) {
-    object ob;
-    string slot;
-    string *slots;
-    string *items;
-    int i;
-    mixed result;
+private mixed remove_all(object tp);
 
-    if(!ob = find_target(tp, str, tp))
-        return "You do not have that item.";
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+    string str
+  ) {
 
-    slot = ob->query_slot();
-    if(nullp(slot))
-        return "That item cannot be removed.";
+  /** @type {STD_CLOTHING | STD_ARMOUR} */ object ob;
+  string slot;
+  mixed result;
 
-    if(tp->equipped_on(slot) != ob)
-        return "You are not wearing that item.";
+  if(str == "all")
+    return remove_all(tp);
 
-    result = ob->can_unequip(tp);
-    if(stringp(result))
-        return result;
+  if(!ob = find_target(tp, str, tp))
+    return "You do not have that item.";
+
+  slot = ob->query_slot();
+  if(nullp(slot))
+    return "That item cannot be removed.";
+
+  if(tp->equipped_on(slot) != ob)
+    return "You are not wearing that item.";
+
+  result = ob->can_unequip(tp);
+  if(stringp(result))
+    return result;
+
+  if(result == 0)
+    return "You cannot remove that item.";
+
+  result = ob->unequip(tp, 0);
+  if(stringp(result))
+    return result;
+
+  if(result == 0)
+    return "You cannot remove that item.";
+
+  return 1;
+}
+
+private mixed remove_all(
+  /** @type {STD_BODY} */ object tp
+) {
+  object all = tp->query_wielded() + tp->query_equipped();
+
+  int removed = 0;
+
+  foreach(string _, /** @type {STD_WEAPON | STD_ARMOUR | STD_CLOTHING} */ object ob in all) {
+    mixed result = ob->can_unequip(tp);
+
+    if(stringp(result)) {
+      tell(tp, result);
+
+      continue;
+    }
+
     if(result == 0)
-        return "You cannot remove that item.";
+      continue;
 
-    result = ob->unequip();
-    if(stringp(result))
-        return result;
+    result = ob->unequip(tp, 0);
+    if(stringp(result)) {
+      tell(tp, result);
+
+      continue;
+    }
+
     if(result == 0)
-        return "You cannot remove that item.";
+      continue;
 
-    return 1;
+    removed++;
+  }
+
+  if(removed)
+    return "You remove everything.";
+
+  return 1;
 }

--- a/cmds/action/unwield.c
+++ b/cmds/action/unwield.c
@@ -62,7 +62,7 @@ mixed main(/** @type {STD_BODY} */ object tp, string str) {
     if(!ob->is_weapon())
       return "You can only unwield weapons.";
 
-    if(!tp->has_wielded(ob))
+    if(!tp->equipped(ob))
       return "You are not wielding that weapon.";
   }
 

--- a/cmds/action/wear.c
+++ b/cmds/action/wear.c
@@ -22,10 +22,15 @@ void setup() {
    usage_text = "wear <item>";
 }
 
+private mixed wear_all(object tp);
+
 mixed main(/** @type {STD_BODY} */ object tp, string str) {
   /** @type {STD_CLOTHING | STD_ARMOUR} */ object ob;
   string slot;
   mixed result;
+
+  if(str == "all")
+    return wear_all(tp);
 
   if(!ob = find_target(tp, str, tp))
     return "You do not have that item.";
@@ -59,5 +64,45 @@ mixed main(/** @type {STD_BODY} */ object tp, string str) {
   if(result == 0)
     return "You cannot wear that item.";
 
-  return "You wear the "+get_short(ob)+".";
+  tp->simple_action("$N $vput on a $o.", ob);
+
+  return 1;
+}
+
+private mixed wear_all(/** @type {STD_BODY} */ object tp) {
+  int num = 0;
+
+  foreach(/** @type {STD_CLOTHING | STD_ARMOUR} */ object ob in all_inventory(tp)) {
+    string slot;
+    mixed result;
+
+    if(!ob->is_armour() && !ob->is_clothing())
+      continue;
+
+    slot = ob->query_slot();
+
+    if(nullp(slot))
+      continue;
+
+    if(!tp->module("race", "query_equipment_slots", slot))
+      continue;
+
+    if(tp->equipped_on(slot))
+      continue;
+
+    result = ob->can_equip(slot, tp);
+    if(stringp(result) || result == 0)
+      continue;
+
+    result = ob->equip(tp, slot);
+    if(stringp(result) || result == 0)
+      continue;
+
+    tp->simple_action("$N $vput on a $o.", ob);
+    num++;
+  }
+
+  return num
+    ? 1
+    : "You found nothing to put on.";
 }

--- a/std/equip/weapon.c
+++ b/std/equip/weapon.c
@@ -215,7 +215,7 @@ varargs int unequip(object tp, int silent) {
     return 0;
 
   if(!silent)
-    tp->simple_action("$N $vunwield $o.", get_short());
+    tp->simple_action("$N $vunwield $p $o.", get_short());
 
   GMCP_D->send_gmcp(tp, GMCP_PKG_CHAR_ITEMS_UPDATE, ({ this_object(), tp }));
 

--- a/std/living/equipment.c
+++ b/std/living/equipment.c
@@ -18,24 +18,24 @@
  */
 
 /** @type ([ string: Wearable ]) */
-protected nosave mapping _equipment = ([ ]);
+protected nosave mapping __equipment = ([ ]);
 
 /** @type ([ string: Wieldable ]) */
-protected nosave mapping _wielded = ([ ]);
+protected nosave mapping __wielded = ([ ]);
 
 /**
  * Query all equipped items.
  *
  * @returns {([ string: Wieldable|Wearable ])} A copy of the equipment mapping
  */
-public mapping query_equipped() { return copy(_equipment); }
+public mapping query_equipped() { return copy(__equipment); }
 
 /**
  * Query all wielded items.
  *
  * @returns {([ string: STD_WEAPON ])} A copy of the wielded mapping
  */
-public mapping query_wielded() { return copy(_wielded); }
+public mapping query_wielded() { return copy(__wielded); }
 
 /**
  * Query what item is equipped on a specific slot.
@@ -43,7 +43,7 @@ public mapping query_wielded() { return copy(_wielded); }
  * @param {string} slot - The slot to check
  * @returns {Wearable|STD_WEAPON} The equipped item or null if slot is empty
  */
-public object equipped_on(string slot) { return _equipment[slot] || null ; }
+public object equipped_on(string slot) { return __equipment[slot] || null ; }
 
 /**
  * Query what item is wielded in a specific slot.
@@ -51,7 +51,7 @@ public object equipped_on(string slot) { return _equipment[slot] || null ; }
  * @param {string} slot - The slot to check
  * @returns {STD_WEAPON} The wielded item or null if slot is empty
  */
-public object wielded_in(string slot) { return _wielded[slot] || null ; }
+public object wielded_in(string slot) { return __wielded[slot] || null ; }
 
 /**
  * Attempt to equip an item.
@@ -84,10 +84,10 @@ public int equipped(object ob) {
     return 0;
 
   if(has(ob, "is_weapon"))
-    return includes(values(_wielded), ob);
+    return includes(values(__wielded), ob);
 
   else if(has(ob, "is_armour") || has(ob, "is_clothing"))
-    return includes(values(_equipment), ob);
+    return includes(values(__equipment), ob);
 
   return 0;
 }
@@ -123,13 +123,13 @@ mixed can_equip(mixed ob, string slot) {
     if(has(ob, "is_weapon")) {
       int hands = /** @type {STD_WEAPON} */ (ob)->query_hands();
       string *all_weapon_slots = query_weapon_slots();
-      mapping w = filter(_wielded, (: objectp($2) :));
+      mapping w = filter(__wielded, (: objectp($2) :));
       int remaining_slots = sizeof(all_weapon_slots) - sizeof(w);
 
       if(!of(slot, all_weapon_slots))
         return "You cannot wield that there.";
 
-      if(_wielded[slot])
+      if(__wielded[slot])
         return "You are already wielding something in that hand.";
 
       if(remaining_slots < hands)
@@ -147,7 +147,7 @@ mixed can_equip(mixed ob, string slot) {
   if(!of(slot, query_body_slots()))
     return "Your body cannot wear something in there.";
 
-  if(_equipment[slot])
+  if(__equipment[slot])
     return "You are already wearing something like that.";
 
   return 1;
@@ -161,7 +161,7 @@ mixed can_equip(mixed ob, string slot) {
  */
 protected int equip_weapon(object weapon, string slot) {
   int slots = weapon->query_hands();
-  mapping w = filter(_wielded, (: !objectp($2) :));
+  mapping w = filter(__wielded, (: !objectp($2) :));
   string *all_weapon_slots = query_weapon_slots();
   int sz = sizeof(all_weapon_slots);
 
@@ -170,8 +170,8 @@ protected int equip_weapon(object weapon, string slot) {
     return 0;
   }
 
-  if(_wielded[slot]) {
-    printf("Slot %s already occupied by %O\n", slot, _wielded[slot]);
+  if(__wielded[slot]) {
+    printf("Slot %s already occupied by %O\n", slot, __wielded[slot]);
     return 0;
   }
 
@@ -183,14 +183,14 @@ protected int equip_weapon(object weapon, string slot) {
     return 0;
   }
 
-  _wielded[slot] = weapon;
-  all_weapon_slots -= keys(_wielded);
+  __wielded[slot] = weapon;
+  all_weapon_slots -= keys(__wielded);
 
   if(slots > 1) {
     while(--slots) {
       string s = element_of(all_weapon_slots);
 
-      _wielded[s] = weapon;
+      __wielded[s] = weapon;
       all_weapon_slots -= ({ s });
     }
   }
@@ -208,10 +208,10 @@ protected int equip_wearable(object wearable, string slot) {
   if(!of(slot, query_body_slots()))
     return 0;
 
-  if(_equipment[slot])
+  if(__equipment[slot])
     return 0;
 
-  _equipment[slot] = wearable;
+  __equipment[slot] = wearable;
 
   return 1;
 }
@@ -223,8 +223,8 @@ protected int equip_wearable(object wearable, string slot) {
  * @returns {int} 1 for success, 0 for failure
  */
 protected int unequip_weapon(object ob) {
-  if(includes(values(_wielded), ob)) {
-    _wielded = filter(_wielded, (: $2 != $(ob) :));
+  if(includes(values(__wielded), ob)) {
+    __wielded = filter(__wielded, (: $2 != $(ob) :));
 
     return 1;
   }
@@ -239,8 +239,8 @@ protected int unequip_weapon(object ob) {
  * @returns {int} 1 for success, 0 for failure
  */
 protected int unequip_wearable(object ob) {
-  if(includes(values(_equipment), ob)) {
-    _equipment = filter(_equipment, (: $2 != $(ob) :));
+  if(includes(values(__equipment), ob)) {
+    __equipment = filter(__equipment, (: $2 != $(ob) :));
 
     return 1;
   }


### PR DESCRIPTION
### TL;DR

Added `wear all` and `remove all` command support, fixed action messaging for wear/unwield, and renamed internal equipment mapping variables.

### What changed?

- `wear` command now supports `wear all`, which iterates inventory and equips all valid, unworn armour and clothing items. The success message was also changed from a direct return string to using `simple_action` for proper room-wide messaging.
- `remove` command now supports `remove all`, which unequips all currently worn and wielded items in a single command.
- `unwield` command now uses `tp->equipped(ob)` instead of `tp->has_wielded(ob)` to check if a weapon is currently wielded.
- The unequip message for weapons now includes the possessive pronoun (`$p`) so it reads as "unwields their weapon" rather than "unwields weapon."
- Internal equipment and wielded mappings in `std/living/equipment.c` were renamed from `_equipment`/`_wielded` to `__equipment`/`__wielded`.

### How to test?

1. Pick up multiple wearable items and type `wear all` — all valid, unoccupied slots should be filled and room messaging should appear for each item worn.
2. While wearing multiple items, type `remove all` — all worn and wielded items should be removed at once.
3. Wield a weapon and type `unwield <weapon>` to confirm the check still works correctly.
4. Wield and then unwield a weapon and verify the unwield message includes the correct possessive pronoun.

### Why make this change?

Players previously had to wear and remove items one at a time, which was tedious when managing multiple pieces of equipment. The `all` variants streamline this workflow. The internal variable rename avoids potential naming conflicts with single-underscore prefixed variables in inherited objects. The messaging fixes ensure consistent, grammatically correct output to the room.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds bulk equipment commands and updates equipment handling messages. The main changes are:

- Adds `wear all` for equipping valid carried armour and clothing.
- Adds `remove all` for unequipping worn and wielded items.
- Updates wear and unwield room messages.
- Switches unwield checks to the shared equipped lookup.
- Renames internal equipment mappings in living equipment state.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (3): Last reviewed commit: ["fixing some equip things"](https://github.com/gesslar/oxidus-mudlib/commit/43920097e0ba58a63acd75e2d86e195b80929711) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41847403)</sub>

<!-- /greptile_comment -->