### PR TITLE
Add tests for `find_key`, `find_keys`, `dot_walk`, and `pretty_map` simul_efuns

### DIFF
--- a/tests/adm/simul_efun/mapping.test.lpc
+++ b/tests/adm/simul_efun/mapping.test.lpc
@@ -1,0 +1,115 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/mapping.test.lpc
+ * @description Tests for the mapping simul_efuns from /adm/simul_efun/mapping.lpc:
+ *              find_key, find_keys, dot_walk, and pretty_map.
+ *
+ * Mapping iteration order is unspecified, so find_key value-match tests use
+ * unique values for a deterministic key, and find_keys multi-match relies on
+ * ASSERT_EQ's loose (order-insensitive) array comparison. dot_walk misses
+ * return undefined, asserted with nullp(). pretty_map's exact %O layout is
+ * driver-dependent, so its contract (keeps the data, strips the size
+ * annotation) is asserted rather than a literal string.
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("find_key", ({
+    test("returns the key for a matching value", function() {
+      ASSERT_EQ("Bob", find_key(([ "Alice": 95, "Bob": 87 ]), 87));
+    }),
+    test("returns the key satisfying a predicate", function() {
+      ASSERT_EQ("b", find_key(([ "a": 5, "b": 10 ]), (: $1 > 7 :)));
+    }),
+    test("forwards a trailing argument to the predicate as $4", function() {
+      ASSERT_EQ("b", find_key(([ "a": 5, "b": 10 ]), (: $1 > $4 :), 7));
+    }),
+    test("returns 0 when no value matches", function() {
+      ASSERT_EQ(0, find_key(([ "a": 5 ]), 99));
+    }),
+    test("returns 0 when no element satisfies the predicate", function() {
+      ASSERT_EQ(0, find_key(([ "a": 5 ]), (: $1 > 100 :)));
+    }),
+  }));
+
+  describe("find_keys", ({
+    test("returns every key for a matching value", function() {
+      ASSERT_EQ(({ "Alice", "Charlie" }),
+        find_keys(([ "Alice": 95, "Bob": 87, "Charlie": 95 ]), 95));
+    }),
+    test("returns every key satisfying a predicate", function() {
+      ASSERT_EQ(({ "b", "c" }),
+        find_keys(([ "a": 5, "b": 10, "c": 15 ]), (: $1 >= 10 :)));
+    }),
+    test("forwards a trailing argument to the predicate as $4", function() {
+      ASSERT_EQ(({ "b", "c" }),
+        find_keys(([ "a": 5, "b": 10, "c": 15 ]), (: $1 >= $4 :), 10));
+    }),
+    test("returns an empty array when nothing matches", function() {
+      ASSERT_EQ(0, sizeof(find_keys(([ "a": 5 ]), 99)));
+    }),
+    test("returns a single-element array for one match", function() {
+      ASSERT_EQ(({ "b" }), find_keys(([ "a": 5, "b": 10 ]), 10));
+    }),
+  }));
+
+  describe("dot_walk", ({
+    test("resolves a single-segment path", function() {
+      ASSERT_EQ(1, dot_walk(([ "a": 1 ]), "a"));
+    }),
+    test("resolves a nested value", function() {
+      mapping data = ([ "player": ([ "name": "Alice" ]) ]);
+      ASSERT_EQ("Alice", dot_walk(data, "player.name"));
+    }),
+    test("resolves a deeply nested value", function() {
+      mapping data = ([ "player": ([ "stats": ([ "hp": 100 ]) ]) ]);
+      ASSERT_EQ(100, dot_walk(data, "player.stats.hp"));
+    }),
+    test("returns an intermediate mapping as-is", function() {
+      mapping data = ([ "player": ([ "stats": ([ "hp": 100, "mp": 40 ]) ]) ]);
+      ASSERT_EQ(1, same(([ "hp": 100, "mp": 40 ]), dot_walk(data, "player.stats")));
+    }),
+    test("a missing final segment yields undefined", function() {
+      mapping data = ([ "player": ([ "name": "Alice" ]) ]);
+      ASSERT_EQ(1, nullp(dot_walk(data, "player.age")));
+    }),
+    test("a missing intermediate hop yields undefined", function() {
+      mapping data = ([ "player": ([ "name": "Alice" ]) ]);
+      ASSERT_EQ(1, nullp(dot_walk(data, "player.gear.head")));
+    }),
+    test("a non-mapping intermediate hop yields undefined", function() {
+      ASSERT_EQ(1, nullp(dot_walk(([ "a": 5 ]), "a.b")));
+    }),
+    test("a missing single segment yields undefined", function() {
+      ASSERT_EQ(1, nullp(dot_walk(([ "a": 1 ]), "z")));
+    }),
+    test("a non-mapping first argument errors", function() {
+      string err = catch(dot_walk(5, "a"));
+      ASSERT_NE(0, err);
+    }),
+    test("a non-string path errors", function() {
+      string err = catch(dot_walk(([ "a": 1 ]), 5));
+      ASSERT_NE(0, err);
+    }),
+  }));
+
+  describe("pretty_map", ({
+    test("returns a string", function() {
+      ASSERT_EQ(1, stringp(pretty_map(([ "hp": 100 ]))));
+    }),
+    test("includes the mapping's keys and values", function() {
+      string s = pretty_map(([ "hp": 100 ]));
+      ASSERT_EQ(1, strsrch(s, "hp") != -1 && strsrch(s, "100") != -1);
+    }),
+    test("strips the sizeof() size annotation", function() {
+      string s = pretty_map(([ "a": 1, "b": 2, "c": 3 ]));
+      ASSERT_EQ(-1, strsrch(s, "sizeof"));
+    }),
+    test("handles an empty mapping", function() {
+      ASSERT_EQ(1, stringp(pretty_map(([]))));
+    }),
+  }));
+}


### PR DESCRIPTION
Adds a test suite for the mapping simul_efuns (`find_key`, `find_keys`, `dot_walk`, and `pretty_map`) defined in `/adm/simul_efun/mapping.lpc`.

**`find_key`** — covers value matching, predicate matching, predicate with a trailing argument forwarded as `$4`, and both no-match cases returning `0`.

**`find_keys`** — covers multi-match by value, multi-match by predicate, predicate with a trailing argument, empty-result, and single-match cases.

**`dot_walk`** — covers single-segment resolution, nested and deeply nested paths, returning an intermediate mapping as-is, missing final/intermediate/non-mapping segments yielding `undefined` (`nullp()`), and error cases for a non-mapping first argument or non-string path.

**`pretty_map`** — covers return type, presence of keys and values in the output, absence of the `sizeof` size annotation, and handling of an empty mapping.

Because mapping iteration order is unspecified, `find_key` value-match tests use unique values to guarantee a deterministic key, `find_keys` multi-match relies on order-insensitive array comparison, and `pretty_map` asserts contract properties rather than a literal string.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds coverage for mapping simul_efuns. The main changes are:

- Tests for `find_key` and `find_keys` value and predicate matching.
- Tests for nested `dot_walk` paths and invalid arguments.
- Tests for `pretty_map` output properties.
</details>

<sub>Reviews (2): Last reviewed commit: ["tests"](https://github.com/gesslar/oxidus-mudlib/commit/43b1324b5db997ddf1553735798b29e78bb52cee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43716226)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->