### PR TITLE
Normalize account name lookups, fix orphaned file on removal, add tests

### DIFF
--- a/adm/daemons/account.lpc
+++ b/adm/daemons/account.lpc
@@ -1,19 +1,18 @@
 /**
- * @file /adm/daemons/account.c
+ * @file /adm/daemons/account.lpc
  *
  * Account daemon responsible for managing player accounts, including creation,
  * modification, and character associations.
  *
  * @created 2024-08-09 - Gesslar
- * @last_modified 2024-08-09 - Gesslar
+ * @last_modified 2026-07-12 - Gesslar
  *
  * @history
  * 2024-08-09 - Gesslar - Created
+ * 2026-07-12 - Gesslar - Normalize names to lower case on every lookup, not
+ *                        just on create; remove the orphaned account file on
+ *                        removal so a removed account cannot resurrect
  */
-
-#ifdef MOO
-#define aroo
-#endif
 
 #include "include/account.h"
 
@@ -53,7 +52,7 @@ void setup() {
  *
  * @param {AccountName} name - The account name to create
  * @param {AccountPassword} password - The encrypted password (must start with $6$)
- * @returns {Boolean} 1 on success, 0 on failure
+ * @returns {int} 1 on success, 0 on failure
  * @example
  * int success = create_account("testuser", "$6$randomsalt$hashedpassword");
  * if(success) {
@@ -61,13 +60,15 @@ void setup() {
  * }
  */
 public int create_account(string name, string password) {
-  if(!valid_manip(name))
-    return false;
-
   if(!name || !stringp(name))
     return false;
 
   if(!password || !stringp(password))
+    return false;
+
+  name = lower_case(name);
+
+  if(!valid_manip(name))
     return false;
 
   if(valid_account(name))
@@ -75,8 +76,6 @@ public int create_account(string name, string password) {
 
   if(password[0..2] != "$6$")
     return false;
-
-  name = lower_case(name);
 
   mapping account = ([
     "password" : password,
@@ -97,20 +96,22 @@ public int create_account(string name, string password) {
  * The disk file will be removed after loading.
  *
  * @param {AccountName} name - The account name to load
- * @returns {AccountRecord} The account data if found, null otherwise
+ * @returns {AccountRecord | undefined} The account data if found, undefined otherwise
  */
 public mapping load_account(string name) {
-  if(!valid_manip(name))
-    return null;
-
   if(!name || !stringp(name))
-    return null;
+    return undefined;
+
+  name = lower_case(name);
+
+  if(!valid_manip(name))
+    return undefined;
 
   if(!accounts[name]) {
     string file = account_file(name);
 
     if(!file_exists(file))
-      return null;
+      return undefined;
 
     accounts[name] = from_string(read_file(file));
     reverse[file] = name;
@@ -127,13 +128,15 @@ public mapping load_account(string name) {
  * @param {AccountName} name - The account name to modify
  * @param {string} key - The key to update
  * @param {mixed} data - The new value to store
- * @returns {mixed|undefined} The stored value on success, 0 on failure
+ * @returns {mixed | undefined} The stored value on success, 0 on failure
  */
 string write_account(string name, string key, mixed data) {
-  if(!valid_manip(name))
+  if(!name || !stringp(name))
     return false;
 
-  if(!name || !stringp(name))
+  name = lower_case(name);
+
+  if(!valid_manip(name))
     return false;
 
   if(!key || !stringp(key))
@@ -163,10 +166,12 @@ string write_account(string name, string key, mixed data) {
  * @returns {mixed} The stored value if found, 0 otherwise
  */
 mixed read_account(string name, string key) {
-  if(!valid_manip(name))
+  if(!name || !stringp(name))
     return false;
 
-  if(!name || !stringp(name))
+  name = lower_case(name);
+
+  if(!valid_manip(name))
     return false;
 
   if(!key || !stringp(key))
@@ -188,7 +193,7 @@ mixed read_account(string name, string key) {
  * - The caller is the GMCP Char module
  *
  * @param {AccountName} name - The account name to check permissions for
- * @returns {Boolean} 1 if manipulation is allowed, 0 otherwise
+ * @returns {int} 1 if manipulation is allowed, 0 otherwise
  */
 int valid_manip(string name) {
   object prev = previous_object();
@@ -217,22 +222,32 @@ int valid_manip(string name) {
  * This removes both the account data and any character associations.
  *
  * @param {AccountName} name - The account name to remove
- * @returns {Boolean} 1 on success, 0 on failure
+ * @returns {int} 1 on success, 0 on failure
  */
 int remove_account(string name) {
-  if(!valid_manip(name))
+  if(!name || !stringp(name))
     return false;
 
-  if(!name || !stringp(name))
+  name = lower_case(name);
+
+  if(!valid_manip(name))
     return false;
 
   if(!valid_account(name))
     return false;
 
   map_delete(accounts, name);
+
+  // Drop any on-disk file too. write_account() may have persisted one, and
+  // load_account() would otherwise slurp it back in and resurrect the
+  // account we just removed.
+  if(file_exists(account_file(name)))
+    rm(account_file(name));
+
   foreach(string key, string value in reverse) {
-    if(value == name)
+    if(value == name) {
       map_delete(reverse, key);
+    }
   }
 
   save_data();
@@ -245,30 +260,30 @@ int remove_account(string name) {
  *
  * @param {AccountName} account_name - The account to add the character to
  * @param {CharacterName} str - The character name to add
- * @returns {1|null} 1 on success, null on failure
+ * @returns {1 | undefined} 1 on success, undefined on failure
  */
 int add_character(string account_name, string str) {
   if(!account_name || !stringp(account_name))
-    return null;
+    return undefined;
+
+  account_name = lower_case(account_name);
 
   if(!valid_manip(account_name))
-    return null;
+    return undefined;
 
   if(!accounts[account_name])
-    return null;
+    return undefined;
 
   if(!str || !stringp(str))
-    return null;
+    return undefined;
 
   str = lower_case(str);
 
   mapping account = load_account(account_name);
-  if(!account)
-    return false;
 
-  /** @type {CharacterName*} */ string *characters = account["characters"] || ({});
+  /** @type {CharacterName*} */ string *characters = account.characters || ({});
   characters += ({ str });
-  account["characters"] = distinct_array(characters);
+  account.characters = distinct_array(characters);
   accounts[account_name] = account;
   reverse[str] = account_name;
 
@@ -284,30 +299,30 @@ int add_character(string account_name, string str) {
  *
  * @param {AccountName} account_name - The account to remove the character from
  * @param {CharacterName} character_name - The character name to remove
- * @returns {int} 1 on success, null on failure
+ * @returns {int | undefined} 1 on success, undefined on failure
  */
 int remove_character(string account_name, string character_name) {
   if(!account_name || !stringp(account_name))
-    return null;
+    return undefined;
+
+  account_name = lower_case(account_name);
 
   if(!valid_manip(account_name))
-    return null;
+    return undefined;
 
   if(!accounts[account_name])
-    return null;
+    return undefined;
 
   if(!character_name || !stringp(character_name))
-      return null;
+      return undefined;
 
   character_name = lower_case(character_name);
 
   mapping account = load_account(account_name);
-  if(!account)
-    return false;
 
-  string *characters = account["characters"] || ({});
+  string *characters = account.characters || ({});
   characters -= ({ character_name });
-  account["characters"] = characters;
+  account.characters = characters;
   accounts[account_name] = account;
 
   map_delete(reverse, character_name);
@@ -321,14 +336,16 @@ int remove_character(string account_name, string character_name) {
  * Retrieves the account name associated with a character.
  *
  * @param {CharacterName} character_name - The character name to look up
- * @returns {AccountName} The associated account name if found, null otherwise
+ * @returns {AccountName | undefined} The associated account name if found, undefined otherwise
  */
 string character_account(string character_name) {
   if(!character_name || !stringp(character_name))
-    return null;
+    return undefined;
+
+  character_name = lower_case(character_name);
 
   if(!reverse[character_name])
-    return null;
+    return undefined;
 
   return reverse[character_name];
 }
@@ -337,27 +354,27 @@ string character_account(string character_name) {
  * Retrieves all characters associated with an account.
  *
  * @param {AccountName} account_name - The account name to look up
- * @returns {CharacterName*} Array of character names if found, null otherwise
+ * @returns {CharacterName* | undefined} Array of character names if found, undefined otherwise
 */
 string* account_characters(string account_name) {
   if(!account_name || !stringp(account_name))
-    return null;
+    return undefined;
+
+  account_name = lower_case(account_name);
 
   if(!valid_manip(account_name))
-    return null;
+    return undefined;
 
   if(!accounts[account_name])
-    return null;
+    return undefined;
 
   mapping account = load_account(account_name);
-  if(!account)
-    return false;
 
-  return account["characters"] || ({});
+  return account.characters || ({});
 }
 
 /**
- * @typedef {0|1} Boolean
+ * @typedef {0 | 1} Boolean
  * 1 for true, 0 for false.
  */
 
@@ -380,6 +397,6 @@ string* account_characters(string account_name) {
  /**
   * An account record.
   * @typedef {mapping} AccountRecord
-  * @property {string*} character_names - A list of character names for this account.
+  * @property {string*} characters - A list of character names for this account.
   * @property {string} password - The password for this account.
   */

--- a/adm/obj/master/security.lpc
+++ b/adm/obj/master/security.lpc
@@ -32,6 +32,9 @@
  * group-conferred plus direct - and is the precise "this operation
  * requires this role" gate.
  *
+ * adm/obj/master.lpc->privs_file(string filename) decides what objects
+ * identify as when loaded.
+ *
  * @created 2005-04-23 - Tacitus
  * @last_modified 2026-06-16 - Gesslar
  *

--- a/tests/adm/daemons/account.test.lpc
+++ b/tests/adm/daemons/account.test.lpc
@@ -1,0 +1,301 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/daemons/account.test.lpc
+ * @description Tests for ACCOUNT_D (/adm/daemons/account.lpc) — account
+ *              creation, record storage, key read/write, character
+ *              association, and removal.
+ *
+ * Permission note: valid_manip() short-circuits on adminp(this_caller()), so
+ * every happy path here relies on `runtests` being run by an admin/owner (it
+ * always is). The negative permission path is therefore NOT exercisable from
+ * this harness — the caller is always privileged — so it is registered as a
+ * pending() rather than a failing test.
+ *
+ * Isolation: these tests mutate the live, persistent daemon and touch
+ * /data/accounts on disk. Every test defensively wipes its fixture names
+ * before and after, and _clean() removes both the in-memory record and the
+ * on-disk account file so a leftover file can't masquerade as a duplicate on
+ * the next run.
+ */
+
+#include <test.h>
+#include <daemons.h>
+
+inherit STD_TEST;
+
+#define ACCT    "oxtestacct"
+#define ACCT_B  "oxtestacctb"
+#define PW      "$6$oxsalt$oxhashvalue"
+#define CHAR_A  "oxtestchara"
+#define CHAR_B  "oxtestcharb"
+
+private void _wipe(string name) {
+  // Belt-and-suspenders isolation: drop any on-disk file and the in-memory
+  // record. remove_account() now rm()s the file itself, but a test may throw
+  // before reaching it, so we clean both here defensively.
+  catch(rm(account_file(name)));
+  catch(ACCOUNT_D->remove_account(name));
+}
+
+private void _clean() {
+  _wipe(ACCT);
+  _wipe(ACCT_B);
+}
+
+void setup() {
+  describe("create_account", ({
+    test("creates a valid account", function() {
+      _clean();
+      ASSERT_EQ(1, ACCOUNT_D->create_account(ACCT, PW));
+      ASSERT_EQ(1, valid_account(ACCT));
+      _clean();
+    }),
+    test("stored record carries password and empty character list", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      mapping record = ACCOUNT_D->load_account(ACCT);
+      ASSERT_EQ(PW, record["password"]);
+      ASSERT_EQ(({}), record["characters"]);
+      _clean();
+    }),
+    test("lower-cases the stored name", function() {
+      _clean();
+      ASSERT_EQ(1, ACCOUNT_D->create_account("OxTestAcct", PW));
+      ASSERT_EQ(1, valid_account(ACCT));
+      _clean();
+    }),
+    test("rejects a duplicate account", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ASSERT_EQ(0, ACCOUNT_D->create_account(ACCT, PW));
+      _clean();
+    }),
+    test("rejects a password not encrypted with $6$", function() {
+      _clean();
+      ASSERT_EQ(0, ACCOUNT_D->create_account(ACCT, "plaintext"));
+      ASSERT_EQ(0, valid_account(ACCT));
+      _clean();
+    }),
+    test("rejects a non-string name", function() {
+      ASSERT_EQ(0, ACCOUNT_D->create_account(5, PW));
+    }),
+    test("rejects a non-string password", function() {
+      _clean();
+      ASSERT_EQ(0, ACCOUNT_D->create_account(ACCT, 5));
+      _clean();
+    }),
+  }));
+
+  describe("valid_account", ({
+    test("false for a non-existent account", function() {
+      _clean();
+      ASSERT_EQ(0, valid_account(ACCT));
+    }),
+    test("false for a non-string name", function() {
+      ASSERT_EQ(0, valid_account(5));
+    }),
+    test("true after the account is created", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ASSERT_EQ(1, valid_account(ACCT));
+      _clean();
+    }),
+  }));
+
+  describe("load_account", ({
+    test("returns undefined for a non-existent account", function() {
+      _clean();
+      ASSERT_EQ(undefined, ACCOUNT_D->load_account(ACCT));
+    }),
+    test("returns the record after creation", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      mapping record = ACCOUNT_D->load_account(ACCT);
+      ASSERT_EQ(1, mapp(record));
+      ASSERT_EQ(PW, record["password"]);
+      _clean();
+    }),
+  }));
+
+  describe("write_account / read_account", ({
+    test("write then read round-trips a value", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ASSERT_EQ("hello", ACCOUNT_D->write_account(ACCT, "greeting", "hello"));
+      ASSERT_EQ("hello", ACCOUNT_D->read_account(ACCT, "greeting"));
+      _clean();
+    }),
+    test("read of an unset key returns undefined", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      // A mapping miss passes through as undefined (T_UNDEFINED), NOT an
+      // explicit `false`/0 (T_NUMBER) — same() distinguishes the two.
+      ASSERT_EQ(undefined, ACCOUNT_D->read_account(ACCT, "no_such_key"));
+      _clean();
+    }),
+    test("write rejects a non-string key", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ASSERT_EQ(0, ACCOUNT_D->write_account(ACCT, 5, "value"));
+      _clean();
+    }),
+    test("write rejects null data", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ASSERT_EQ(0, ACCOUNT_D->write_account(ACCT, "greeting", 0));
+      _clean();
+    }),
+    test("read of a non-existent account returns 0", function() {
+      _clean();
+      ASSERT_EQ(0, ACCOUNT_D->read_account(ACCT, "greeting"));
+    }),
+  }));
+
+  describe("character association", ({
+    test("add_character associates a character with the account", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ASSERT_EQ(1, ACCOUNT_D->add_character(ACCT, CHAR_A));
+      ASSERT_EQ(ACCT, ACCOUNT_D->character_account(CHAR_A));
+      ASSERT_EQ(({ CHAR_A }), ACCOUNT_D->account_characters(ACCT));
+      _clean();
+    }),
+    test("add_character lower-cases the character name", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ACCOUNT_D->add_character(ACCT, "OxTestCharA");
+      ASSERT_EQ(ACCT, ACCOUNT_D->character_account(CHAR_A));
+      _clean();
+    }),
+    test("add_character does not duplicate an existing character", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ACCOUNT_D->add_character(ACCT, CHAR_A);
+      ACCOUNT_D->add_character(ACCT, CHAR_A);
+      ASSERT_EQ(1, sizeof(ACCOUNT_D->account_characters(ACCT)));
+      _clean();
+    }),
+    test("add_character tracks multiple characters", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ACCOUNT_D->add_character(ACCT, CHAR_A);
+      ACCOUNT_D->add_character(ACCT, CHAR_B);
+      ASSERT_EQ(({ CHAR_A, CHAR_B }), ACCOUNT_D->account_characters(ACCT));
+      _clean();
+    }),
+    test("add_character returns undefined for an unknown account", function() {
+      _clean();
+      ASSERT_EQ(undefined, ACCOUNT_D->add_character(ACCT, CHAR_A));
+    }),
+    test("remove_character drops the association", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ACCOUNT_D->add_character(ACCT, CHAR_A);
+      ASSERT_EQ(1, ACCOUNT_D->remove_character(ACCT, CHAR_A));
+      ASSERT_EQ(0, sizeof(ACCOUNT_D->account_characters(ACCT)));
+      ASSERT_EQ(undefined, ACCOUNT_D->character_account(CHAR_A));
+      _clean();
+    }),
+    test("remove_character returns undefined for an unknown account", function() {
+      _clean();
+      ASSERT_EQ(undefined, ACCOUNT_D->remove_character(ACCT, CHAR_A));
+    }),
+    test("account_characters is undefined for an unknown account", function() {
+      _clean();
+      ASSERT_EQ(undefined, ACCOUNT_D->account_characters(ACCT));
+    }),
+    test("character_account is undefined for an unknown character", function() {
+      ASSERT_EQ(undefined, ACCOUNT_D->character_account("oxnobodychar"));
+    }),
+  }));
+
+  describe("remove_account", ({
+    test("removes an existing account", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ASSERT_EQ(1, ACCOUNT_D->remove_account(ACCT));
+      ASSERT_EQ(0, valid_account(ACCT));
+      _clean();
+    }),
+    test("clears the reverse character mapping", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ACCOUNT_D->add_character(ACCT, CHAR_A);
+      ACCOUNT_D->remove_account(ACCT);
+      ASSERT_EQ(undefined, ACCOUNT_D->character_account(CHAR_A));
+      _clean();
+    }),
+    test("returns 0 for a non-existent account", function() {
+      _clean();
+      ASSERT_EQ(0, ACCOUNT_D->remove_account(ACCT));
+    }),
+  }));
+
+  describe("case normalization", ({
+    test("valid_account is case-insensitive", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ASSERT_EQ(1, valid_account("OxTestAcct"));
+      _clean();
+    }),
+    test("load_account is case-insensitive", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      mapping record = ACCOUNT_D->load_account("OxTestAcct");
+      ASSERT_EQ(PW, record["password"]);
+      _clean();
+    }),
+    test("read_account is case-insensitive", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ACCOUNT_D->write_account(ACCT, "greeting", "hello");
+      ASSERT_EQ("hello", ACCOUNT_D->read_account("OxTestAcct", "greeting"));
+      _clean();
+    }),
+    test("create_account rejects a case-variant duplicate", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ASSERT_EQ(0, ACCOUNT_D->create_account("OxTestAcct", PW));
+      _clean();
+    }),
+    test("character_account is case-insensitive", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ACCOUNT_D->add_character(ACCT, CHAR_A);
+      ASSERT_EQ(ACCT, ACCOUNT_D->character_account("OxTestCharA"));
+      _clean();
+    }),
+  }));
+
+  describe("removal — disk persistence", ({
+    test("remove_account deletes the on-disk account file", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      // write_account() is the only path that puts a file on disk.
+      ACCOUNT_D->write_account(ACCT, "greeting", "hello");
+      ASSERT_EQ(1, file_exists(account_file(ACCT)));
+      ACCOUNT_D->remove_account(ACCT);
+      // remove_account() now rm()s the file it persisted, so no orphan is
+      // left behind.
+      ASSERT_EQ(0, file_exists(account_file(ACCT)));
+      _wipe(ACCT);
+    }),
+    test("a removed account does not resurrect from a stale file", function() {
+      _clean();
+      ACCOUNT_D->create_account(ACCT, PW);
+      ACCOUNT_D->write_account(ACCT, "greeting", "hello");
+      ACCOUNT_D->remove_account(ACCT);
+      // With the file gone, load_account() has nothing to slurp back in, so
+      // a removed account stays removed.
+      ASSERT_EQ(0, valid_account(ACCT));
+      _wipe(ACCT);
+    }),
+  }));
+
+  describe("known boundaries", ({
+    pending("valid_manip() rejects an unprivileged caller",
+      "adminp(this_caller()) short-circuits to true under the admin-run test "
+      "runner, so the rejection branch of valid_manip() cannot be reached from "
+      "here. Needs a fixture that calls in with non-admin privs."),
+  }));
+}

--- a/tests/adm/daemons/runner.lpc
+++ b/tests/adm/daemons/runner.lpc
@@ -1,0 +1,1 @@
+inherit STD_TEST_RUNNER;


### PR DESCRIPTION
Account daemon names are now normalized to lower case on every public entry point — not only during account creation — so mixed-case lookups, writes, reads, and character operations all resolve correctly regardless of how the caller spells the name.

`remove_account` now deletes the on-disk account file after wiping the in-memory record. Previously, a persisted file left behind by `write_account` could be slurped back in by a subsequent `load_account` call, silently resurrecting an account that had been removed.

Null returns throughout the daemon have been replaced with `undefined` to accurately reflect the absence of a value rather than a falsy integer.

The `valid_manip` and null-guard checks have been reordered in every function so that the name is lower-cased before validation runs, ensuring the permission and existence checks operate on the canonical form.

A full test suite for `ACCOUNT_D` has been added covering account creation, duplicate rejection, password validation, key round-trips, character association and removal, case-insensitive lookups across all entry points, and the disk-persistence/resurrection regression. A pending test documents the one branch — the unprivileged-caller path in `valid_manip` — that cannot be exercised from an admin-run test harness.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes account operations use canonical lowercase names. The main changes are:
- Normalize account and character names at public daemon entry points.
- Delete persisted account files during account removal.
- Add account-daemon lifecycle and persistence tests.
- Add the daemon test runner.
</details>

<sub>Reviews (1): Last reviewed commit: ["adding tests for adm/daemons/account"](https://github.com/gesslar/oxidus-mudlib/commit/0cdcaa7eac573aad69757747c6e05770efc04af3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43686522)</sub>

**Context used:**

- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->