### PR TITLE
Enable `statusCheck` in Greptile config

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -2,7 +2,7 @@
   "strictness": 2,
   "commentTypes": ["logic", "syntax"],
   "triggerOnUpdates": true,
-  "statusCheck": false,
+  "statusCheck": true,
   "fixWithAI": false,
   "ignorePatterns": "adm/dist/fluffos/**\nadm/dist/bin/**\ninclude/driver/**\narchive/**\ndoc/_wiki/**\nnode_modules/**\ndata/**\nopen/**\ntmp/**\nlog/**\n*.tbl\n*.sqlite3\npackage-lock.json",
   "summarySection": {


### PR DESCRIPTION
Enables the Greptile status check, which will now block or flag pull requests based on Greptile's review results rather than running in an advisory-only capacity.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR enables Greptile status-check reporting for pull requests.

- Sets `statusCheck` to `true` in `.greptile/config.json`.
</details>

<sub>Reviews (2): Last reviewed commit: ["switching to status check=true"](https://github.com/gesslar/oxidus-mudlib/commit/5b53f17de686aa928a99a119c8fc2f3288e1a815) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43686708)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
</details>

<!-- /greptile_comment -->