### PR TITLE
Add Greptile config and rename gLPU references to Oxidus

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,60 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax"],
+  "triggerOnUpdates": true,
+  "statusCheck": false,
+  "fixWithAI": false,
+  "ignorePatterns": "adm/dist/fluffos/**\nadm/dist/bin/**\ninclude/driver/**\narchive/**\ndoc/_wiki/**\nnode_modules/**\ndata/**\nopen/**\ntmp/**\nlog/**\n*.tbl\n*.sqlite3\npackage-lock.json",
+  "summarySection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": false
+  },
+  "issuesTableSection": {
+    "included": true,
+    "collapsible": false,
+    "defaultOpen": true
+  },
+  "confidenceScoreSection": {
+    "included": false
+  },
+  "sequenceDiagramSection": {
+    "included": false
+  },
+  "context": {
+    "repos": ["fluffos/fluffos"]
+  },
+  "instructions": "This repository is Oxidus, a MUD library written in LPC (Lars Pensjo C) targeting the FluffOS 2019+ driver. It is NOT C, C++, TypeScript, or any general-purpose language, and it is NOT an enterprise codebase. Review it as a living, actively-developed, single-author game library. Read .greptile/rules.md before reviewing: it documents LPC/FluffOS semantics that routinely produce false positives, and this project's review philosophy. Prioritise genuine correctness bugs over stylistic or architectural preferences. Coding style, naming, spacing, and documentation format are governed by project skills the reviewer cannot see, so do not raise style, formatting, or naming comments. Trace before you claim: you have the entire repository, so resolve the actual callers, callees, and data flow and state findings as facts, not conditionals. If a finding can only be phrased as 'if X then Y' or 'this could...', finish the trace until you can assert what actually happens, or omit it — a hedged finding that pushes verification back onto the author is noise, and uncertainty you did not resolve should LOWER confidence, never be posted as a caveat. Front-load the trace: the FIRST comment must already carry the validated premise. A finding is a conclusion you verified before posting, not an opening hypothesis you refine across a reply thread — do not use the author's replies as your verification loop, and never let a valid premise emerge only after the author pushes back. 'Fails silently' is not a defect on its own, and its premise is usually false here: every caught error is logged (the driver routes caught/runtime errors through master's error_handler, which always writes a full trace to the catch/runtime log); the on-screen dev notification is separately gated by whether an interactive dev is present, so 'no message on screen' means logged-not-lost, which is intended. Returning 0/null or swallowing a signal is also a deliberate idiom throughout this lib, so only raise 'fails silently' when you have traced a specific caller that is actually harmed and you name that caller. The context repo fluffos/fluffos is the C++ source of the FluffOS driver this lib runs on; use it as the authoritative reference for efun semantics (e.g. sscanf match counting, numeric coercion, path resolution, the privs model) and ground any driver-behavior claim in that source rather than assuming C-language defaults. It is a semantics reference only — never review it, and note it tracks upstream HEAD while this lib targets FluffOS 2019+, so prefer stable, long-standing efun behavior over anything that looks version-specific.",
+  "rules": [
+    {
+      "id": "lpc-source-extension",
+      "rule": "New LPC source files must use the .lpc extension, not .c. The .c extension is legacy; the lib has fully migrated. Header files remain .h.",
+      "scope": ["**/*.c"],
+      "severity": "low"
+    },
+    {
+      "id": "prefer-pointerp",
+      "rule": "Prefer pointerp() over arrayp() for array type checks, to match repository convention.",
+      "scope": ["**/*.lpc"],
+      "severity": "low"
+    },
+    {
+      "id": "valid-function-guard",
+      "rule": "When guarding invocation of a closure/function pointer, prefer valid_function(f) over a bare functionp(f). functionp() alone is truthy even for closures whose owner has been destructed, which can crash at call time.",
+      "scope": ["**/*.lpc"],
+      "severity": "medium"
+    },
+    {
+      "id": "no-mudlib-h-include",
+      "rule": "Do not add '#include <mudlib.h>'. mudlib.h is auto-included via global.h; an explicit include is redundant.",
+      "scope": ["**/*.lpc", "**/*.h"],
+      "severity": "low"
+    },
+    {
+      "id": "lib-relative-paths-in-docs",
+      "rule": "In comments and documentation, refer to files by lib-relative paths (e.g. /std/object.lpc), never absolute host paths like /mud/ox/lib/... — the repository is meant to be forkable.",
+      "scope": ["**/*.lpc", "**/*.h", "**/*.md"],
+      "severity": "low"
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,15 @@
+[
+  {
+    "path": "../CLAUDE.md",
+    "description": "Project overview, LPC language notes, directory layout, and conventions for the Oxidus mudlib."
+  },
+  {
+    "path": "../LLM.md",
+    "description": "Shared LLM guidance for this repository (symlinked as AIDER.md, CODEX.md, COPILOT.md, CURSOR.md)."
+  },
+  {
+    "path": "../lpc-config.json",
+    "description": "LPC language-server / driver configuration: include paths, simul_efun location, and driver settings.",
+    "scope": ["**/*.lpc", "**/*.h"]
+  }
+]

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,14 +1,10 @@
 [
   {
-    "path": "../CLAUDE.md",
+    "path": "CLAUDE.md",
     "description": "Project overview, LPC language notes, directory layout, and conventions for the Oxidus mudlib."
   },
   {
-    "path": "../LLM.md",
-    "description": "Shared LLM guidance for this repository (symlinked as AIDER.md, CODEX.md, COPILOT.md, CURSOR.md)."
-  },
-  {
-    "path": "../lpc-config.json",
+    "path": "lpc-config.json",
     "description": "LPC language-server / driver configuration: include paths, simul_efun location, and driver settings.",
     "scope": ["**/*.lpc", "**/*.h"]
   }

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,110 @@
+# Greptile reviewer guide — Oxidus
+
+This is an **LPC** mudlib running on the **FluffOS 2019+** driver. Much LPC
+looks like C but behaves differently. Read this before flagging anything, and
+treat every item below as a reason **not** to raise a comment unless you have
+positive evidence of a real defect.
+
+## Language / driver facts that produce false positives
+
+- **LPC is not C.** `string *arr` is an **array**, not a pointer. There are no
+  raw pointers. Mappings are `([ key: value ])`; array literals are `({ ... })`.
+  No `main()`; entry points are lifecycle hooks (`create`, `setup`, `init`).
+- **Single-threaded and synchronous is first-class.** The driver runs one
+  execution at a time. Do not suggest async/await, locking, or "race
+  condition" fixes; there is no preemption. Only flag a call if its *duration*
+  would stall the driver, not because it is synchronous.
+- **C99 mid-block declarations are supported.** Declaring a variable partway
+  through a block is fine; do not ask for it to be hoisted or wrapped in a
+  scope block.
+- **`sscanf` counts `%*s` matches too** (unlike C). A format with assignment-
+  suppressed fields returns a higher count than the number of stored values.
+  Guard against the *full* match count, not `!= 1`.
+- **File efuns resolve from the mudlib root.** A leading `/` is optional and the
+  author's convention is slashless (e.g. `std/object.lpc`). Do not "correct"
+  slashless paths, and do not claim a path is broken — compilation does not
+  prove path resolution either way.
+- **Security uses the FluffOS privs model, not `PACKAGE_UIDS`.** `valid_seteuid`
+  and euid machinery never fire here; do not flag their absence. `master.lpc`'s
+  defensive `set_privs("[master]")` re-asserts are intentional and working.
+- **Numeric coercion preserves float values** through int-typed locals in
+  FluffOS. `int x = <float expr>` does not necessarily truncate; verify before
+  claiming a truncation bug.
+- **Reserved type words** (`buffer`, `function`, `class`, `mapping`, `object`,
+  `mixed`, …) may not be used as variable names — that one *is* worth flagging.
+- **Closures.** In `(: :)` closures, `$N` is the call-time positional argument
+  and `$(EXPR)` is a value captured lexically at creation. `$(2)` is not `$2`.
+
+## Review philosophy
+
+- **Judge this as a living single-author MUD**, not an enterprise
+  JS/C++/service codebase. Favour a small number of high-confidence
+  correctness findings over breadth.
+- **"Touches a lot / might break things" is never a blocker** and not a
+  warning on its own. Scope of impact is a scheduling question, not a defect.
+- **Dormant-by-design scaffolding is not dead code.** Unused config keys,
+  partially-wired APIs, and pinned/fixed procedural-generation seeds (used for
+  reproducible reboots) are deliberate. Do not report them as bugs.
+- **Do not raise style, formatting, spacing, naming, or documentation-format
+  comments.** Those conventions live in project skills you cannot see, and a
+  generic guess about LPC style will usually be wrong. Notably: private
+  functions are **not** underscore-prefixed here.
+- **Answer at the altitude of the change.** Stay within the diff; surface
+  adjacent observations sparingly, as a brief aside at most.
+
+## Trace, don't hedge
+
+You have the whole repository. Use it before you write a comment.
+
+- **State findings as facts, not conditionals.** "If `foo()` returns null then
+  this dereferences null" is not a finding — it is unfinished homework. Go read
+  `foo()` and its callers. Either it *can* return null on a real path (now it is
+  a fact worth raising, with that path named) or it cannot (drop it). Phrasings
+  like "if this...", "this could...", "it's possible that..." are a signal that
+  the trace was not completed. Complete it or say nothing.
+- **Unresolved uncertainty lowers confidence; it does not become a caveat.** Do
+  not post a low-confidence guess wrapped in hedging language and let the author
+  do the verification. That inverts the job — the reviewer that has the code
+  should look, not ask the human to look. If you genuinely cannot resolve it
+  from the repository, that is a reason to omit the comment, not to hedge it.
+- **A claim that merely looks like a claim is worse than silence.** A confident-
+  sounding comment that turns out to be "well, *if*..." wastes more trust than
+  no comment at all.
+- **Front-load the trace — the first comment must already carry the validated
+  premise.** A finding is a conclusion you verified *before* posting, not an
+  opening hypothesis you refine across a reply thread. Do not use the author's
+  responses as your verification loop: if a premise only becomes valid after the
+  author pushes back, it should have been checked before the comment existed.
+  The author's time is not your compute. Disagreement is welcome — it is useful
+  rubber-ducking and you are sometimes right — but it must start from a premise
+  you already did the work to stand behind, not one you reach on reply #11.
+
+## "Fails silently" is not a defect by itself — and nothing here is truly silent
+
+First, the premise is usually false. **Every caught error is logged.** The
+driver routes caught errors (and runtime errors) through `master`'s
+`error_handler` (see /adm/obj/master.lpc), which unconditionally writes a full
+trace to the catch log / runtime log. Dev notification on-screen is separately
+gated by whether an interactive dev is online — so an error that raises no
+on-screen message when no interactive is involved is **logged, not lost**.
+"Silent" here means "did not print to someone's screen," which is correct,
+intended behaviour, not a swallowed failure. (The one exception is a test-runner
+sweep, where caught errors are intentional sad-path tests and suppression
+auto-expires.)
+
+Second, returning `0`/null, swallowing an error, or no-op-ing is a **deliberate
+idiom** throughout this lib — guard returns, unauthorized-caller no-ops (e.g. the
+`set_privs` override), and uniform result passthrough (e.g. `evaluate_result`
+handling 1/0/string). Do **not** raise "this fails silently" on its own. Raise
+it only when you have traced a **specific caller** that is actually harmed by the
+swallowed signal — and name that caller and the concrete bad outcome. If you
+cannot point to the victim, there is no bug.
+
+## Things that are genuinely worth flagging
+
+- Real logic errors: wrong operator, off-by-one, inverted condition, unhandled
+  null (`nullp`) where an object/array is dereferenced **on a path you traced**.
+- Calling a possibly-destructed object or invalid closure without a guard.
+- Using a reserved type word as an identifier.
+- Missing permission/input validation before a sensitive operation.
+- New `.c` source files (should be `.lpc`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# LLM Guide for gLPU
+# LLM Guide for Oxidus
 
-This document provides guidance for LLMs (Language Learning Models) when working with the gLPU (Gesslar's LPUniversity) mudlib codebase.
+This document provides guidance for LLMs (Language Learning Models) when working with the Oxidus mudlib codebase.
 
 ## IMPORTANT: Required Skills
 
@@ -14,7 +14,7 @@ These skills contain critical information about code formatting, documentation s
 
 ## Project Overview
 
-**gLPU** is a MUD (Multi-User Dungeon) library written in LPC (Lars Pensjö C), designed to run on FluffOS 2019+. It is a fork of LPUniversity, actively maintained and extended by Gesslar.
+**Oxidus** is a MUD (Multi-User Dungeon) library written in LPC (Lars Pensjö C), designed to run on FluffOS 2019+. It is authored and maintained by Gesslar.
 
 - **Language**: LPC (a C-like scripting language for MUDs)
 - **Driver**: FluffOS 2019+
@@ -206,7 +206,7 @@ string append(string source, string to_append) {
 - `@history` - Change log
 - `@simul_efun` - Marks simulated efuns (built-in function replacements)
 
-## Common Patterns in gLPU
+## Common Patterns in Oxidus
 
 ### Object Lifecycle
 
@@ -292,7 +292,13 @@ Current state (from git status):
 
 - Documentation site: <https://oxidus.online/>
 - Contributing guide: <https://oxidus.online/contributing>
-- Original LPUniversity: <http://dead-souls.net/>
+
+### Attribution
+
+Oxidus began life as a fork of LPUniversity and has since diverged into its own
+codebase. This lineage is retained here purely as attribution — LPUniversity is
+no longer a reference for how Oxidus is built. LPUniversity is available from
+<http://dead-souls.net/>.
 
 ## Tips for Claude Code
 


### PR DESCRIPTION
This PR establishes Greptile AI code review configuration for the repository and updates project identity references from "gLPU" to "Oxidus" throughout the documentation.

The Greptile setup (`.greptile/config.json`, `.greptile/files.json`, `.greptile/rules.md`) configures automated review behavior tailored specifically to LPC/FluffOS semantics. Key aspects of the configuration include:

- A detailed reviewer guide (`rules.md`) that documents LPC-specific behaviors likely to produce false positives in AI review (e.g., `sscanf` match counting, the FluffOS privs model, numeric coercion, closure syntax), along with a philosophy emphasizing high-confidence correctness findings over stylistic noise
- Custom rules enforcing `.lpc` file extensions for new source files, preferring `pointerp()` over `arrayp()`, using `valid_function()` guards over bare `functionp()`, avoiding redundant `mudlib.h` includes, and using lib-relative paths in documentation
- Context files pointing Greptile to `CLAUDE.md`, `LLM.md`, and `lpc-config.json` as authoritative project references, with the FluffOS driver repository linked as a semantics reference for efun behavior

The `CLAUDE.md` updates remove the "fork of LPUniversity" framing, replacing it with attribution-only language that clarifies LPUniversity is no longer a reference for how Oxidus is built.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Greptile review configuration and updates the project identity to Oxidus.

- Adds Greptile configuration, review rules, and context-file registration.
- Updates `CLAUDE.md` from gLPU references to Oxidus.
- Retains LPUniversity history as attribution only.
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix .greptile context paths and drop sta..."](https://github.com/gesslar/oxidus-mudlib/commit/27ab315f0460fc3b464b649408d00072166cb3e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43669749)</sub>

<details><summary><h4>Context used (6)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - Custom context ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->