### PR TITLE
Fix `chop`, `from_string` hex parsing, `different` null guard, and add `safe_string` tests

### DIFF
--- a/adm/obj/master.lpc
+++ b/adm/obj/master.lpc
@@ -161,6 +161,12 @@ protected void log_error(string _file, string message) {
 
 // Blatanly stolen from Lima
 int different(string fn, string pr) {
+  // A programless frame (destructed/failed-to-load object) yields a 0
+  // program name; there's nothing to compare, and feeding 0 to chop() now
+  // throws on its stringp guard — which would fault the error handler itself.
+  if(!stringp(fn) || !stringp(pr))
+    return 0;
+
   sscanf(fn, "%s#%*d", fn);
   pr = chop(chop(pr, ".lpc", -1), ".c", -1);
 

--- a/adm/simul_efun/string.lpc
+++ b/adm/simul_efun/string.lpc
@@ -54,27 +54,25 @@ string prepend(string source, string to_prepend) {
  * @param {int} [dir=-1] - The direction to chop: 1 for left, -1 for right.
  * @returns {string} The string with the substring chopped off if it was present.
  */
-varargs string chop(string str, string sub, int dir) {
-    int sub_len;
+varargs string chop(string str, string sub, int dir: (: -1 :)) {
+  assert_arg(stringp(str), 1, "Missing or invalid argument.");
+  assert_arg(stringp(sub), 2, "Missing or invalid argument.");
 
-    if(nullp(str)) error("chop: Missing argument 1 for chop");
-    if(nullp(sub)) error("chop: Missing argument 2 for chop");
+  if(dir != 1)
+    dir = -1;
 
-    if(dir != -1)
-        dir = 1;
-
-    sub_len = strlen(sub);
-    if(dir == 1) {
-        if(sub[0..sub_len-1] == sub) {
-            str = str[0..sub_len];
-        }
-    } else if(dir == -1) {
-        if(str[<sub_len..] == sub) {
-            str = str[0..<sub_len+1];
-        }
+  int sub_len = strlen(sub);
+  if(dir == 1) {
+    if(str[0..sub_len-1] == sub) {
+      str = str[sub_len..];
     }
+  } else if(dir == -1) {
+    if(str[<sub_len..] == sub) {
+      str = str[0..<sub_len+1];
+    }
+  }
 
-    return str;
+  return str;
 }
 
 /**
@@ -314,7 +312,9 @@ varargs mixed from_string(string str, int flag) {
         if(strlen(str) > 1 && str[0..1] == "0x") {
             tmp = "0x";
             str = str[2..];
-            while(str != "" && (str[0] >= '0' && str[0] <= '9')) {
+            while(str != "" && ((str[0] >= '0' && str[0] <= '9') ||
+                    (str[0] >= 'a' && str[0] <= 'f') ||
+                    (str[0] >= 'A' && str[0] <= 'F'))) {
                 tmp += str[0..0];
                 if(strlen(str) > 1) str = str[1..];
                 else str = "";
@@ -628,7 +628,7 @@ string sanitize_regex(string msg) {
   return msg;
 }
 
-private nomask string illegal_filename_chars = "[<>:\"/\\\\|?*\x01-\x1F\x7F]";
+private nomask string illegal_filename_chars = "([<>:\"/\\\\|?*\x01-\x1F\x7F])";
 
 /**
  * Sanitises a string so that it is safe to use as a filename.

--- a/tests/adm/simul_efun/string.affix.test.lpc
+++ b/tests/adm/simul_efun/string.affix.test.lpc
@@ -62,16 +62,15 @@ void setup() {
       string err = catch(chop("foo", 0));
       ASSERT_NE(0, err);
     }),
-    // The left-chop branch (dir == 1) tests `sub[0..sub_len-1] == sub`, which
-    // compares sub to itself and is always true, then slices `str[0..sub_len]`.
-    // chop("foobar", "foo", 1) yields "foob" instead of "bar".
-    pending("left direction removes the prefix",
-      "dir==1 branch is broken — compares sub to itself, see string.c#L67-70"),
-    // With no dir argument, dir defaults to 0 and `if(dir != -1) dir = 1` routes
-    // to the broken left-chop branch, so chop("foobar", "bar") yields "foob"
-    // rather than the documented right-chop result "foo".
-    pending("default direction chops from the right",
-      "default dir routes to the broken left branch, see string.c#L57-70"),
+    test("left direction removes the prefix", function() {
+      ASSERT_EQ("bar", chop("foobar", "foo", 1));
+    }),
+    test("left direction leaves the string unchanged when the prefix is absent", function() {
+      ASSERT_EQ("foobar", chop("foobar", "xyz", 1));
+    }),
+    test("default direction chops from the right", function() {
+      ASSERT_EQ("foo", chop("foobar", "bar"));
+    }),
   }));
 
   describe("starts_with", ({

--- a/tests/adm/simul_efun/string.convert.test.lpc
+++ b/tests/adm/simul_efun/string.convert.test.lpc
@@ -27,10 +27,12 @@ void setup() {
     test("parses a quoted string", function() {
       ASSERT_EQ("hello", from_string("\"hello\""));
     }),
-    // The hex scan loop only accepts digits 0-9, never a-f, so any hex literal
-    // containing a letter digit stops early: from_string("0xFF") yields 0.
-    pending("parses a hexadecimal integer with letter digits",
-      "hex loop excludes a-f, see string.c#L316"),
+    test("parses a hexadecimal integer with letter digits", function() {
+      ASSERT_EQ(255, from_string("0xFF"));
+    }),
+    test("parses a hexadecimal integer with lowercase letter digits", function() {
+      ASSERT_EQ(255, from_string("0xff"));
+    }),
     test("an empty string parses to 0", function() {
       ASSERT_EQ(0, from_string(""));
     }),

--- a/tests/adm/simul_efun/string.safe.test.lpc
+++ b/tests/adm/simul_efun/string.safe.test.lpc
@@ -1,0 +1,77 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/string.safe.test.lpc
+ * @description Tests for the safe_string() simul_efun from
+ *              /adm/simul_efun/string.lpc — strips filename-illegal
+ *              characters (and leading/trailing dots) so a string can be
+ *              used as a filename.
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("safe_string", ({
+    test("leaves an already-safe string unchanged", function() {
+      ASSERT_EQ("hello_world", safe_string("hello_world"));
+    }),
+    test("an empty string is safe and returns empty", function() {
+      ASSERT_EQ("", safe_string(""));
+    }),
+    test("drops illegal characters by default", function() {
+      ASSERT_EQ("abc", safe_string("a/b:c"));
+    }),
+    test("drops the full set of illegal filename characters", function() {
+      ASSERT_EQ("ab", safe_string("a<>:\"/\\|?*b"));
+    }),
+    test("collapses a run of illegal characters", function() {
+      ASSERT_EQ("ab", safe_string("a<<>>b"));
+    }),
+    test("strips control characters", function() {
+      ASSERT_EQ("abc", safe_string("a\tb\nc"));
+    }),
+    test("a string of only illegal characters becomes empty", function() {
+      ASSERT_EQ("", safe_string("///"));
+    }),
+    test("strips trailing dots", function() {
+      ASSERT_EQ("file", safe_string("file..."));
+    }),
+    test("strips leading dots", function() {
+      ASSERT_EQ("hidden", safe_string(".hidden"));
+    }),
+    test("strips both leading and trailing dots", function() {
+      ASSERT_EQ("name", safe_string("..name.."));
+    }),
+    test("keeps interior dots", function() {
+      ASSERT_EQ("a.b.c", safe_string("a.b.c"));
+    }),
+  }));
+
+  describe("safe_string replacement", ({
+    test("substitutes a replacement for each illegal character", function() {
+      ASSERT_EQ("a_b_c", safe_string("a/b:c", "_"));
+    }),
+    test("replacement applies per illegal character", function() {
+      ASSERT_EQ("a__b", safe_string("a<>b", "_"));
+    }),
+    test("a non-illegal replacement string is allowed", function() {
+      ASSERT_EQ("a-b", safe_string("a/b", "-"));
+    }),
+  }));
+
+  describe("safe_string errors", ({
+    test("non-string first argument errors", function() {
+      string err = catch(safe_string(42));
+      ASSERT_NE(0, err);
+    }),
+    test("undefined first argument errors", function() {
+      string err = catch(safe_string(undefined));
+      ASSERT_NE(0, err);
+    }),
+    test("a replacement containing illegal characters errors", function() {
+      string err = catch(safe_string("abc", "/"));
+      ASSERT_NE(0, err);
+    }),
+  }));
+}


### PR DESCRIPTION
This PR fixes several bugs in the string simul_efun and master object, and adds new test coverage.

**`chop()` rewrite**

The `dir` parameter default and branch logic were inverted, causing the left-chop branch to always match (comparing `sub` to itself) and the default direction to route to that broken branch instead of right-chop. The function now uses a proper default of `-1`, correctly normalizes unrecognized direction values to `-1`, and fixes the left-chop slice to return the remainder after the prefix rather than an overlapping segment. Argument validation is updated to use `assert_arg` with a `stringp` guard, replacing the previous `nullp` checks. Previously pending tests for left-chop and default-direction behavior are now active and passing.

**`from_string()` hex parsing**

The hex digit scan loop only accepted `0–9`, causing any hex literal with letter digits (e.g. `0xFF`) to stop early and return `0`. The loop condition now also accepts `a–f` and `A–F`. The previously pending test is now active.

**`different()` null guard in master**

A destructed or failed-to-load object produces a `0` program name. Passing that `0` to `chop()` now throws due to the new `stringp` guard, which would fault the error handler itself. A `stringp` check on both arguments short-circuits the comparison and returns `0` before reaching `chop()`.

**`illegal_filename_chars` regex fix**

The replacement pattern lacked a capture group, so `regexp_replace` had no `\1` to substitute and was not correctly isolating individual illegal characters for replacement. The pattern is now wrapped in a capture group.

**New `safe_string` tests**

A new test file covers `safe_string` across normal operation (safe passthrough, illegal character removal, control character stripping, dot trimming), replacement-string behavior, and error cases for invalid arguments and illegal replacement strings.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes string helper edge cases and expands their tests.

- Corrects `chop()` defaults, prefix removal, and argument validation.
- Accepts letter digits in hexadecimal `from_string()` inputs.
- Guards programless error-trace frames in `master`.
- Fixes filename-character replacement matching and adds `safe_string()` tests.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: guard master different() against pr..."](https://github.com/gesslar/oxidus-mudlib/commit/4916396bac18fa5b186f38f7fde40f0de9862e7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43716168)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
</details>

<!-- /greptile_comment -->