### PR TITLE
Refactor `evaluate_compound_condition` into recursive descent parser, add tests

### DIFF
--- a/adm/simul_efun/number.lpc
+++ b/adm/simul_efun/number.lpc
@@ -144,45 +144,92 @@ private int evaluate_simple_condition(int number, string condition) {
 
     set = map(explode(set_str[1..<2], ","), (: to_int($1) :));
 
-    return exclude ? (of(set, number) == -1) : (of(set, number) != -1);
+    return exclude ? !of(number, set) : of(number, set);
   }
 
   error("Invalid condition format: " + condition);
 }
 
 /**
- * Evaluates a number against a compound condition.
+ * Splits a condition string on a delimiter word, but only where it
+ * appears at the top level — occurrences nested inside parentheses `()`
+ * or set brackets `[]` are left intact so grouping is honoured.
  *
- * Handles compound conditions using logical operators AND and OR.
- * AND has higher precedence than OR.
- *
- * @param {int} number - The number to evaluate.
- * @param {string} condition - The compound condition to evaluate against.
- * @returns {int} 1 if the compound condition evaluates to true, 0 otherwise.
+ * @param {string} str - The condition string to split.
+ * @param {string} delim - The delimiter word ("and" or "or").
+ * @returns {string*} The top-level segments, with the delimiter removed.
  */
