### PR TITLE
add FFI package efun docs, new efun docs, and fix several efun signatures

### DIFF
--- a/doc/driver/efun/add_a
+++ b/doc/driver/efun/add_a
@@ -1,0 +1,20 @@
+
+### NAME
+
+    add_a() - prefix a string with the correct indefinite article
+
+### SYNOPSIS
+
+    string add_a( string str );
+
+### DESCRIPTION
+
+    Returns `str` with "a " or "an " prepended, choosing the article
+    from the following word's sound rather than just its first letter:
+    vowels take "an", but the special cases "us..." ("a user", "a use"),
+    "hour..." ("an hour"), and words already beginning "a "/"an " are
+    handled. A string of only spaces yields "a ".
+
+### SEE ALSO
+
+    add_a(3), vowel(3)

--- a/doc/driver/efun/cache_stats
+++ b/doc/driver/efun/cache_stats
@@ -5,7 +5,7 @@
 
 ### SYNOPSIS
 
-    void cache_stats( void );
+    string cache_stats();
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/call_stack
+++ b/doc/driver/efun/call_stack
@@ -6,7 +6,7 @@
 
 ### SYNOPSIS
 
-    string *call_stack(int option);
+    mixed *call_stack(int option);
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/debugmalloc
+++ b/doc/driver/efun/debugmalloc
@@ -5,7 +5,7 @@
 
 ### SYNOPSIS
 
-    void debugmalloc( string filename, int mask );
+    string debugmalloc( string filename, int mask );
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/disable_commands
+++ b/doc/driver/efun/disable_commands
@@ -5,16 +5,15 @@
 
 ### SYNOPSIS
 
-    int disable_commands( void );
+    void disable_commands();
 
 ### DESCRIPTION
 
     Makes a living object non-living, that is, add_actions have no effects,
     livingp returns false, and, if the object is interactive, disallows the
-    user  to type in commands other than for an input_to.  disable_commands
-    always returns 0.
+    user to type in commands other than for an input_to.
 
-    calling disable_commands() also have side-effct of clearing all actions
+    calling disable_commands() also has the side-effect of clearing all actions
     previously  added  by  other  object,  it also removes actions that was
     defined by this object.
 

--- a/doc/driver/efun/dump_file_descriptors
+++ b/doc/driver/efun/dump_file_descriptors
@@ -5,7 +5,7 @@
 
 ### SYNOPSIS
 
-    void dump_file_descriptors( void );
+    string dump_file_descriptors();
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/ffi_address
+++ b/doc/driver/efun/ffi_address
@@ -1,0 +1,18 @@
+
+### NAME
+
+    ffi_address() - raw native address of a buffer
+
+### SYNOPSIS
+
+    int ffi_address( buffer mem );
+
+### DESCRIPTION
+
+    Returns the raw native address of the first byte of `mem` as an
+    integer — for passing to C as a pointer value or for pointer
+    comparisons. The address is valid only while `mem` is alive.
+
+### SEE ALSO
+
+    ffi_alloc(3), ffi_peek(3), ffi_call(3)

--- a/doc/driver/efun/ffi_alloc
+++ b/doc/driver/efun/ffi_alloc
@@ -1,0 +1,19 @@
+
+### NAME
+
+    ffi_alloc() - allocate a native memory block as a buffer
+
+### SYNOPSIS
+
+    buffer ffi_alloc( int nbytes );
+
+### DESCRIPTION
+
+    Returns a zeroed buffer of `nbytes` bytes whose storage is the native
+    memory block itself, suitable for structs, out-parameters, and
+    pointer arguments to ffi_call(). The block is reference-counted like
+    any buffer and freed by the GC; ffi_free() releases it early.
+
+### SEE ALSO
+
+    ffi_free(3), ffi_read(3), ffi_write(3), ffi_address(3), ffi_struct_layout(3)

--- a/doc/driver/efun/ffi_call
+++ b/doc/driver/efun/ffi_call
@@ -1,0 +1,25 @@
+
+### NAME
+
+    ffi_call() - call a prepared C function
+
+### SYNOPSIS
+
+    mixed ffi_call( int func, mixed *args );
+
+### DESCRIPTION
+
+    Calls the function handle `func` returned by ffi_prepare(). `args`
+    must have exactly the prepared argument count; each element is an
+    int, a float, or a buffer (never a string — LPC strings are
+    UTF-8-native and never implicitly marshalled to char*), matching the
+    prepared argument type codes.
+
+    The return value follows `ret_type`: an int or float for scalar
+    types, a buffer for an owned FFI_POINTER result or an int address for
+    a raw foreign pointer, and 0 for FFI_VOID. Argument-count or -type
+    mismatches raise an error rather than calling C with a bad frame.
+
+### SEE ALSO
+
+    ffi_prepare(3), ffi_peek(3), ffi_alloc(3), string_encode(3), string_decode(3)

