### PR TITLE
Add tests for `generate_uuid`, `of`, `truthy`, and `falsy` simul_efuns

### DIFF
--- a/tests/adm/simul_efun/util.test.lpc
+++ b/tests/adm/simul_efun/util.test.lpc
@@ -1,0 +1,105 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/util.test.lpc
+ * @description Tests for the util simul_efuns from /adm/simul_efun/util.lpc:
+ *              generate_uuid, of (array/mapping/string membership), and the
+ *              JS-style truthy/falsy predicates.
+ *
+ * generate_uuid is random, so its structure (v4 UUID format) is asserted
+ * rather than a fixed value.
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("generate_uuid", ({
+    test("matches the version-4 UUID format", function() {
+      string uuid = generate_uuid();
+      ASSERT_EQ(1, pcre_match(uuid,
+        "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"));
+    }),
+    test("is 36 characters long", function() {
+      ASSERT_EQ(36, strlen(generate_uuid()));
+    }),
+    test("produces a different value each call", function() {
+      ASSERT_EQ(1, generate_uuid() != generate_uuid());
+    }),
+  }));
+
+  describe("of (array)", ({
+    test("finds a present integer", function() {
+      ASSERT_EQ(1, of(2, ({ 1, 2, 3 })));
+    }),
+    test("rejects an absent integer", function() {
+      ASSERT_EQ(0, of(9, ({ 1, 2, 3 })));
+    }),
+    test("finds a present string", function() {
+      ASSERT_EQ(1, of("b", ({ "a", "b" })));
+    }),
+    test("an empty array contains nothing", function() {
+      ASSERT_EQ(0, of(1, ({})));
+    }),
+  }));
+
+  describe("of (mapping)", ({
+    test("finds a present key", function() {
+      ASSERT_EQ(1, of("key", ([ "key": 1 ])));
+    }),
+    test("rejects an absent key", function() {
+      ASSERT_EQ(0, of("missing", ([ "key": 1 ])));
+    }),
+    test("finds a key whose value is zero", function() {
+      ASSERT_EQ(1, of("k", ([ "k": 0 ])));
+    }),
+  }));
+
+  describe("of (string)", ({
+    test("finds a substring", function() {
+      ASSERT_EQ(1, of("ell", "hello"));
+    }),
+    test("rejects an absent substring", function() {
+      ASSERT_EQ(0, of("xyz", "hello"));
+    }),
+  }));
+
+  describe("of (other types)", ({
+    test("a non-container haystack yields 0", function() {
+      ASSERT_EQ(0, of(5, 42));
+    }),
+  }));
+
+  describe("truthy", ({
+    test("a non-zero integer is truthy", function() {
+      ASSERT_EQ(1, truthy(1));
+    }),
+    test("zero is not truthy", function() {
+      ASSERT_EQ(0, truthy(0));
+    }),
+    test("an empty string is not truthy", function() {
+      ASSERT_EQ(0, truthy(""));
+    }),
+    test("a non-empty string is truthy", function() {
+      ASSERT_EQ(1, truthy("hi"));
+    }),
+    test("an empty array is truthy (not 0 or \"\")", function() {
+      ASSERT_EQ(1, truthy(({})));
+    }),
+  }));
+
+  describe("falsy", ({
+    test("a non-zero integer is not falsy", function() {
+      ASSERT_EQ(0, falsy(1));
+    }),
+    test("zero is falsy", function() {
+      ASSERT_EQ(1, falsy(0));
+    }),
+    test("an empty string is falsy", function() {
+      ASSERT_EQ(1, falsy(""));
+    }),
+    test("a non-empty string is not falsy", function() {
+      ASSERT_EQ(0, falsy("hi"));
+    }),
+  }));
+}


### PR DESCRIPTION
Adds a test suite for the `util` simul_efuns covering `generate_uuid`, `of`, `truthy`, and `falsy`.

`generate_uuid` tests verify the v4 UUID format via regex, the expected 36-character length, and that successive calls produce distinct values.

`of` tests cover membership checks across arrays, mappings, and strings, including edge cases such as empty arrays, keys with a zero value, and non-container haystacks.

`truthy` and `falsy` tests confirm expected behavior for integers, empty and non-empty strings, and empty arrays (which are neither `0` nor `""` and therefore truthy).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds coverage for utility simul_efuns. The main changes are:
- UUID format, length, and uniqueness tests.
- Array, mapping, string, and non-container membership tests.
- Truthy and falsy predicate tests.
</details>

<sub>Reviews (2): Last reviewed commit: ["tests"](https://github.com/gesslar/oxidus-mudlib/commit/cc2080e5537b4064bf02d4c66ae3c4ee4c588de9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43716229)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->