-private int evaluate_compound_condition(int number, string condition) {
-  string *parts, part;
-  string *or_parts, or_part;
-  int or_result, i, j;
+private string *split_top_level(string str, string delim) {
+  string *parts = ({});
+  int depth = 0, start = 0, len = strlen(str), dlen = strlen(delim), i;
 
-  parts = explode(lower_case(condition), "and");
-  for(i = 0; i < sizeof(parts); i++) {
-    part = parts[i];
-    or_parts = explode(part, "or");
-    or_result = 0;
-    for(j = 0; j < sizeof(or_parts); j++) {
-      or_part = trim(or_parts[j]);
-      if(or_part[0] == '(') or_part = or_part[1..<2]; // Remove parentheses
-      if(evaluate_simple_condition(number, or_part)) {
-        or_result = 1;
-        break;
-      }
+  for(i = 0; i < len; i++) {
+    int c = str[i];
+
+    if(c == '(' || c == '[')
+      depth++;
+    else if(c == ')' || c == ']')
+      depth--;
+    else if(depth == 0 && i + dlen <= len && str[i..i+dlen-1] == delim) {
+      parts += ({ str[start..i-1] });
+      i += dlen - 1;
+      start = i + 1;
     }
-    if(!or_result)
-      return 0; // If any AND condition fails, return false
   }
 
-  return 1; // All AND conditions passed
+  parts += ({ str[start..] });
+  return parts;
+}
+
+// Forward declaration — evaluate_term() recurses into a parenthesised group.
+private int evaluate_or_expr(int number, string condition);
+
+/**
+ * Evaluates a single term: either a parenthesised sub-expression
+ * (evaluated recursively) or a leaf simple condition.
+ *
+ * @param {int} number - The number to evaluate.
+ * @param {string} condition - A single AND-operand.
+ * @returns {int} 1 if the term is satisfied, 0 otherwise.
+ */
+private int evaluate_term(int number, string condition) {
+  condition = trim(condition);
+
+  if(condition[0] == '(' && condition[<1] == ')')
+    return evaluate_or_expr(number, condition[1..<2]);
+
+  return evaluate_simple_condition(number, condition);
+}
+
+/**
+ * Evaluates an AND-expression: every top-level term must be true.
+ *
+ * @param {int} number - The number to evaluate.
+ * @param {string} condition - An OR-operand (an AND of terms).
+ * @returns {int} 1 if all terms are satisfied, 0 otherwise.
+ */
+private int evaluate_and_expr(int number, string condition) {
+  foreach(string term in split_top_level(condition, "and"))
+    if(!evaluate_term(number, term))
+      return 0;
+
+  return 1;
+}
+
+/**
+ * Evaluates an OR-expression: at least one top-level AND-expression must
+ * be true. OR binds loosest, so this is the compound-condition entry point.
+ *
+ * @param {int} number - The number to evaluate.
+ * @param {string} condition - A compound condition.
+ * @returns {int} 1 if any AND-expression is satisfied, 0 otherwise.
+ */
+private int evaluate_or_expr(int number, string condition) {
+  foreach(string term in split_top_level(condition, "or"))
+    if(evaluate_and_expr(number, term))
+      return 1;
+
+  return 0;
 }
 
 /**
@@ -251,9 +298,9 @@ private int evaluate_compound_condition(int number, string condition) {
  * @throws If the condition contains invalid syntax or operators.
  */
 int evaluate_number(int number, string condition) {
-  // Remove all spaces from the condition
-  condition = replace_string(condition, " ", "");
-  return evaluate_compound_condition(number, condition);
+  // Strip all spaces and normalise operator case before parsing.
+  condition = lower_case(replace_string(condition, " ", ""));
+  return evaluate_or_expr(number, condition);
 }
 
 float diminish(mixed val, mixed scale) {
@@ -355,13 +402,19 @@ float dim_exponential_decay(mixed val, mixed scale) {
 
 /**
  * Sigmoid (zero-anchored logistic) diminishing return on `val`,
- * scaled by `scale`. Computes `scale * (2/(1 + e^-(val/scale)) - 1)`,
- * producing an S-shaped curve that is 0 at `val == 0`, equals
- * roughly `0.462 * scale` when `val == scale`, and asymptotically
- * approaches `scale` as `val` grows.
+ * scaled by `scale`. Computes `scale * (2/(1 + e^-(val*k)) - 1)`,
+ * producing an S-shaped curve that is 0 at `val == 0`, odd-symmetric
+ * about the origin, and asymptotically approaches `scale` as `val`
+ * grows. The steepness coefficient `k` controls how fast the curve
+ * climbs: output reaches `scale / 2` at `val == ln(3) / k` (~1.0986/k).
+ *
+ * Note: `k` is applied as a multiplier on `val`, not derived from
+ * `scale`, and has no default — omitting it passes 0, which flattens
+ * the curve to 0 for every input. Always supply a `k`.
  *
  * @param {mixed} val - The input value.
  * @param {mixed} scale - The scale factor and asymptotic ceiling.
+ * @param {mixed} k - The steepness coefficient, multiplied into `val`.
  * @returns {float} The diminished value, bounded by `scale`.
  */
 varargs float dim_sigmoid(mixed val, mixed scale, mixed k) {

--- a/tests/adm/simul_efun/number.test.lpc
+++ b/tests/adm/simul_efun/number.test.lpc
@@ -1,0 +1,324 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/number.test.lpc
+ * @description Tests for the number simul_efuns from /adm/simul_efun/number.lpc:
+ *              percent/percent_of, clamp/clamped/between, remainder, sum,
+ *              evaluate_number (condition DSL), and the diminishing-return
+ *              family (diminish, dim_square_root, dim_logarithmic,
+ *              dim_hyperbolic, dim_exponential_decay, dim_sigmoid).
+ *
+ * Exact IEEE results are asserted directly; irrational results (sqrt/log/exp)
+ * are asserted to fall within a tight band via `ASSERT_EQ(1, lo < r && r < hi)`.
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("percent_of", ({
+    test("50% of 200 is 100", function() {
+      ASSERT_EQ(100.0, percent_of(50.0, 200.0));
+    }),
+    test("25% of 80 is 20", function() {
+      ASSERT_EQ(20.0, percent_of(25.0, 80.0));
+    }),
+    test("0% of anything is 0", function() {
+      ASSERT_EQ(0.0, percent_of(0.0, 200.0));
+    }),
+    test("100% of 50 is 50", function() {
+      ASSERT_EQ(50.0, percent_of(100.0, 50.0));
+    }),
+  }));
+
+  describe("percent", ({
+    test("50 out of 200 is 25%", function() {
+      ASSERT_EQ(25.0, percent(50.0, 200.0));
+    }),
+    test("1 out of 4 is 25%", function() {
+      ASSERT_EQ(25.0, percent(1.0, 4.0));
+    }),
+    test("the whole is 100%", function() {
+      ASSERT_EQ(100.0, percent(200.0, 200.0));
+    }),
+    test("0 out of anything is 0%", function() {
+      ASSERT_EQ(0.0, percent(0.0, 5.0));
+    }),
+  }));
+
+  describe("clamp", ({
+    test("a value inside the range is unchanged", function() {
+      ASSERT_EQ(5.0, clamp(5.0, 0.0, 10.0));
+    }),
+    test("a value below the range clamps to min", function() {
+      ASSERT_EQ(0.0, clamp(-5.0, 0.0, 10.0));
+    }),
+    test("a value above the range clamps to max", function() {
+      ASSERT_EQ(10.0, clamp(15.0, 0.0, 10.0));
+    }),
+    test("the min boundary is preserved", function() {
+      ASSERT_EQ(0.0, clamp(0.0, 0.0, 10.0));
+    }),
+    test("the max boundary is preserved", function() {
+      ASSERT_EQ(10.0, clamp(10.0, 0.0, 10.0));
+    }),
+  }));
+
+  describe("clamped", ({
+    test("a value inside the range is clamped", function() {
+      ASSERT_EQ(1, clamped(5.0, 0.0, 10.0));
+    }),
+    test("the min boundary is inclusive", function() {
+      ASSERT_EQ(1, clamped(0.0, 0.0, 10.0));
+    }),
+    test("the max boundary is inclusive", function() {
+      ASSERT_EQ(1, clamped(10.0, 0.0, 10.0));
+    }),
+    test("below the range is not clamped", function() {
+      ASSERT_EQ(0, clamped(-1.0, 0.0, 10.0));
+    }),
+    test("above the range is not clamped", function() {
+      ASSERT_EQ(0, clamped(11.0, 0.0, 10.0));
+    }),
+  }));
+
+  describe("between", ({
+    test("a value inside the range is between", function() {
+      ASSERT_EQ(1, between(5.0, 0.0, 10.0));
+    }),
+    test("the min boundary is exclusive", function() {
+      ASSERT_EQ(0, between(0.0, 0.0, 10.0));
+    }),
+    test("the max boundary is exclusive", function() {
+      ASSERT_EQ(0, between(10.0, 0.0, 10.0));
+    }),
+    test("below the range is not between", function() {
+      ASSERT_EQ(0, between(-1.0, 0.0, 10.0));
+    }),
+  }));
+
+  describe("remainder", ({
+    test("fractional part of 10/4 is 0.5", function() {
+      ASSERT_EQ(0.5, remainder(10, 4));
+    }),
+    test("an evenly divisible quotient has no remainder", function() {
+      ASSERT_EQ(0.0, remainder(9, 3));
+    }),
+    test("accepts float arguments", function() {
+      ASSERT_EQ(0.5, remainder(5.0, 2.0));
+    }),
+    test("fractional part of 10/3 is ~0.333", function() {
+      float r = remainder(10, 3);
+      ASSERT_EQ(1, r > 0.333 && r < 0.334);
+    }),
+  }));
+
+  describe("sum", ({
+    test("sums a list of positive integers", function() {
+      ASSERT_EQ(10, sum(({ 1, 2, 3, 4 })));
+    }),
+    test("an empty array sums to 0", function() {
+      ASSERT_EQ(0, sum(({})));
+    }),
+    test("a single element sums to itself", function() {
+      ASSERT_EQ(5, sum(({ 5 })));
+    }),
+    test("negatives cancel positives", function() {
+      ASSERT_EQ(0, sum(({ 10, -3, -7 })));
+    }),
+  }));
+
+  describe("evaluate_number basic operators", ({
+    test("= matches", function() {
+      ASSERT_EQ(1, evaluate_number(5, "=5"));
+    }),
+    test("== matches", function() {
+      ASSERT_EQ(1, evaluate_number(5, "==5"));
+    }),
+    test("> is true when greater", function() {
+      ASSERT_EQ(1, evaluate_number(5, ">3"));
+    }),
+    test("< is false when not less", function() {
+      ASSERT_EQ(0, evaluate_number(5, "<3"));
+    }),
+    test(">= is inclusive", function() {
+      ASSERT_EQ(1, evaluate_number(5, ">=5"));
+    }),
+    test("<= is inclusive", function() {
+      ASSERT_EQ(1, evaluate_number(5, "<=5"));
+    }),
+    test("!= is true when unequal", function() {
+      ASSERT_EQ(1, evaluate_number(5, "!=3"));
+    }),
+    test("!= is false when equal", function() {
+      ASSERT_EQ(0, evaluate_number(5, "!=5"));
+    }),
+    test("spaces in the condition are ignored", function() {
+      ASSERT_EQ(1, evaluate_number(7, "5 - 10"));
+    }),
+  }));
+
+  describe("evaluate_number modulo, range, set", ({
+    test("modulo is true when divisible", function() {
+      ASSERT_EQ(1, evaluate_number(9, "%3"));
+    }),
+    test("modulo is false when not divisible", function() {
+      ASSERT_EQ(0, evaluate_number(10, "%3"));
+    }),
+    test("range is inclusive of both ends", function() {
+      ASSERT_EQ(1, evaluate_number(5, "5-10"));
+    }),
+    test("range matches the upper bound", function() {
+      ASSERT_EQ(1, evaluate_number(10, "5-10"));
+    }),
+    test("range excludes values outside it", function() {
+      ASSERT_EQ(0, evaluate_number(11, "5-10"));
+    }),
+    test("set inclusion matches a member", function() {
+      ASSERT_EQ(1, evaluate_number(2, "[1,2,3]"));
+    }),
+    test("set inclusion rejects a non-member", function() {
+      ASSERT_EQ(0, evaluate_number(4, "[1,2,3]"));
+    }),
+    test("set exclusion matches a non-member", function() {
+      ASSERT_EQ(1, evaluate_number(4, "![1,2,3]"));
+    }),
+    test("set exclusion rejects a member", function() {
+      ASSERT_EQ(0, evaluate_number(2, "![1,2,3]"));
+    }),
+  }));
+
+  describe("evaluate_number compound", ({
+    test("pure AND requires both conditions (pass)", function() {
+      ASSERT_EQ(1, evaluate_number(9, "5-15AND%3"));
+    }),
+    test("pure AND requires both conditions (fail)", function() {
+      ASSERT_EQ(0, evaluate_number(7, "5-15AND%3"));
+    }),
+    test("banded-comparison AND (the real-world usage)", function() {
+      ASSERT_EQ(1, evaluate_number(60, ">=50AND<80"));
+    }),
+    test("banded-comparison AND rejects out-of-band", function() {
+      ASSERT_EQ(0, evaluate_number(90, ">=50AND<80"));
+    }),
+    test("pure OR matches the first alternative", function() {
+      ASSERT_EQ(1, evaluate_number(5, "=5OR=10"));
+    }),
+    test("pure OR matches the second alternative", function() {
+      ASSERT_EQ(1, evaluate_number(10, "=5OR=10"));
+    }),
+    test("pure OR fails when neither matches", function() {
+      ASSERT_EQ(0, evaluate_number(7, "=5OR=10"));
+    }),
+    // The documented grouped example `(5-15AND%3)OR[20,25,30]`: parens bind
+    // tightest, OR loosest, so the AND-group is evaluated as a unit first.
+    test("grouped example: in-band AND divisible satisfies the AND-group", function() {
+      ASSERT_EQ(1, evaluate_number(9, "(5-15AND%3)OR[20,25,30]"));
+    }),
+    test("grouped example: in-band but not divisible falls through to the set", function() {
+      ASSERT_EQ(0, evaluate_number(7, "(5-15AND%3)OR[20,25,30]"));
+    }),
+    test("grouped example: a set member satisfies the OR arm", function() {
+      ASSERT_EQ(1, evaluate_number(20, "(5-15AND%3)OR[20,25,30]"));
+    }),
+    test("precedence: AND binds tighter than OR without parens", function() {
+      // 20: (fails 5-15 AND %3) OR (matches =20) -> true
+      ASSERT_EQ(1, evaluate_number(20, "5-15AND%3OR=20"));
+    }),
+    test("nested groups evaluate innermost first", function() {
+      ASSERT_EQ(1, evaluate_number(12, "((10-20)AND%3)OR=99"));
+    }),
+  }));
+
+  describe("evaluate_number errors", ({
+    test("an unparseable condition errors", function() {
+      string err = catch(evaluate_number(5, "garbage"));
+      ASSERT_NE(0, err);
+    }),
+  }));
+
+  describe("diminish", ({
+    test("output equals scale when val == scale", function() {
+      ASSERT_EQ(10.0, diminish(10, 10));
+    }),
+    test("triangular growth: 3x input yields 2x output", function() {
+      ASSERT_EQ(20.0, diminish(30, 10));
+    }),
+    test("triangular growth: 6x input yields 3x output", function() {
+      ASSERT_EQ(30.0, diminish(60, 10));
+    }),
+    test("zero input yields zero", function() {
+      ASSERT_EQ(0.0, diminish(0, 10));
+    }),
+    test("negative input mirrors the positive result", function() {
+      ASSERT_EQ(-10.0, diminish(-10, 10));
+    }),
+  }));
+
+  describe("dim_square_root", ({
+    test("output equals scale when val == scale", function() {
+      ASSERT_EQ(10.0, dim_square_root(10, 10));
+    }),
+    test("4x input yields 2x output", function() {
+      ASSERT_EQ(20.0, dim_square_root(40, 10));
+    }),
+    test("9x input yields 3x output", function() {
+      ASSERT_EQ(30.0, dim_square_root(90, 10));
+    }),
+    test("zero input yields zero", function() {
+      ASSERT_EQ(0.0, dim_square_root(0, 10));
+    }),
+    test("negative input mirrors the positive result", function() {
+      ASSERT_EQ(-20.0, dim_square_root(-40, 10));
+    }),
+  }));
+
+  describe("dim_logarithmic", ({
+    test("zero input yields zero", function() {
+      ASSERT_EQ(0.0, dim_logarithmic(0, 10));
+    }),
+    test("val == scale yields scale*ln(2) ~= 6.931", function() {
+      float r = dim_logarithmic(10, 10);
+      ASSERT_EQ(1, r > 6.93 && r < 6.932);
+    }),
+  }));
+
+  describe("dim_hyperbolic", ({
+    test("output is scale/2 when val == scale", function() {
+      ASSERT_EQ(5.0, dim_hyperbolic(10, 10));
+    }),
+    test("zero input yields zero", function() {
+      ASSERT_EQ(0.0, dim_hyperbolic(0, 10));
+    }),
+    test("approaches but stays under the ceiling", function() {
+      ASSERT_EQ(7.5, dim_hyperbolic(30, 10));
+    }),
+    test("negative input mirrors the positive result", function() {
+      ASSERT_EQ(-5.0, dim_hyperbolic(-10, 10));
+    }),
+  }));
+
+  describe("dim_exponential_decay", ({
+    test("zero input yields zero", function() {
+      ASSERT_EQ(0.0, dim_exponential_decay(0, 10));
+    }),
+    test("val == scale yields ~0.632*scale", function() {
+      float r = dim_exponential_decay(10, 10);
+      ASSERT_EQ(1, r > 6.32 && r < 6.322);
+    }),
+  }));
+
+  describe("dim_sigmoid", ({
+    test("zero input yields zero", function() {
+      ASSERT_EQ(0.0, dim_sigmoid(0, 10, 1));
+    }),
+    test("a large val*k approaches the ceiling", function() {
+      float r = dim_sigmoid(10, 10, 1);
+      ASSERT_EQ(1, r > 9.99 && r < 10.0);
+    }),
+    test("negative input mirrors the positive result", function() {
+      float r = dim_sigmoid(-10, 10, 1);
+      ASSERT_EQ(1, r < -9.99 && r > -10.0);
+    }),
+  }));
+}


### PR DESCRIPTION
This PR refactors the compound condition evaluation logic in `evaluate_number` to correctly handle operator precedence and nested parentheses, and adds a comprehensive test suite for the number simul_efuns.

## Condition Parsing Rewrite

The previous `evaluate_compound_condition` used naive `explode` calls on `"and"` and `"or"` delimiter strings, which broke whenever those tokens appeared inside parenthesised groups or set brackets. It also failed to enforce proper precedence — AND was intended to bind tighter than OR, but the implementation did not reliably guarantee this.

The replacement introduces three cooperating functions that form a proper recursive descent parser:

- **`split_top_level`** — splits a condition string on a delimiter word only at depth zero, leaving tokens inside `()` or `[]` untouched.
- **`evaluate_term`** — handles a single operand: either a parenthesised sub-expression (recursed via `evaluate_or_expr`) or a leaf simple condition.
- **`evaluate_and_expr`** — evaluates an AND-chain of terms; all must be true.
- **`evaluate_or_expr`** — evaluates an OR-chain of AND-expressions; at least one must be true. This is the new entry point called by `evaluate_number`.

Operator case normalisation (`lower_case`) is now applied up front in `evaluate_number` alongside whitespace stripping, rather than only inside the compound evaluator.

A small fix is also included: the set membership check in `evaluate_simple_condition` now calls `of(number, set)` with the correct argument order.

## `dim_sigmoid` Documentation Fix

The docblock for `dim_sigmoid` previously described the steepness coefficient as being derived from `scale`. The corrected comment clarifies that `k` is an independent multiplier on `val`, that omitting it silently passes `0` and flattens the curve entirely, and that the half-scale point occurs at `val == ln(3) / k`.

## Test Suite

A new test file covers the full public surface of the number simul_efuns:

- `percent_of` / `percent`
- `clamp` / `clamped` / `between`
- `remainder` / `sum`
- `evaluate_number` — basic operators, modulo, range, set inclusion/exclusion, compound AND/OR, nested parentheses, precedence, and error handling
- `diminish`, `dim_square_root`, `dim_logarithmic`, `dim_hyperbolic`, `dim_exponential_decay`, `dim_sigmoid`

Exact IEEE results are asserted directly; irrational results are bounded with a tight interval check.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR rewrites compound numeric-condition parsing and adds coverage for number simul_efuns. The main changes are:

- Recursive parsing for grouped `AND` and `OR` expressions.
- Correct set inclusion and exclusion checks.
- New tests for number helpers and condition syntax.
</details>

<sub>Reviews (2): Last reviewed commit: ["update"](https://github.com/gesslar/oxidus-mudlib/commit/2a17dbadca71b00482a702caf548c437c76863b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43716209)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->