### PR TITLE
add wipe_balance and remove_account to bank daemon, integrate with awipe and nuke

### DIFF
--- a/adm/daemons/bank.c
+++ b/adm/daemons/bank.c
@@ -1,18 +1,20 @@
 /**
  * @file /adm/daemons/bank.c
  *
- * Bank daemon responsible for managing player bank accounts,
- * including creation, balance queries, deposits/withdrawals,
- * and transaction activity history.
+ * Bank daemon responsible for managing player bank accounts,  including
+ * creation, balance queries, deposits/withdrawals, wiping, removal, and
+ * transaction activity history.
  *
  * @created 2024-02-28 - Gesslar
- * @last_modified 2026-05-02 - Gesslar
+ * @last_modified 2026-07-04 - Gesslar
  *
  * @history
- * 2026-05-02 - Gesslar - Drop dead DB-error string checks; DB_D
- *                        no longer returns strings on failure
- * 2026-03-30 - Gesslar - Refactored to use DB_D REST interface
  * 2024-02-28 - Gesslar - Created
+ * 2026-03-30 - Gesslar - Refactored to use DB_D REST interface
+ * 2026-05-02 - Gesslar - Drop dead DB-error string checks; DB_D no longer
+ *                        returns strings on failure
+ * 2026-07-04 - Gesslar - Add wipe_balance and remove_account for clearing and
+ *                        deleting player bank accounts
  */
 
 inherit STD_DAEMON;
@@ -22,13 +24,15 @@ public mixed new_account(string name);
 public mixed query_balance(string name);
 public mixed add_balance(string name, int amount);
 public varargs mixed query_activity(string name, int limit);