--- a/doc/driver/efun/ffi_callback
+++ b/doc/driver/efun/ffi_callback
@@ -1,0 +1,22 @@
+
+### NAME
+
+    ffi_callback() - expose an LPC function to C as a callback
+
+### SYNOPSIS
+
+    int ffi_callback( function fn, int ret_type, int *arg_types );
+
+### DESCRIPTION
+
+    Wraps the LPC function pointer `fn` in a libffi closure with the
+    given return and argument type codes (from <ffi.h>), and returns a
+    callback handle. Pass ffi_callback_addr() of that handle to C as an
+    FFI_POINTER argument so a C library (a comparator for qsort(), an
+    event handler, ...) can call back into LPC.
+
+    Gated by the master apply valid_ffi("callback", 0, caller).
+
+### SEE ALSO
+
+    ffi_callback_addr(3), ffi_callback_free(3), ffi_call(3), valid_ffi(4)

--- a/doc/driver/efun/ffi_callback_addr
+++ b/doc/driver/efun/ffi_callback_addr
@@ -1,0 +1,18 @@
+
+### NAME
+
+    ffi_callback_addr() - raw address of a callback closure
+
+### SYNOPSIS
+
+    int ffi_callback_addr( int cb );
+
+### DESCRIPTION
+
+    Returns the raw native code address of the closure for callback
+    handle `cb` (from ffi_callback()), as an integer — the value to hand
+    to C as an FFI_POINTER argument.
+
+### SEE ALSO
+
+    ffi_callback(3), ffi_callback_free(3), ffi_call(3)

--- a/doc/driver/efun/ffi_callback_free
+++ b/doc/driver/efun/ffi_callback_free
@@ -1,0 +1,18 @@
+
+### NAME
+
+    ffi_callback_free() - release a callback closure
+
+### SYNOPSIS
+
+    void ffi_callback_free( int cb );
+
+### DESCRIPTION
+
+    Releases the libffi closure for callback handle `cb`. Optional — the
+    closure is also reclaimed by the GC. Do not free a callback while C
+    still holds its address.
+
+### SEE ALSO
+
+    ffi_callback(3), ffi_callback_addr(3)

--- a/doc/driver/efun/ffi_error
+++ b/doc/driver/efun/ffi_error
@@ -1,0 +1,20 @@
+
+### NAME
+
+    ffi_error() - most recent FFI error message
+
+### SYNOPSIS
+
+    string ffi_error();
+
+### DESCRIPTION
+
+    Returns the most recent FFI error message for the current thread —
+    for example the reason a ffi_load() returned 0 — or the empty string
+    if there has been no error. Efuns on the FFI surface raise an LPC
+    error on misuse; ffi_error() reports the failures that are signalled
+    by a 0 return instead.
+
+### SEE ALSO
+
+    ffi_load(3), ffi_symbol(3), ffi_status(3)

--- a/doc/driver/efun/ffi_free
+++ b/doc/driver/efun/ffi_free
@@ -1,0 +1,18 @@
+
+### NAME
+
+    ffi_free() - free a native memory block
+
+### SYNOPSIS
+
+    void ffi_free( buffer mem );
+
+### DESCRIPTION
+
+    Releases a buffer allocated by ffi_alloc(). Optional — the block is
+    also reclaimed by the garbage collector when no LPC value references
+    it. Using `mem` after freeing it is an error.
+
+### SEE ALSO
+
+    ffi_alloc(3)

--- a/doc/driver/efun/ffi_load
+++ b/doc/driver/efun/ffi_load
@@ -1,0 +1,25 @@
+
+### NAME
+
+    ffi_load() - load a native shared library
+
+### SYNOPSIS
+
+    int ffi_load( string path );
+
+### DESCRIPTION
+
+    Opens the shared library at `path` (via dlopen/LoadLibrary) and
+    returns a positive library handle for use with ffi_symbol() and
+    ffi_prepare(). Returns 0 on failure; call ffi_error() for the reason.
+
+    An empty `path` opens the driver's own process image, giving access
+    to already-linked C symbols such as libc/libm (`sqrt`, `abs`, ...).
+
+    Every call is gated by the master apply valid_ffi("load", path,
+    caller); the default master denies it. This efun is only present when
+    the driver is built with package_ffi (`__PACKAGE_FFI__`).
+
+### SEE ALSO
+
+    ffi_symbol(3), ffi_prepare(3), ffi_unload(3), ffi_error(3), valid_ffi(4)

--- a/doc/driver/efun/ffi_peek
+++ b/doc/driver/efun/ffi_peek
@@ -1,0 +1,21 @@
+
+### NAME
+
+    ffi_peek() - copy bytes from a raw foreign address into a buffer
+
+### SYNOPSIS
+
+    buffer ffi_peek( int address, int nbytes );
+
+### DESCRIPTION
+
+    Copies `nbytes` bytes starting at the raw native `address` into a
+    fresh owned buffer. This is the only way bytes behind a foreign
+    pointer — for example a `char *` returned by a C function — become an
+    LPC value. Pass -1 for `nbytes` to copy a NUL-terminated string up to
+    an internal cap. Decode text with string_decode() once you have the
+    bytes.
+
+### SEE ALSO
+
+    ffi_call(3), ffi_symbol(3), ffi_address(3), string_decode(3)

