### PR TITLE
Add braces to `if` block in GMCP daemon

### DIFF
--- a/adm/daemons/gmcp.lpc
+++ b/adm/daemons/gmcp.lpc
@@ -80,8 +80,10 @@ class ClassGMCP convert_message(string message) {
     err = catch {
       gmcp.payload = json_decode(message_info);
     };
-    if(err)
+
+    if(err) {
       debug("Error decoding JSON: %O", chop(err, "\n", -1));
+    }
   }
 
   return gmcp;


### PR DESCRIPTION
Adds braces around the error handling block in `convert_message` for consistent code style.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the GMCP JSON error-handling block consistent with surrounding control flow.

- Adds braces around the JSON decode error branch.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["minor edit of err"](https://github.com/gesslar/oxidus-mudlib/commit/f52f1cf54160991821e545ba2baa393607f9d3ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43601424)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
</details>

<!-- /greptile_comment -->