### PR TITLE
Remove commented-out debug lines from `redistribute_resources`

### DIFF
--- a/adm/daemons/resource.lpc
+++ b/adm/daemons/resource.lpc
@@ -50,10 +50,6 @@ public mapping query_resources() {
 }
 
 private void redistribute_resources() {
-  // shout("Redistributing resources.\n");
-
-  // debug("Loaded = %O", __loaded);
-
   each(__loaded, (: reset_room_resources :));
 }
 


### PR DESCRIPTION
Removes leftover commented-out debug and logging statements from the `redistribute_resources` function in the resource daemon.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes obsolete diagnostic comments from the resource daemon.

- Removes a commented-out `shout` call.
- Removes a commented-out `debug` call.
- Leaves resource redistribution behavior unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["removing dead comments"](https://github.com/gesslar/oxidus-mudlib/commit/34ed1b17c31f27de428b1dd0dbb87beaaa802ec5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43601422)</sub>

**Context used:**

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))

<!-- /greptile_comment -->