--- a/doc/driver/efun/ffi_prepare
+++ b/doc/driver/efun/ffi_prepare
@@ -1,0 +1,22 @@
+
+### NAME
+
+    ffi_prepare() - describe a C function signature for calling
+
+### SYNOPSIS
+
+    int ffi_prepare( int lib, string name, int ret_type, int *arg_types );
+
+### DESCRIPTION
+
+    Resolves `name` in `lib`, builds the platform call frame for the
+    described signature, and returns a callable function handle for
+    ffi_call(). `ret_type` and each element of `arg_types` are type codes
+    from <ffi.h> (FFI_INT32, FFI_DOUBLE, FFI_POINTER, ...).
+
+    Gated by the master apply valid_ffi("prepare", name, caller). Errors
+    if the symbol is missing or a type code is invalid.
+
+### SEE ALSO
+
+    ffi_call(3), ffi_load(3), ffi_sizeof(3), valid_ffi(4)

--- a/doc/driver/efun/ffi_read
+++ b/doc/driver/efun/ffi_read
@@ -1,0 +1,19 @@
+
+### NAME
+
+    ffi_read() - read a typed scalar from a buffer
+
+### SYNOPSIS
+
+    mixed ffi_read( buffer mem, int offset, int type_code );
+
+### DESCRIPTION
+
+    Reads the scalar of type `type_code` (a code from <ffi.h>) stored at
+    byte `offset` within `mem`, returning an int for integer/pointer
+    types or a float for FFI_FLOAT/FFI_DOUBLE. Combine with
+    ffi_struct_layout() to read C struct fields symbolically.
+
+### SEE ALSO
+
+    ffi_write(3), ffi_struct_layout(3), ffi_sizeof(3)

--- a/doc/driver/efun/ffi_sizeof
+++ b/doc/driver/efun/ffi_sizeof
@@ -1,0 +1,18 @@
+
+### NAME
+
+    ffi_sizeof() - size of a scalar type code
+
+### SYNOPSIS
+
+    int ffi_sizeof( int type_code );
+
+### DESCRIPTION
+
+    Returns the size in bytes, on this platform, of the scalar C type
+    named by `type_code` (a code from <ffi.h>). Useful for sizing
+    ffi_alloc() blocks and computing offsets by hand.
+
+### SEE ALSO
+
+    ffi_alloc(3), ffi_struct_layout(3), ffi_read(3)

--- a/doc/driver/efun/ffi_status
+++ b/doc/driver/efun/ffi_status
@@ -1,0 +1,19 @@
+
+### NAME
+
+    ffi_status() - counts of open FFI handles
+
+### SYNOPSIS
+
+    mapping ffi_status();
+
+### DESCRIPTION
+
+    Returns a mapping of live-handle counts for introspection and leak
+    checks, with integer values under the keys "libraries" (open
+    ffi_load() handles), "functions" (prepared ffi_prepare() handles),
+    and "callbacks" (live ffi_callback() closures).
+
+### SEE ALSO
+
+    ffi_load(3), ffi_prepare(3), ffi_callback(3)

--- a/doc/driver/efun/ffi_struct_layout
+++ b/doc/driver/efun/ffi_struct_layout
@@ -1,0 +1,20 @@
+
+### NAME
+
+    ffi_struct_layout() - compute a C struct's field layout
+
+### SYNOPSIS
+
+    mixed *ffi_struct_layout( int *field_types );
+
+### DESCRIPTION
+
+    Given an array of scalar type codes (from <ffi.h>), one per struct
+    field, returns `({ total_size, ({ offset0, offset1, ... }) })`
+    honoring the platform's alignment rules. Size an ffi_alloc() block to
+    `total_size` and use the offsets with ffi_read()/ffi_write(). The
+    tools/ffi generator emits these arrays from a C header.
+
+### SEE ALSO
+
+    ffi_alloc(3), ffi_read(3), ffi_write(3), ffi_sizeof(3)

--- a/doc/driver/efun/ffi_symbol
+++ b/doc/driver/efun/ffi_symbol
@@ -1,0 +1,24 @@
+
+### NAME
+
+    ffi_symbol() - resolve a symbol to its raw address
+
+### SYNOPSIS
+
+    int ffi_symbol( int lib, string name );
+
+### DESCRIPTION
+
+    Resolves the symbol `name` in library `lib` and returns its raw
+    native address as an integer, or 0 if not found.
+
+    To *call* a C function you do not need this — use ffi_prepare(), which
+    resolves the symbol itself. ffi_symbol() is for taking the address of
+    a data symbol (read it with ffi_peek()) or of a function to pass to C
+    as an FFI_POINTER argument.
+
+    Gated by the master apply valid_ffi("symbol", name, caller).
+
+### SEE ALSO
+
+    ffi_prepare(3), ffi_peek(3), ffi_address(3), valid_ffi(4)

--- a/doc/driver/efun/ffi_unload
+++ b/doc/driver/efun/ffi_unload
@@ -1,0 +1,18 @@
+
+### NAME
+
+    ffi_unload() - release a library handle
+
+### SYNOPSIS
+
+    void ffi_unload( int lib );
+
+### DESCRIPTION
+
+    Releases a library handle returned by ffi_load(). Function handles
+    prepared from it become invalid. Libraries are also released when the
+    driver shuts down.
+
+### SEE ALSO
+
+    ffi_load(3), ffi_status(3)

