### PR TITLE
Increase string, file, and byte transfer size limits to 1000000

### DIFF
--- a/adm/dist/config.mud
+++ b/adm/dist/config.mud
@@ -68,7 +68,7 @@ maximum evaluation cost : 500000
 maximum array size : 15000
 
 # This is the maximum allowed size of a variable of type 'buffer'.
-maximum buffer size : 400000
+maximum buffer size : 1000000
 
 # Max size for a mapping
 maximum mapping size : 1500000
@@ -77,14 +77,14 @@ maximum mapping size : 1500000
 inherit chain size : 30
 
 # maximum length of a string variable
-maximum string length : 200000
+maximum string length : 1000000
 
 # Max size of a file allowed to be read by 'read_file()'.
-maximum read file size : 200000
+maximum read file size : 1000000
 
 # max number of bytes you allow to be read and written with read_bytes
 # and write_bytes
-maximum byte transfer : 10000
+maximum byte transfer : 1000000
 
 # Define the size of the shared string hash table.  This number should
 # a prime, probably between 1000 and 30000; if you set it to about 1/5

--- a/adm/etc/config.github
+++ b/adm/etc/config.github
@@ -85,7 +85,7 @@ maximum evaluation cost : 300000000
 maximum array size : 15000
 
 # This is the maximum allowed size of a variable of type 'buffer'.
-maximum buffer size : 400000
+maximum buffer size : 1000000
 
 # Max size for a mapping
 maximum mapping size : 15000
@@ -94,14 +94,14 @@ maximum mapping size : 15000
 inherit chain size : 30
 
 # maximum length of a string variable
-maximum string length : 200000
+maximum string length : 1000000
 
 # Max size of a file allowed to be read by 'read_file()'.
-maximum read file size : 200000
+maximum read file size : 1000000
 
 # max number of bytes you allow to be read and written with read_bytes
 # and write_bytes
-maximum byte transfer : 10000
+maximum byte transfer : 1000000
 
 # Define the size of the shared string hash table.  This number should
 # a prime, probably between 1000 and 30000; if you set it to about 1/5


### PR DESCRIPTION
Increases the limits for maximum string length, maximum read file size, and maximum byte transfer from 200,000 and 10,000 to 1,000,000 across both the dist and github config files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises the configured transfer and content size limits. The main changes are:

- Raises buffer size limits to 1,000,000 bytes.
- Raises maximum string and read-file sizes to 1,000,000 bytes.
- Raises byte-transfer limits to 1,000,000 bytes in both config variants.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (3): Last reviewed commit: ["updated configs"](https://github.com/gesslar/oxidus-mudlib/commit/f6ba5be54665dc88388c685f6961a2030ded6e88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43591043)</sub>

<!-- /greptile_comment -->