### PR TITLE
Add call stack to security access denial logs and allow simul_efun to set privs

### DIFF
--- a/adm/obj/master/security.lpc
+++ b/adm/obj/master/security.lpc
@@ -834,10 +834,13 @@ private nomask int access_ok(string file, object user, string op) {
 private nomask int access_gate(string file, object user, string op, string func) {
   int ok;
 
+
   // A nested check (the logging below reads/writes files) must not
   // recurse; permit it and let the outermost call decide.
   if(in_access_check)
     return 1;
+
+  defer((: in_access_check = 0 :));
 
   in_access_check = 1;
 
@@ -866,12 +869,13 @@ private nomask int access_gate(string file, object user, string op, string func)
 private nomask void log_access_denial(string file, object user, string op, string func, int enforced) {
   log_file(
     LOG_SECURITY,
-    sprintf("%s %s of %s by %s (%O) via %s - %s\n",
+    sprintf("%s %s of %s by %s (%O via %s) via %s - %s\n",
       enforced ? "DENIED" : "SHADOW",
       op,
       file,
       query_privs(user) || "(no privs)",
       user,
+      implode(map(reverse_array(previous_object(-1)), (: sprintf("%s (%s)", file_name($1), query_privs($1)) :)), " => "),
       func || "?",
       ldatetime()
     )

--- a/adm/obj/simul_efun.lpc
+++ b/adm/obj/simul_efun.lpc
@@ -44,3 +44,7 @@
 #include "/adm/simul_efun/time.lpc"
 #include "/adm/simul_efun/user.lpc"
 #include "/adm/simul_efun/util.lpc"
+
+private nomask void create() {
+  efun::set_privs(this_object(), "[adm_obj]");
+}

--- a/adm/simul_efun/override.lpc
+++ b/adm/simul_efun/override.lpc
@@ -68,7 +68,7 @@ void shutdown(int how) {
 void set_privs(object ob, string privs) {
   string name;
 
-  if(has_role(query_privs(previous_object()), "admin") || previous_object() == master())
+  if(has_role(query_privs(previous_object()), "admin") || previous_object() == master() || previous_object() == simul_efun())
     efun::set_privs(ob, privs);
 
   sscanf(file_name(ob), "/home/%*s/%s/%*s", name);


### PR DESCRIPTION
## Enhanced Security Access Denial Logging with Call Chain Visibility

### Changes

**Improved access denial log format**

The security log now includes the full call chain when logging access denials. Previously, only the immediate calling object was logged; now the entire chain of previous objects is captured and displayed inline with the user info, making it much easier to trace how a denied access was reached.

Log entries now follow the format:
```
DENIED read of /some/file by wizard (OB /path/to/obj via caller1 (privs1) => caller2 (privs2)) via valid_read - [timestamp]
```

**`simul_efun` privilege assignment**

The simul_efun object now assigns itself the `[adm_obj]` privilege on creation, giving it a consistent and identifiable privilege level rather than inheriting none.

**`set_privs` permission expansion**

`set_privs` now allows the simul_efun object to set privileges on objects, in addition to admin-privileged callers and the master object. This is necessary to support the simul_efun self-initialization added above.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves security denial diagnostics and privilege setup. The main changes are:
- Adds the full previous-object call chain to access-denial logs.
- Resets the access-check guard during error unwinding.
- Assigns `[adm_obj]` privileges to the simul_efun object.
- Allows the simul_efun object to set privileges through its override.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The access-check guard is cleared on normal returns and error exits.
- The updated denial-log formatting does not leave the guard set for invalid stack frames.
- No blocking issues found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["minor updates and logging things"](https://github.com/gesslar/oxidus-mudlib/commit/3cac85a0bf8c16afb401f392078cb7b69737b1a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43528056)</sub>

<!-- /greptile_comment -->