--- a/doc/driver/efun/ffi_write
+++ b/doc/driver/efun/ffi_write
@@ -1,0 +1,19 @@
+
+### NAME
+
+    ffi_write() - write a typed scalar into a buffer
+
+### SYNOPSIS
+
+    void ffi_write( buffer mem, int offset, int type_code, mixed value );
+
+### DESCRIPTION
+
+    Writes `value` as the scalar type `type_code` (a code from <ffi.h>)
+    at byte `offset` within `mem`. `value` is an int for integer/pointer
+    types or a float for FFI_FLOAT/FFI_DOUBLE. Used to fill struct fields
+    and out-parameters before an ffi_call().
+
+### SEE ALSO
+
+    ffi_read(3), ffi_struct_layout(3), ffi_alloc(3)

--- a/doc/driver/efun/flush_messages
+++ b/doc/driver/efun/flush_messages
@@ -5,8 +5,8 @@
 
 ### SYNOPSIS
 
-    int flush_messages();
-    int flush_messages(object user);
+    void flush_messages();
+    void flush_messages(object user);
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/function_profile
+++ b/doc/driver/efun/function_profile
@@ -5,7 +5,7 @@
 
 ### SYNOPSIS
 
-    mixed *function_profile( object ob );
+    mapping *function_profile( object ob );
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/get_char
+++ b/doc/driver/efun/get_char
@@ -6,7 +6,7 @@
 
 ### SYNOPSIS
 
-    varargs void get_char( string | function fun, int flag, ... );
+    varargs int get_char( string | function fun, int flag, ... );
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/get_dir
+++ b/doc/driver/efun/get_dir
@@ -17,7 +17,7 @@
     If called with a second argument equal to -1, get_dir  will  return  an
     array of subarrays, where the format of each subarray is:
 
-          ({ filename, size_of_file, last_time_file_touched })
+          (\{ filename, size_of_file, last_time_file_touched \})
 
     Where  filename  is  a  string and last_time_file_touched is an integer
     being number of seconds since January 1, 1970 (same format as time(3)).

--- a/doc/driver/efun/implode
+++ b/doc/driver/efun/implode
@@ -6,14 +6,26 @@
 ### SYNOPSIS
 
     string implode( mixed *arr, string del );
+    mixed implode( mixed *arr, function f, void | mixed extra );
 
 ### DESCRIPTION
 
-    Concatenate  all  strings  found  in array 'arr', with the string 'del'
-    between each element. Only strings are used from the  array.   elements
-    that are not strings are ignored.
+    In the first form, concatenate all strings found in array 'arr', with
+    the  string  'del' between each element. Only strings are used from the
+    array; elements that are not strings are ignored.
+
+    In the second form, when the second argument is a function, implode()
+    instead  reduces  the  array: it combines the elements left to right by
+    repeatedly  calling  'f'  with the running result and the next element
+    (a fold), and returns whatever the final call returns. The optional
+    'extra' argument, when present, is used as the starting value.
+
+### RETURN VALUE
+
+    The joined string for the delimiter form, or the accumulated value
+    (any type) for the function form.
 
 ### SEE ALSO
 
-    explode(3), sprintf(3)
+    explode(3), sprintf(3), filter(3), map(3)
 

--- a/doc/driver/efun/input_to
+++ b/doc/driver/efun/input_to
@@ -6,7 +6,7 @@
 
 ### SYNOPSIS
 
-    varargs void input_to( string | function fun, int flag, ... );
+    varargs int input_to( string | function fun, int flag, ... );
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/link
+++ b/doc/driver/efun/link
@@ -5,7 +5,7 @@
 
 ### SYNOPSIS
 
-    void link( string original, string reference );
+    int link( string original, string reference );
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/malloc_status
+++ b/doc/driver/efun/malloc_status
@@ -5,7 +5,7 @@
 
 ### SYNOPSIS
 
-    void malloc_status( void );
+    string malloc_status();
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/max_eval_cost
+++ b/doc/driver/efun/max_eval_cost
@@ -5,7 +5,7 @@
 
 ### SYNOPSIS
 
-    void max_eval_cost()
+    int max_eval_cost()
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/mud_status
+++ b/doc/driver/efun/mud_status
@@ -5,7 +5,7 @@
 
 ### SYNOPSIS
 
-    void mud_status( int extra );
+    string mud_status( int extra );
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/pcre_replace_callback
+++ b/doc/driver/efun/pcre_replace_callback
@@ -1,21 +1,96 @@
 
 ### NAME
 
-    pcre_replace_callback() - string replace uses a callback to get the replace string
+    pcre_replace_callback() - replace captured groups using a callback
 
 ### SYNOPSIS
 
-    string pcre_replace_callback(string input, string pattern, string|function, mixed *args..., void|int pcre_flags);
+    string pcre_replace_callback(string subject, string pattern,
+                                 function fun,
+                                 mixed extra..., void|int pcre_flags);
+
+    string pcre_replace_callback(string subject, string pattern,
+                                 string fun, object|string ob,
+                                 mixed extra..., void|int pcre_flags);
 
 ### DESCRIPTION
 
-    returns a string where all captured groups have been replaced by the return
-    value of function pointer fun or function fun in object ob. (called with
-    the matched string and match number, starting with 0).
+    Returns a copy of `subject` in which each captured group of
+    `pattern` has been replaced by the value returned from invoking
+    `fun`.
 
