### PR TITLE
Open `/data/**` to all and add clarifying comments

### DIFF
--- a/adm/etc/security/access.lpml
+++ b/adm/etc/security/access.lpml
@@ -16,23 +16,31 @@
 // code identities) bypass this table entirely, so "role:admin" below
 // really means "admins only", and "role:developer" means "developers
 // and admins" (admin confers developer via the group hierarchy).
+//
+// /data and /open may look the same, but they semantically different.
+// /data = more persistent-y kind of things, like save files, etc
+// /open = open-to-all read/write
+// - both require read/write - all, but the distinction is organisational
+// more than it is correct.
+
 [
-  { path: "/tmp/**",            read: "all",            write: "all", },
-  { path: "/log/**",            read: "role:developer", write: "all", },
-  { path: "/data/users/*/*/**", read: "self",           write: "self", },
-  { path: "/data/**",           read: "role:admin",     write: "role:admin", },
-  { path: "/adm/etc/secret/**", read: "role:admin",     write: "role:admin", },
-  { path: "/adm/etc/**",        read: "all",            write: "role:admin", },
-  { path: "/adm/**",            read: "role:admin",     write: "role:admin", },
-  { path: "/home/*/*/**",       read: "all",            write: "self", },
-  { path: "/doc/**",            read: "all",            write: "role:developer", },
-  { path: "/include/**",        read: "all",            write: "role:developer", },
-  { path: "/std/**",            read: "all",            write: "role:developer", },
-  { path: "/lib/**",            read: "all",            write: "role:developer", },
-  { path: "/obj/**",            read: "all",            write: "role:developer", },
-  { path: "/cmds/**",           read: "all",            write: "role:developer", },
-  { path: "/d/**",              read: "all",            write: "role:developer", },
-  { path: "/open/**",           read: "all",            write: "all", },
-  { path: "/tests/**",          read: "role:runtests",  write: "role:runtests", },
-  { path: "/**",                read: "all",            write: "role:admin", },
+  { path: "/tmp/**",                read: "all",            write: "all", },
+  { path: "/log/**",                read: "role:developer", write: "all", },
+  { path: "/data/users/*/*/**",     read: "self",           write: "self", },
+  { path: "/data/accounts/*/**",    read: "none",           write: "none", },
+  { path: "/data/**",               read: "all",            write: "all", },
+  { path: "/adm/etc/secret/**",     read: "role:admin",     write: "role:admin", },
+  { path: "/adm/etc/**",            read: "all",            write: "role:admin", },
+  { path: "/adm/**",                read: "role:admin",     write: "role:admin", },
+  { path: "/home/*/*/**",           read: "all",            write: "self", },
+  { path: "/doc/**",                read: "all",            write: "role:developer", },
+  { path: "/include/**",            read: "all",            write: "role:developer", },
+  { path: "/std/**",                read: "all",            write: "role:developer", },
+  { path: "/lib/**",                read: "all",            write: "role:developer", },
+  { path: "/obj/**",                read: "all",            write: "role:developer", },
+  { path: "/cmds/**",               read: "all",            write: "role:developer", },
+  { path: "/d/**",                  read: "all",            write: "role:developer", },
+  { path: "/open/**",               read: "all",            write: "all", },
+  { path: "/tests/**",              read: "role:runtests",  write: "role:runtests", },
+  { path: "/**",                    read: "all",            write: "role:admin", },
 ]


### PR DESCRIPTION
Changes the `/data/**` path permissions from admin-only to read/write for all users. This opens up general data access while preserving the more specific `/data/users/*/*/**` rule that restricts user-specific paths to self-access only.

Also adds a clarifying comment explaining the intended semantic distinction between `/data` (persistent storage, save files, etc.) and `/open` (open read/write for all), noting that while both require read/write access for all users, the separation is organizational in nature.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR opens general `/data/**` access while adding a protected account-data exception. The main changes are:

- Opens `/data/**` for read and write access.
- Denies access to `/data/accounts/*/**`.
- Adds comments distinguishing `/data` from `/open`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (6): Last reviewed commit: ["freeing up perms on data/"](https://github.com/gesslar/oxidus-mudlib/commit/7994bc4664b631233b3898b78416defa08f0de8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43591044)</sub>

<!-- /greptile_comment -->