### PR TITLE
add self-access rules for /data/users and /adm/etc, fix owns_path for both paths

### DIFF
--- a/adm/etc/default.lpml
+++ b/adm/etc/default.lpml
@@ -16,7 +16,9 @@
   FIRST_USER: "adm/custom/first_user",
   TLS_CERT: "adm/custom/certs/cert.pem",
   TLS_KEY: "adm/custom/certs/key.pem",
-  SECURITY_ENFORCE_PATHS: false,
+  // Path-access enforcement is ON by default. Set to false in
+  // adm/custom/config.lpml to run in shadow mode (log-only, permits all).
+  SECURITY_ENFORCE_PATHS: true,
   LOOK_HIGHLIGHT: "on",
   LOOK_HIGHLIGHT_COLOUR: "669",
   COLOUR_TOO_DARK: "on",

--- a/adm/etc/security/access.lpml
+++ b/adm/etc/security/access.lpml
@@ -19,7 +19,10 @@
 [
   { path: "/tmp/**",      read: "all",             write: "all", },
   { path: "/log/**",      read: "role:admin",      write: "role:admin", },
+  { path: "/data/users/*/*/**", read: "self",       write: "self", },
   { path: "/data/**",     read: "role:admin",      write: "role:admin", },
+  { path: "/adm/etc/secret/**", read: "role:admin", write: "role:admin", },
+  { path: "/adm/etc/**",  read: "all",             write: "role:admin", },
   { path: "/adm/**",      read: "role:admin",      write: "role:admin", },
   { path: "/home/*/*/**", read: "all",             write: "self", },
   { path: "/doc/**",      read: "all",             write: "role:developer", },

--- a/adm/obj/master/security.c
+++ b/adm/obj/master/security.c
@@ -720,9 +720,10 @@ private nomask string glob_to_regex(string pattern) {
 }
 
 /**
- * Returns 1 if the identity owns the home path of the file: either the
- * player named in the third segment of /home/<x>/<name>/..., or the
- * matching [home_<name>] code identity.
+ * Returns 1 if the identity owns the path: either the name in the owner
+ * segment of /home/<x>/<name>/... or /data/users/<x>/<name>/... (a player
+ * writing their own home or save data), or the matching [home_<name>]
+ * code identity.
  *
  * @param {string} privs - The caller's privs string.
  * @param {string} file - The target file path.
@@ -734,7 +735,8 @@ private nomask int owns_path(string privs, string file) {
   if(!stringp(privs) || !truthy(privs))
     return 0;
 
-  if(sscanf(file, "/home/%*s/%s/%*s", owner) != 1)
+  if(sscanf(file, "/home/%*s/%s/%*s", owner) != 3 &&
+     sscanf(file, "/data/users/%*s/%s/%*s", owner) != 3)
     return 0;
 
   if(privs == owner)


### PR DESCRIPTION
Adds access control rules for `/data/users` and `/adm/etc`, and updates `owns_path` to recognize `/data/users/<x>/<name>/...` as a self-owned path.

Users can now read and write their own save data under `/data/users/*/*/**`. The `/adm/etc` directory is readable by all but writable only by admins, with `/adm/etc/secret` restricted to admin read and write. Previously, `owns_path` only checked `/home` paths for self-ownership; it now also checks `/data/users` paths so the `self` permission on that route resolves correctly.

Path-access enforcement (`SECURITY_ENFORCE_PATHS`) is now **on** by default. To run in shadow mode (log-only, permits all), set it to `false` in `adm/custom/config.lpml`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates path-access enforcement and self-owned path handling. The main changes are:

- Path enforcement now defaults to on.
- `/data/users` gets self read and write rules.
- `/adm/etc` gets public read and admin write rules.
- `owns_path()` now checks `/data/users/<x>/<name>/...` paths.

<h3>Confidence Score: 4/5</h3>

This is close, but the changed access-control paths should be checked against the existing review feedback before merging.

- The latest changes are concentrated in path matching and enforcement.
- The remaining concerns overlap with already reported access-rule and self-ownership behavior.
- No new distinct follow-up finding cleared the reporting bar.

adm/obj/master/security.c and adm/etc/security/access.lpml

<sub>Reviews (7): Last reviewed commit: ["flipping the sec switch"](https://github.com/gesslar/oxidus-mudlib/commit/00dc4e23b5936c5d011171ab3dab0efcc4abe51c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41852882)</sub>

<!-- /greptile_comment -->