-    The optional `pcre_flags` sets PCRE options (e.g., `PCRE_I` for
-    case-insensitive, `PCRE_M` for multiline). Defaults to 0.
+    The callback is called once for each capture group in the
+    pattern, left-to-right. Group 0 (the whole match) is never
+    passed. Each invocation receives:
+
+      string  matched   - the text captured by this group
+      int     index     - the 0-based index of this capture group
+                          (PCRE group 1 -> 0, group 2 -> 1, ...)
+      ...extra          - any additional arguments supplied at the
+                          call site, forwarded verbatim
+
+    The callback's return value replaces the captured text in the
+    output. If the callback returns a non-string value (including 0),
+    the original captured text is used unchanged.
+
+    When `fun` is a function pointer, no `ob` argument is supplied.
+    When `fun` is a string, the next argument must name an object
+    (either an `object` value or its filename) in which to look up
+    the function.
+
+    If `pattern` does not match `subject`, the callback is not
+    invoked and `subject` is returned unchanged.
+
+    The optional `pcre_flags` argument sets PCRE options:
+
+      PCRE_I   case-insensitive matching
+      PCRE_M   multiline (^ and $ match at line breaks)
+      PCRE_S   dotall (`.` also matches newline)
+      PCRE_U   ungreedy quantifiers
+      PCRE_X   extended (ignore unescaped whitespace and `#` comments)
+      PCRE_A   anchored matching
+
+    Flags may be combined with `|`. Defaults to 0. When supplied,
+    `pcre_flags` must be the final argument and an int. Because a
+    trailing int is always consumed as `pcre_flags`, an extra
+    argument intended for the callback must not be a bare int at the
+    tail of the argument list.
+
+### EXAMPLES
+
+    // One match, multiple capture groups; callback fires per group.
+    string label(string found, int group_index) {
+        return sprintf("[%d:%s]", group_index, found);
+    }
+
+    string s = pcre_replace_callback("foo-bar-baz",
+                                     "(\\w+)-(\\w+)-(\\w+)",
+                                     "label", this_object());
+    // s == "[0:foo]-[1:bar]-[2:baz]"
+
+    // Function-pointer form (no `ob` argument).
+    string s = pcre_replace_callback("foo-bar-baz",
+                                     "(\\w+)-(\\w+)-(\\w+)",
+                                     (: sprintf("[%d:%s]", $2, $1) :));
+    // s == "[0:foo]-[1:bar]-[2:baz]"
+
+    // Forwarding extra arguments to the callback.
+    string wrap(string found, int idx, string prefix, string suffix) {
+        return prefix + found + suffix;
+    }
+
+    string s = pcre_replace_callback("hello world",
+                                     "(world)",
+                                     "wrap", this_object(),
+                                     "<", ">");
+    // s == "hello <world>"
+
+    // No match returns the subject unchanged.
+    string s = pcre_replace_callback("hello", "(xyz)",
+                                     "wrap", this_object());
+    // s == "hello"
 
 ### SEE ALSO
 
-    pcre_assoc(3), pcre_cache(3), pcre_extract(3), pcre_replace(3)
+    pcre_assoc(3), pcre_cache(3), pcre_extract(3), pcre_match(3),
+    pcre_match_all(3), pcre_replace(3), pcre_version(3)

--- a/doc/driver/efun/query_multiple_short
+++ b/doc/driver/efun/query_multiple_short
@@ -1,0 +1,24 @@
+
+### NAME
+
+    query_multiple_short() - combine several objects into one short description
+
+### SYNOPSIS
+
+    string query_multiple_short( mixed *items, int|string|void type, int|void no_dollars, int|void quiet, int|void dark );
+
+### DESCRIPTION
+
+    Formats an array of items (objects, or their short strings) into a
+    single natural-language list — grouping identical shorts and counting
+    them, e.g. "two swords, a shield and some coins".
+
+    The optional arguments tune the output: `type` selects which short
+    (a named category) to query from the objects; `no_dollars` suppresses
+    the `$`-markup used for colour/where clauses; `quiet` omits items
+    flagged as quiet; and `dark` produces the description as seen in the
+    dark. This is a Discworld-mudlib inventory helper.
+
+### SEE ALSO
+
+    query_multiple_short(3)

--- a/doc/driver/efun/receive
+++ b/doc/driver/efun/receive
@@ -5,14 +5,14 @@
 
 ### SYNOPSIS
 
-    int receive( string message );
+    void receive( string | buffer message );
 
 ### DESCRIPTION
 
     This  efun is an interface to the add_message() function in the driver.
-    Its purpose is to display a message to the current object.  It  returns
-    1  if the current object is interactive, 0 otherwise.  Often, receive()
-    is called from within catch_tell(4) or receive_message(4).
+    Its  purpose  is  to  display  a message to the current object. The
+    message may be a string or a buffer of raw bytes.  Often, receive() is
+    called from within catch_tell(4) or receive_message(4).
 
 ### SEE ALSO
 

--- a/doc/driver/efun/reference_allowed
+++ b/doc/driver/efun/reference_allowed
@@ -1,0 +1,20 @@
+
+### NAME
+
+    reference_allowed() - Discworld playtester reference check
+
+### SYNOPSIS
+
+    int reference_allowed( object referee, string|object|void referrer );
+
+### DESCRIPTION
+
+    Discworld-mudlib helper: returns whether `referrer` (defaulting to
+    this_player(), or looked up by name if a string is given) is allowed
+    to hold a reference to `referee`, consulting the mudlib's playtester
+    and player handlers. Returns 0 when the handlers are absent, so it is
+    only meaningful in a mudlib that provides them.
+
+### SEE ALSO
+
+    this_player(3)

