### PR TITLE
Add error handling to `assure_dir` and `load_lpml` with catch blocks

### DIFF
--- a/adm/simul_efun/directory.lpc
+++ b/adm/simul_efun/directory.lpc
@@ -38,15 +38,20 @@ mixed assure_dir(string path) {
   old_privs = query_privs();
   set_privs(this_object(), query_privs(previous_object()));
 
-  parts = explode(path, "/");
-  dir = "";
-  for(j = 0; j < sizeof(parts); j++) {
-    dir += parts[j];
-    mkdir(dir);
-    dir += "/";
-  }
+  string err = catch {
+    parts = explode(path, "/");
+    dir = "";
+    for(j = 0; j < sizeof(parts); j++) {
+      dir += parts[j];
+      mkdir(dir);
+      dir += "/";
+    }
+  };
 
   set_privs(this_object(), old_privs);
+
+  if(err)
+    return 0;
 
   return file_size(path) == -2;
 }

--- a/adm/simul_efun/file.lpc
+++ b/adm/simul_efun/file.lpc
@@ -266,8 +266,11 @@ varargs mixed load_lpml(string file, string root) {
 
   old_privs = query_privs();
   set_privs(this_object(), query_privs(previous_object()));
-  contents = read_file(file);
+  string err = catch(contents = read_file(file));
   set_privs(this_object(), old_privs);
+
+  if(err)
+    return undefined;
 
   if(stringp(root) && truthy(root))
     return lpml_decode(contents, root);


### PR DESCRIPTION
Adds error handling to `assure_dir` and `load_lpml` to gracefully handle failures rather than allowing exceptions to propagate.

In `assure_dir`, the directory creation loop is wrapped in a `catch` block, returning `0` if an error occurs. In `load_lpml`, the `read_file` call is wrapped in a `catch`, returning `undefined` if the file cannot be read.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds handled failure paths for directory creation and LPML reads.

- Restores privileges after caught directory-creation errors.
- Returns `undefined` when an LPML file read throws.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (4): Last reviewed commit: ["some guards"](https://github.com/gesslar/oxidus-mudlib/commit/16eb932cea811c0dfcb1fa8db7d7c3f3acfd8f28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43528059)</sub>

**Context used:**

- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))

<!-- /greptile_comment -->