### PR TITLE
Use `each` for object moves in crawler's `stash_objects`

### DIFF
--- a/adm/daemons/crawler.lpc
+++ b/adm/daemons/crawler.lpc
@@ -281,14 +281,18 @@ object stash_objects(string room_file, object _tp) {
   object v = load_object(ROOM_VOID);
 
   if(room = find_object(room_file)) {
-    /** @type {STD_ITEM | STD_BODY} */ object *all = all_inventory(room);
+    /** @type {STD_ITEM* | STD_BODY*} */ object *all = all_inventory(room);
 
-    if(sizeof(all))
-      all->move(v);
+    if(sizeof(all)) {
+      each(all, (: $1->move($(v)) :));
+    }
 
     room->remove();
     room = load_object(room_file);
-    all->move(room);
+
+    if(sizeof(all)) {
+      each(all, (: $1->move($(room)) :));
+    }
   } else {
     catch(room = load_object(room_file));
   }


### PR DESCRIPTION
Replaces array call syntax (`all->move()`) with `each()` and a closure when moving objects to and from the void during room reloading. This avoids potential issues with array calls propagating errors across all objects if a single `move()` fails, handling each object's movement individually instead.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes room-reload object moves to run one object at a time.

- Replaces array `move()` dispatch with `each()` closures.
- Moves inventory to the void before reloading the room.
- Restores the saved inventory after reload.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["cleaner moving"](https://github.com/gesslar/oxidus-mudlib/commit/440572fd21e28ce0fccae3abf1d648fb06b6ec4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43601425)</sub>

<!-- /greptile_comment -->