+public mixed wipe_balance(string name);
+public mixed remove_account(string name, object caller);
 
 /**
  * Creates a new bank account for the given name.
  *
  * @param {string} name - The name of the account holder
- * @returns {mixed} 1 if the account was created, or
- *                  "Account already exists." if it does
+ * @returns {mixed} 1 if the account was created, or "Account already exists."
+ *  if it does
  */
 public mixed new_account(string name) {
   name = capitalize(lower_case(name));
@@ -75,11 +79,9 @@ public mixed query_balance(string name) {
  * account.
  *
  * @param {string} name - The name of the account holder
- * @param {int} amount - The amount to add (positive) or
- *                       subtract (negative)
- * @returns {mixed} 1 on success, "Account does not exist." if
- *                  the account is missing, or "Insufficient
- *                  funds." if the new balance would be negative
+ * @param {int} amount - The amount to add (positive) or subtract (negative)
+ * @returns {mixed} 1 on success, "Account does not exist." if the account is
+ *  missing, or "Insufficient funds." if the new balance would be negative
  */
 public mixed add_balance(string name, int amount) {
   mixed current_balance;
@@ -110,16 +112,76 @@ public mixed add_balance(string name, int amount) {
 }
 
 /**
+ * Wipes the balance of the given account back to zero, logging
+ * the removed amount as activity.
+ *
+ * @param {string} name - The name of the account holder
+ * @returns {mixed} 1 on success, or "Account does not exist." if the account
+ *  is missing
+ */
+public mixed wipe_balance(string name) {
+  mixed current_balance;
+
+  name = capitalize(lower_case(name));
+  current_balance = query_balance(name);
+
+  if(nullp(current_balance))
+    return "Account does not exist.";
+
+  DB_D->rest("PUT", "db://bank/balance?name="+name, ([
+    "time": time(),
+    "amount": 0,
+  ]));
+
+  DB_D->rest("POST", "db://bank/activity", ([
+    "name": name,
+    "time": time(),
+    "amount": -current_balance,
+  ]));
+
+  return 1;
+}
+
+/**
+ * Removes the given account entirely, deleting both its balance and all of its
+ * activity history.
+ *
+ * @param {string} name - The name of the account holder
+ * @param {STD_PLAYER} caller - The person maybe who called this.
+ * @returns {mixed} 1 on success, or "Account does not exist." if the account
+ *  is missing
+ */
+public mixed remove_account(string name, object caller) {
+  name = capitalize(lower_case(name));
+
+  if(nullp(query_balance(name)))
+    return "Account does not exist.";
+
+  string result;
+
+  result = DB_D->rest("DELETE", "db://bank/balance?name="+name);
+  if(stringp(result) && objectp(caller) && interactive(caller))
+    tell(caller, result);
+
+  result = DB_D->rest("DELETE", "db://bank/activity?name="+name);
+  if(stringp(result) && objectp(caller) && interactive(caller))
+    tell(caller, result);
+
+  return 1;
+}
+
+/**
  * Retrieves the recent activity for the given account.
  *
  * @param {string} name - The name of the account holder
- * @param {int} [limit=10] - The maximum number of recent
- *                           activities to retrieve
- * @returns {mixed} An array of recent activities, or null if
- *                  there are none
+ * @param {int} [limit=10] - The maximum number of recent activities to
+ *  retrieve
+ * @returns {mixed} An array of recent activities, or null if there are none
  */
-public varargs mixed query_activity(string name,
-  int limit: (: 10 :)) {
+public varargs mixed query_activity(
+  string name,
+  int limit: (: 10 :)
+) {
   mixed result;
 
   name = capitalize(lower_case(name));

--- a/adm/daemons/db.c
+++ b/adm/daemons/db.c
@@ -190,8 +190,10 @@ public mixed query(string db, string q, mixed *callback) {
   mixed rows, *result = ({});
 
   if(!db || !q) {
-    log_file("system/db",
-      "Invalid call: missing db or query.\n");
+    log_file(
+      "system/db",
+      "Invalid call: missing db or query.\n"
+    );
     return 0;
   }
 

--- a/cmds/adm/awipe.c
+++ b/cmds/adm/awipe.c
@@ -62,6 +62,9 @@ void confirm_awipe(string str, object caller, string account) {
       }
     }
 
+    _info(caller, "Removing bank account for user '%s'.", capitalize(character));
+    BANK_D->remove_account(character, caller);
+
     string user_dir = user_data_directory(character);
     if(directory_exists(user_dir)) {
       mixed err;

--- a/cmds/adm/nuke.c
+++ b/cmds/adm/nuke.c
@@ -61,6 +61,9 @@ void confirm_nuke(string str, object caller, string user) {
     ACCOUNT_D->remove_character(account_name, user);
   }
 
+  _info(caller, "Removing bank account for user '%s'.", capitalize(user));
+  BANK_D->remove_account(user, caller);
+
   string user_dir = user_data_directory(user);
   if(directory_exists(user_dir)) {
     mixed err;


### PR DESCRIPTION
Adds `wipe_balance` and `remove_account` functions to the bank daemon. `wipe_balance` resets an account's balance to zero and logs the removed amount as a negative activity entry. `remove_account` deletes an account's balance and full activity history entirely.

Both the `awipe` and `nuke` admin commands now call `remove_account` as part of their cleanup process, ensuring bank accounts are properly removed when a character is wiped or nuked.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds bank-account cleanup to player wipe and nuke flows. The main changes are:

- New bank daemon helpers for wiping balances and removing accounts.
- Bank account removal during `awipe` cleanup.
- Bank account removal during `nuke` cleanup.
- Minor formatting cleanup in the DB daemon.

<h3>Confidence Score: 4/5</h3>

This is close, but the remaining cleanup gap should be fixed before merging.

- Account removal can skip transaction-history cleanup when the balance row is already missing.
- The wipe and nuke flows continue after that return, so stale bank activity can remain for a deleted character.

adm/daemons/bank.c

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aadm%2Fdaemons%2Fbank.c%3A157-158%0A**Activity%20Cleanup%20Skipped**%0A%0AWhen%20the%20balance%20row%20is%20already%20gone%20but%20%60bank%2Factivity%60%20still%20has%20rows%20for%20this%20name%2C%20this%20branch%20returns%20before%20the%20activity%20delete%20runs.%20The%20new%20wipe%20and%20nuke%20flows%20can%20then%20delete%20the%20character%20while%20leaving%20the%20transaction%20history%20behind%2C%20and%20a%20later%20character%20with%20the%20same%20name%20can%20see%20those%20old%20activity%20rows.%20Account%20removal%20should%20still%20clear%20activity%20for%20the%20name%20when%20the%20balance%20row%20is%20missing.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=265&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (6): Last reviewed commit: ["add bank wiping"](https://github.com/gesslar/oxidus-mudlib/commit/45687996e0031a401f81973308c109af110576c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41852878)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))

<!-- /greptile_comment -->