--- a/doc/driver/efun/replace
+++ b/doc/driver/efun/replace
@@ -1,0 +1,25 @@
+
+### NAME
+
+    replace() - replace occurrences of a substring, or of many substrings
+
+### SYNOPSIS
+
+    string replace( string str, string *|string from, string|void to );
+
+### DESCRIPTION
+
+    Two forms:
+
+    - `replace(str, from, to)` returns `str` with every occurrence of the
+      string `from` replaced by `to` (this is the plain string form,
+      equivalent to the replace_string() efun).
+    - `replace(str, arr)` takes an even-length array `arr` of
+      `({ from1, to1, from2, to2, ... })` pairs and applies each
+      replacement in turn.
+
+    Errors on an odd-length pair array.
+
+### SEE ALSO
+
+    replace_string(3), replace_dollars(3)

--- a/doc/driver/efun/replace_dollars
+++ b/doc/driver/efun/replace_dollars
@@ -1,0 +1,21 @@
+
+### NAME
+
+    replace_dollars() - expand $-markers in a string
+
+### SYNOPSIS
+
+    string replace_dollars( string str, string *pairs );
+
+### DESCRIPTION
+
+    Scans `str` for `$`-prefixed markers and substitutes them using
+    `pairs`, an even-length array alternating a marker and its
+    replacement text, e.g.
+    `({ "$name", "Bob", "$place", "the docks" })`. Text that matches no
+    marker is copied through unchanged; if nothing matches, the original
+    string is returned.
+
+### SEE ALSO
+
+    replace(3), replace_string(3)

--- a/doc/driver/efun/replace_html
+++ b/doc/driver/efun/replace_html
@@ -1,0 +1,19 @@
+
+### NAME
+
+    replace_html() - escape a string for HTML
+
+### SYNOPSIS
+
+    string replace_html( string str );
+
+### DESCRIPTION
+
+    Returns `str` with the HTML-significant characters escaped:
+    `&` becomes `&amp;`, `<` becomes `&lt;`, `>` becomes `&gt;`, and
+    `"` becomes `&quot;`. The result is capped at the driver's maximum
+    string length.
+
+### SEE ALSO
+
+    replace_mxp(3)

--- a/doc/driver/efun/replace_mxp
+++ b/doc/driver/efun/replace_mxp
@@ -1,0 +1,19 @@
+
+### NAME
+
+    replace_mxp() - escape a string for MXP
+
+### SYNOPSIS
+
+    string replace_mxp( string str );
+
+### DESCRIPTION
+
+    Returns `str` escaped for MXP output: `&`, `<` and `>` become their
+    entity forms (`&amp;`, `&lt;`, `&gt;`) and each newline is turned into
+    a secure-line MXP `<BR>` tag. The result is capped at the driver's
+    maximum string length.
+
+### SEE ALSO
+
+    replace_html(3)

--- a/doc/driver/efun/replace_objects
+++ b/doc/driver/efun/replace_objects
@@ -1,0 +1,21 @@
+
+### NAME
+
+    replace_objects() - recursively render objects in a value as strings
+
+### SYNOPSIS
+
+    mixed replace_objects( mixed value );
+
+### DESCRIPTION
+
+    Walks `value` (an object, array, class, or mapping, to any depth) and
+    returns a copy in which every object is replaced by a descriptive
+    string — its object name plus, via the master apply object_name(),
+    a readable label, or "(destructed)" for a destructed object. Arrays,
+    classes and mappings keep their structure; other values pass through
+    unchanged. Chiefly a debugging / dump helper.
+
+### SEE ALSO
+
+    sprintf(3)

--- a/doc/driver/efun/roulette_wheel
+++ b/doc/driver/efun/roulette_wheel
@@ -1,0 +1,19 @@
+
+### NAME
+
+    roulette_wheel() - weighted-random pick of a mapping key
+
+### SYNOPSIS
+
+    mixed roulette_wheel( mapping weights );
+
+### DESCRIPTION
+
+    Given a mapping whose values are non-negative integer weights,
+    returns one of its keys chosen at random with probability
+    proportional to that key's weight ("roulette-wheel" selection).
+    Errors on an empty mapping or a negative/non-integer weight.
+
+### SEE ALSO
+
+    random(3)

--- a/doc/driver/efun/save_object
+++ b/doc/driver/efun/save_object
@@ -6,6 +6,7 @@
 ### SYNOPSIS
 
     int save_object( string name, int flag );
+    string save_object( int flag );
 
 ### DESCRIPTION
 
@@ -16,9 +17,15 @@
     aren't).   Object  variables always save as 0.  If bit 1 is 1, then the
     save file will be compressed.
 
+    If no file name is given (the argument is omitted or is the integer
+    flag bitfield), the serialized data is not written to disk but is
+    returned as a string instead, suitable for use with the string form of
+    restore_object().
+
 ### RETURN VALUE
 
-    save_object() returns 1 for success, 0 for failure.
+    With a file name, save_object() returns 1 for success, 0 for failure.
+    In the no-file-name form it returns the save data as a string.
 
 ### SEE ALSO
 

