### PR TITLE
Fix `seq_set` closure capture, `push` ref, refactor `seq_from_mapping`, add tests

### DIFF
--- a/adm/simul_efun/seq.lpc
+++ b/adm/simul_efun/seq.lpc
@@ -47,13 +47,13 @@ int seq_set(mixed ref *map, mixed key, mixed value) {
 
   assert_arg(valid_seq(map), 1, "Sequential map is required");
 
-  if((sz = sizeof(map)) > 0 && (i = find_index(map, (: $1[0] == $2 :), key)) != -1) {
+  if((sz = sizeof(map)) > 0 && (i = find_index(map, (: $1[0] == $(key) :))) != -1) {
     map[i][1] = value;
 
     return sz;
   }
 
-  return push(map, ({key, value}));
+  return push(ref map, ({key, value}));
 }
 
 /**
@@ -227,7 +227,8 @@ mixed *seq_from_mapping(mapping m) {
 
   assert_arg(mapp(m), 1, "Source must be a mapping.");
 
-  each(m, (: seq_set(ref $4, $1, $2) :), ref seq);
+  foreach(mixed key, mixed value in m)
+    seq_set(ref seq, key, value);
 
   return seq;
 }

--- a/tests/adm/simul_efun/seq.test.lpc
+++ b/tests/adm/simul_efun/seq.test.lpc
@@ -1,0 +1,182 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/seq.test.lpc
+ * @description Tests for the seq_* simul_efuns from /adm/simul_efun/seq.lpc —
+ *              the "sequential map" (ordered array of {key, value} pairs,
+ *              JS Map-like): valid_seq, seq_set/get/has/delete/clear,
+ *              seq_keys/values, and seq_from_mapping/seq_to_mapping.
+ *
+ * Note: a miss on seq_get() returns undefined (`([])[0]`), not 0, so those
+ * are asserted with nullp(). Insertion order is preserved by the array, so
+ * seq_keys/seq_values are compared with strict same_array; conversions from a
+ * mapping are order-agnostic (mapping iteration order is unspecified) and are
+ * asserted via seq_get instead.
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("valid_seq", ({
+    test("any array is valid when non_empty is not set", function() {
+      ASSERT_EQ(1, valid_seq(({})));
+    }),
+    test("an empty array is invalid when non_empty is required", function() {
+      ASSERT_EQ(0, valid_seq(({}), 1));
+    }),
+    test("an array of pairs is valid when non_empty is required", function() {
+      ASSERT_EQ(1, valid_seq(({ ({ "a", 1 }), ({ "b", 2 }) }), 1));
+    }),
+    test("a non-pair element fails the non_empty check", function() {
+      ASSERT_EQ(0, valid_seq(({ ({ "a", 1 }), ({ "b" }) }), 1));
+    }),
+    test("an over-long element fails the non_empty check", function() {
+      ASSERT_EQ(0, valid_seq(({ ({ "a", 1, 2 }) }), 1));
+    }),
+    test("a non-array is invalid", function() {
+      ASSERT_EQ(0, valid_seq("nope"));
+    }),
+    test("an integer is invalid", function() {
+      ASSERT_EQ(0, valid_seq(5));
+    }),
+  }));
+
+  describe("seq_set", ({
+    test("adds a new key and returns the new size", function() {
+      mixed *m = ({});
+      int sz = seq_set(ref m, "a", 1);
+      ASSERT_EQ(1, sz);
+      ASSERT_EQ(1, seq_get(m, "a"));
+    }),
+    test("adding a second key grows the map", function() {
+      mixed *m = ({});
+      seq_set(ref m, "a", 1);
+      ASSERT_EQ(2, seq_set(ref m, "b", 2));
+    }),
+    test("updating an existing key keeps the size", function() {
+      mixed *m = ({ ({ "a", 1 }) });
+      int sz = seq_set(ref m, "a", 99);
+      ASSERT_EQ(1, sz);
+      ASSERT_EQ(99, seq_get(m, "a"));
+    }),
+    test("update does not append a duplicate", function() {
+      mixed *m = ({ ({ "a", 1 }) });
+      seq_set(ref m, "a", 2);
+      ASSERT_EQ(1, sizeof(m));
+    }),
+    test("a non-seq argument errors", function() {
+      mixed *m = 0;
+      string err = catch(seq_set(ref m, "a", 1));
+      ASSERT_NE(0, err);
+    }),
+  }));
+
+  describe("seq_get", ({
+    test("returns the value for an existing key", function() {
+      mixed *m = ({ ({ "a", 25 }), ({ "b", 30 }) });
+      ASSERT_EQ(30, seq_get(m, "b"));
+    }),
+    test("returns undefined for a missing key", function() {
+      mixed *m = ({ ({ "a", 25 }) });
+      ASSERT_EQ(1, nullp(seq_get(m, "charlie")));
+    }),
+    test("supports integer keys", function() {
+      mixed *m = ({ ({ 1, "one" }), ({ 2, "two" }) });
+      ASSERT_EQ("two", seq_get(m, 2));
+    }),
+  }));
+
+  describe("seq_has", ({
+    test("returns 1 for an existing key", function() {
+      mixed *m = ({ ({ "a", 1 }) });
+      ASSERT_EQ(1, seq_has(m, "a"));
+    }),
+    test("returns 0 for a missing key", function() {
+      mixed *m = ({ ({ "a", 1 }) });
+      ASSERT_EQ(0, seq_has(m, "z"));
+    }),
+    test("returns 0 on an empty map", function() {
+      ASSERT_EQ(0, seq_has(({}), "a"));
+    }),
+  }));
+
+  describe("seq_delete", ({
+    test("removes an existing key and returns 1", function() {
+      mixed *m = ({ ({ "a", 1 }), ({ "b", 2 }), ({ "c", 3 }) });
+      ASSERT_EQ(1, seq_delete(ref m, "b"));
+      ASSERT_EQ(2, sizeof(m));
+      ASSERT_EQ(0, seq_has(m, "b"));
+    }),
+    test("returns 0 for a missing key and leaves the map intact", function() {
+      mixed *m = ({ ({ "a", 1 }), ({ "b", 2 }) });
+      ASSERT_EQ(0, seq_delete(ref m, "z"));
+      ASSERT_EQ(2, sizeof(m));
+    }),
+    test("preserves the order of the remaining pairs", function() {
+      mixed *m = ({ ({ "a", 1 }), ({ "b", 2 }), ({ "c", 3 }) });
+      seq_delete(ref m, "b");
+      ASSERT_EQ(1, same_array(({ "a", "c" }), seq_keys(m), 1));
+    }),
+  }));
+
+  describe("seq_clear", ({
+    test("empties the map", function() {
+      mixed *m = ({ ({ "a", 1 }), ({ "b", 2 }) });
+      seq_clear(ref m);
+      ASSERT_EQ(0, sizeof(m));
+    }),
+  }));
+
+  describe("seq_keys", ({
+    test("returns the keys in insertion order", function() {
+      mixed *m = ({});
+      seq_set(ref m, "a", 1);
+      seq_set(ref m, "b", 2);
+      seq_set(ref m, "c", 3);
+      ASSERT_EQ(1, same_array(({ "a", "b", "c" }), seq_keys(m), 1));
+    }),
+    test("an empty map has no keys", function() {
+      ASSERT_EQ(0, sizeof(seq_keys(({}))));
+    }),
+  }));
+
+  describe("seq_values", ({
+    test("returns the values in insertion order", function() {
+      mixed *m = ({});
+      seq_set(ref m, "a", 10);
+      seq_set(ref m, "b", 20);
+      seq_set(ref m, "c", 30);
+      ASSERT_EQ(1, same_array(({ 10, 20, 30 }), seq_values(m), 1));
+    }),
+  }));
+
+  describe("seq_from_mapping", ({
+    test("converts every mapping pair (order-agnostic)", function() {
+      mixed *m = seq_from_mapping(([ "hp": 100, "sp": 50 ]));
+      ASSERT_EQ(2, sizeof(m));
+      ASSERT_EQ(100, seq_get(m, "hp"));
+      ASSERT_EQ(50, seq_get(m, "sp"));
+    }),
+    test("an empty mapping yields an empty seq", function() {
+      ASSERT_EQ(0, sizeof(seq_from_mapping(([]))));
+    }),
+    test("a non-mapping argument errors", function() {
+      string err = catch(seq_from_mapping(({ 1, 2 })));
+      ASSERT_NE(0, err);
+    }),
+  }));
+
+  describe("seq_to_mapping", ({
+    test("converts a seq to a mapping", function() {
+      mixed *m = ({ ({ "name", "sword" }), ({ "damage", 15 }) });
+      mapping result = seq_to_mapping(m);
+      ASSERT_EQ("sword", result["name"]);
+      ASSERT_EQ(15, result["damage"]);
+    }),
+    test("roundtrips a mapping through seq and back", function() {
+      mapping original = ([ "a": 1, "b": 2, "c": 3 ]);
+      ASSERT_EQ(1, same(original, seq_to_mapping(seq_from_mapping(original))));
+    }),
+  }));
+}


### PR DESCRIPTION
Fixes two bugs in `seq_set` and `seq_from_mapping`, and adds a comprehensive test suite for the `seq_*` simul_efuns.

In `seq_set`, the lambda passed to `find_index` now closes over `key` directly using `$(key)` rather than passing it as an extra argument, and the `push` call now correctly passes `map` by reference so insertions are reflected in the caller.

In `seq_from_mapping`, the `each` call with a lambda that attempted to pass the seq by reference through a fourth argument is replaced with a `foreach` loop that calls `seq_set(ref seq, ...)` directly, which correctly mutates the local seq array.

The new test file covers `valid_seq`, `seq_set`, `seq_get`, `seq_has`, `seq_delete`, `seq_clear`, `seq_keys`, `seq_values`, `seq_from_mapping`, and `seq_to_mapping`, including edge cases such as missing keys returning undefined, duplicate-key updates not appending, insertion-order preservation, and round-trip conversion between a seq and a mapping.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes sequential-map mutation and conversion behavior. The main changes are:

- Capture `seq_set` keys directly in the lookup closure.
- Pass the sequence by reference when appending entries.
- Convert mappings with direct `foreach` iteration.
- Add coverage for the `seq_*` simul_efuns.
</details>

<sub>Reviews (2): Last reviewed commit: ["tests and fixes"](https://github.com/gesslar/oxidus-mudlib/commit/746b48618a01118d01bd954afc7188101af44db4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43716218)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->