### PR TITLE
Fix whitespace alignment in DOCKER.md

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -80,7 +80,7 @@ prompt.
 
 ```bash
 docker pull ghcr.io/gesslar/oxidus:latest   # fetch the newest image
-docker rm -f oxidus                          # remove the old container
+docker rm -f oxidus                         # remove the old container
 # then re-run the `docker run` command above to recreate it on the new image
 ```
 


### PR DESCRIPTION
Fixed a minor whitespace alignment issue in the Docker documentation where the comment spacing was inconsistent with the surrounding lines.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects whitespace alignment in the Docker update example.

- Aligns the inline comment on the `docker rm` command.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["minor formatting update to DOCKER.md"](https://github.com/gesslar/oxidus-mudlib/commit/45fc2d33dee6d4a764b317ca10433449e42b576e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43569383)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
</details>

<!-- /greptile_comment -->