--- a/doc/driver/efun/set_eval_limit
+++ b/doc/driver/efun/set_eval_limit
@@ -5,7 +5,7 @@
 
 ### SYNOPSIS
 
-    void set_eval_limit( int );
+    int set_eval_limit( int );
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/set_heart_beat
+++ b/doc/driver/efun/set_heart_beat
@@ -5,7 +5,7 @@
 
 ### SYNOPSIS
 
-    int set_heart_beat( int flag );
+    void set_heart_beat( int flag );
 
 ### DESCRIPTION
 

--- a/doc/driver/efun/sort_array
+++ b/doc/driver/efun/sort_array
@@ -5,8 +5,9 @@
 
 ### SYNOPSIS
 
-    mixed *sort_array( mixed *arr, string fun, object ob );
-    mixed *sort_array( mixed *arr, function f );
+    mixed *sort_array( mixed *arr, string fun, object ob,
+                       mixed extra, ... );
+    mixed *sort_array( mixed *arr, function f, mixed extra, ... );
     mixed *sort_array( mixed *arr, int direction );
 
 ### DESCRIPTION
@@ -19,6 +20,12 @@
 
     The second form does the same thing but allows a function pointer to be
     used instead.
+
+    For the first and second forms, any additional arguments  passed  after
+    the comparison function are forwarded to it on each call, appearing af‐
+    ter  the  two  elements  being  compared.  This is useful for threading
+    context (such as a lookup mapping) through to the comparator without  a
+    closure.
 
     The third form returns an array with the same elements  as  'arr',  but
     quicksorted using built-in sort routines.  A 'direction' of 1 or 0 will

--- a/doc/driver/efun/sprintf
+++ b/doc/driver/efun/sprintf
@@ -78,6 +78,9 @@
 
     f       floating point number
 
+    g       floating point number, trailing zeros removed
+            (e.g. 3.14 instead of 3.140000, 100 instead of 100.000000)
+
 ### RETURN VALUES
 
     sprintf() returns the formatted string.

--- a/doc/driver/efun/stat
+++ b/doc/driver/efun/stat
@@ -13,7 +13,7 @@
     will return an array of information pertaining to that file.  The  form
     of the array is as follows:
 
-           ({ file_size, last_time_file_touched, time_object_loaded, time_file_created })
+           (\{ file_size, last_time_file_touched, time_object_loaded, time_file_created \})
 
     If stat is called on a directory (not a regular file), or with a second
     argument of -1, then stat() behaves identically to get_dir(3).

--- a/doc/driver/efun/vowel
+++ b/doc/driver/efun/vowel
@@ -1,0 +1,18 @@
+
+### NAME
+
+    vowel() - test whether a character is a vowel
+
+### SYNOPSIS
+
+    int vowel( int c );
+
+### DESCRIPTION
+
+    Returns 1 if the character code `c` is an ASCII vowel
+    (a, e, i, o, u in either case), 0 otherwise. Used together with
+    add_a() for article selection.
+
+### SEE ALSO
+
+    add_a(3)

--- a/include/ffi.h
+++ b/include/ffi.h
@@ -1,0 +1,40 @@
+/*
+ * ffi.h -- type codes for the FFI package (package_ffi).
+ *
+ * Copy this file to your mudlib include dir. The codes describe the C
+ * type of an argument or return value to ffi_prepare()/ffi_call() and
+ * the scalar type for ffi_read()/ffi_write(). See docs/driver/ffi-plan.md.
+ *
+ * The boundary is BYTES: LPC strings are UTF-8-native and are NEVER
+ * marshalled implicitly to C char*. All pointer/data crosses as a
+ * `buffer`; encode with string_encode()/decode with string_decode().
+ */
+
+#ifndef _FFI_H_
+#define _FFI_H_
+
+#define FFI_VOID 0
+#define FFI_INT8 1
+#define FFI_UINT8 2
+#define FFI_INT16 3
+#define FFI_UINT16 4
+#define FFI_INT32 5
+#define FFI_UINT32 6
+#define FFI_INT64 7
+#define FFI_UINT64 8
+#define FFI_FLOAT 9   /* C float  <-> LPC float */
+#define FFI_DOUBLE 10 /* C double <-> LPC float */
+/*
+ * A pointer. As an ARGUMENT: pass a buffer; the native pointer is the
+ * buffer's bytes (whatever encoding you put there). As a RETURN: an
+ * integer holding the raw address -- copy from it with ffi_peek().
+ */
+#define FFI_POINTER 11
+
+/* Native C int/long widths (resolved to fixed sizes at build time). */
+#define FFI_INT FFI_INT32
+#define FFI_UINT FFI_UINT32
+#define FFI_LONG FFI_INT64
+#define FFI_ULONG FFI_UINT64
+
+#endif /* _FFI_H_ */


### PR DESCRIPTION
This PR adds and corrects documentation for a large number of efuns, and introduces a complete FFI (Foreign Function Interface) package.

## FFI Package

A new `include/ffi.h` header defines type codes (`FFI_VOID`, `FFI_INT8` through `FFI_POINTER`, and platform-width aliases) used across the FFI efun surface. Documentation is added for the full set of FFI efuns:

- **Library management**: `ffi_load()`, `ffi_unload()`, `ffi_symbol()`
- **Calling C**: `ffi_prepare()`, `ffi_call()`
- **Memory**: `ffi_alloc()`, `ffi_free()`, `ffi_peek()`, `ffi_address()`
- **Struct access**: `ffi_read()`, `ffi_write()`, `ffi_struct_layout()`, `ffi_sizeof()`
- **Callbacks into LPC**: `ffi_callback()`, `ffi_callback_addr()`, `ffi_callback_free()`
- **Diagnostics**: `ffi_error()`, `ffi_status()`

## New Efun Documentation

- `add_a()` — prepends the correct indefinite article ("a"/"an") with special-case handling
- `vowel()` — tests whether a character is an ASCII vowel
- `replace()` — single-pair and multi-pair substring replacement
- `replace_dollars()` — expands `$`-prefixed markers using a pairs array
- `replace_html()` — escapes `&`, `<`, `>`, and `"` for HTML output
- `replace_mxp()` — escapes characters and newlines for MXP output
- `replace_objects()` — recursively replaces objects in a value with descriptive strings
- `roulette_wheel()` — weighted-random key selection from a mapping
- `query_multiple_short()` — formats an array of objects into a natural-language list
- `reference_allowed()` — Discworld playtester reference check
- `sprintf` gains a `%g` format specifier that strips trailing zeros from floats

## Corrected Return Types

Several efuns had incorrect return types documented; these are fixed:

| Efun | Was | Now |
|---|---|---|
| `cache_stats()` | `void` | `string` |
| `call_stack()` | `string *` | `mixed *` |
| `debugmalloc()` | `void` | `string` |
| `disable_commands()` | `int` | `void` |
| `dump_file_descriptors()` | `void` | `string` |
| `flush_messages()` | `int` | `void` |
| `function_profile()` | `mixed *` | `mapping *` |
| `get_char()` | `void` | `int` |
| `input_to()` | `void` | `int` |
| `link()` | `void` | `int` |
| `malloc_status()` | `void` | `string` |
| `max_eval_cost()` | `void` | `int` |
| `mud_status()` | `void` | `string` |
| `receive()` | `int` | `void`, and now accepts `buffer` in addition to `string` |
| `set_eval_limit()` | `void` | `int` |
| `set_heart_beat()` | `int` | `void` |

## Other Documentation Improvements

- `disable_commands()` — removes the incorrect claim that it always returns 0 and fixes a typo ("have side-effct" → "has the side-effect")
- `implode()` — documents the function/fold form with `extra` argument and updated return value description
- `pcre_replace_callback()` — substantially expanded with precise callback argument semantics, all flag options, and multiple usage examples
- `save_object()` — documents the no-filename form that returns serialized data as a string
- `sort_array()` — documents forwarding of extra arguments to the comparator function
- `get_dir()` and `stat()` — fix literal `{`/`}` rendering in array format examples

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the driver efun reference and adds a new FFI include surface.

- New documentation for the FFI efuns and helper efuns.
- Corrected return types for several existing efun pages.
- Expanded notes for PCRE callbacks, save/restore helpers, sorting, formatting, and array/file examples.
- New `include/ffi.h` constants for FFI type codes.

<h3>Confidence Score: 4/5</h3>

The FFI include surface needs a fix for native-width aliases before callers rely on it.

- `include/ffi.h` can describe the wrong ABI shape for C `long` on some targets.
- The rest of the changes are documentation-focused and mostly low risk.
- The PCRE callback page has one documented argument shape that can mislead callers with trailing integer callback data.

include/ffi.h; doc/driver/efun/pcre_replace_callback

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ainclude%2Fffi.h%3A35-38%0A**Native%20Width%20Aliases%20Are%20Fixed**%0A%0AThese%20aliases%20are%20documented%20as%20native%20C%20widths%2C%20but%20%60FFI_LONG%60%20and%20%60FFI_ULONG%60%20are%20always%20mapped%20to%2064-bit%20types.%20On%20targets%20where%20C%20%60long%60%20is%2032%20bits%2C%20LPC%20code%20that%20follows%20this%20header%20will%20prepare%20an%208-byte%20ABI%20slot%20for%20a%204-byte%20native%20argument%20or%20return%20value%2C%20so%20%60ffi_call%28%29%60%20can%20pass%20corrupted%20arguments%20or%20read%20the%20wrong%20return%20value.%0A%0A%23%23%23%20Issue%202%20of%202%0Adoc%2Fdriver%2Fefun%2Fpcre_replace_callback%3A54-57%0A**Trailing%20Integers%20Become%20Flags**%0A%0AThis%20now%20says%20any%20final%20%60int%60%20is%20always%20consumed%20as%20%60pcre_flags%60.%20A%20caller%20that%20needs%20to%20forward%20an%20integer%20as%20the%20last%20callback%20argument%20cannot%20express%20that%20shape%20from%20this%20documented%20signature%2C%20so%20code%20following%20the%20docs%20can%20silently%20drop%20the%20callback%20value%20and%20change%20replacement%20output.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["adding new efun docs from upstream"](https://github.com/gesslar/oxidus-mudlib/commit/da979b65c59b95d5e59fe7450375b5eb684ee2d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43399609)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))

<!-- /greptile_comment -->