### PR TITLE
Fix `ordinal` teen detection, improve `query_num`, add grammar tests

### DIFF
--- a/adm/simul_efun/grammar.lpc
+++ b/adm/simul_efun/grammar.lpc
@@ -27,7 +27,7 @@ string ordinal(int num) {
       if(num == 1) return "first";
       if(num == 0) return "zeroth";
   } else {
-      x = (num < 14 && num > 10) ? 4 : num % 10;
+      x = (num % 100 >= 11 && num % 100 <= 13) ? 4 : num % 10;
       if(x == 1) return num + "st";
       else if(x == 2) return num + "nd";
       else if(x == 3) return num + "rd";

--- a/adm/simul_efun/override.lpc
+++ b/adm/simul_efun/override.lpc
@@ -148,20 +148,19 @@ varargs int userp(object ob) {
 
 /**
  * @efun_override query_num
- * This function is an override of query_num(). It will return
- * the number in string form.
+ * This function is an override of query_num(). It will return the number in
+ * string form.
  *
  * @param {int} x - The number to convert to a string.
- * @param {int} many - If true, the number will be returned in plural form.
+ * @param {int} [many=0] - If 1, the number will be returned in plural form.
  * @returns {string} The number in string form.
  */
-varargs string query_num(int x, int many) {
-  string sign;
+varargs string query_num(int x, int many: (: 0 :)) {
+  assert_arg(!nullp(x) && intp(x), 1, "Missing argument.");
 
-  assert_arg(!nullp(x), 1, "Missing argument.");
-  assert_arg(!nullp(many) && intp(many), 2, "Invalid argument.");
+  many = !!many;
 
-  sign = x < 0 ? "negative " : "";
+  string sign = x < 0 ? "negative " : "";
   x = abs(x);
 
   return sign + efun::query_num(x, many);

--- a/tests/adm/simul_efun/grammar.test.lpc
+++ b/tests/adm/simul_efun/grammar.test.lpc
@@ -1,0 +1,125 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/grammar.test.lpc
+ * @description Tests for the grammar simul_efuns from /adm/simul_efun/grammar.lpc:
+ *              ordinal (number -> "first"/"21st"), int_string (number -> words),
+ *              and consolidate (quantity + pluralized item description).
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("ordinal", ({
+    test("spells out single digits as words", function() {
+      ASSERT_EQ("first", ordinal(1));
+    }),
+    test("zero is zeroth", function() {
+      ASSERT_EQ("zeroth", ordinal(0));
+    }),
+    test("ninth", function() {
+      ASSERT_EQ("ninth", ordinal(9));
+    }),
+    test("ten uses the numeric suffix form", function() {
+      ASSERT_EQ("10th", ordinal(10));
+    }),
+    test("the teens all take -th", function() {
+      ASSERT_EQ("11th", ordinal(11));
+      ASSERT_EQ("12th", ordinal(12));
+      ASSERT_EQ("13th", ordinal(13));
+    }),
+    test("21st / 22nd / 23rd take st/nd/rd", function() {
+      ASSERT_EQ("21st", ordinal(21));
+      ASSERT_EQ("22nd", ordinal(22));
+      ASSERT_EQ("23rd", ordinal(23));
+    }),
+    test("100th", function() {
+      ASSERT_EQ("100th", ordinal(100));
+    }),
+    test("101st", function() {
+      ASSERT_EQ("101st", ordinal(101));
+    }),
+    test("the teens stay -th in higher hundreds", function() {
+      ASSERT_EQ("111th", ordinal(111));
+      ASSERT_EQ("112th", ordinal(112));
+      ASSERT_EQ("113th", ordinal(113));
+    }),
+    test("121st (not a teen) still takes -st", function() {
+      ASSERT_EQ("121st", ordinal(121));
+    }),
+    test("a negative number errors", function() {
+      string err = catch(ordinal(-1));
+      ASSERT_NE(0, err);
+    }),
+  }));
+
+  describe("int_string", ({
+    test("zero", function() {
+      ASSERT_EQ("zero", int_string(0));
+    }),
+    test("a single digit", function() {
+      ASSERT_EQ("seven", int_string(7));
+    }),
+    test("a teen", function() {
+      ASSERT_EQ("thirteen", int_string(13));
+    }),
+    test("a round ten", function() {
+      ASSERT_EQ("twenty", int_string(20));
+    }),
+    test("a hyphenated two-digit number", function() {
+      ASSERT_EQ("forty-two", int_string(42));
+    }),
+    test("a round hundred", function() {
+      ASSERT_EQ("one hundred", int_string(100));
+    }),
+    test("a hundred with a remainder uses 'and'", function() {
+      ASSERT_EQ("one hundred and twenty-three", int_string(123));
+    }),
+    test("a round thousand", function() {
+      ASSERT_EQ("one thousand", int_string(1000));
+    }),
+    test("a thousand with hundreds", function() {
+      ASSERT_EQ("one thousand two hundred and thirty-four", int_string(1234));
+    }),
+    test("a thousand with a sub-hundred remainder uses 'and'", function() {
+      ASSERT_EQ("one thousand and five", int_string(1005));
+    }),
+    test("a million", function() {
+      ASSERT_EQ("one million", int_string(1000000));
+    }),
+    test("a negative number is prefixed with 'minus'", function() {
+      ASSERT_EQ("minus five", int_string(-5));
+    }),
+    test("int max is 'too much'", function() {
+      ASSERT_EQ("too much", int_string(2147483647));
+    }),
+  }));
+
+  describe("consolidate", ({
+    test("a quantity of one returns the string unchanged", function() {
+      ASSERT_EQ("sword", consolidate(1, "sword"));
+    }),
+    test("an empty string is returned unchanged", function() {
+      ASSERT_EQ("", consolidate(5, ""));
+    }),
+    test("a plural quantity words the count and pluralizes", function() {
+      ASSERT_EQ("five swords", consolidate(5, "sword"));
+    }),
+    test("pluralizes an -es plural", function() {
+      ASSERT_EQ("two boxes", consolidate(2, "box"));
+    }),
+    test("drops a leading article", function() {
+      ASSERT_EQ("three swords", consolidate(3, "a sword"));
+    }),
+    test("drops a leading 'the'", function() {
+      ASSERT_EQ("three swords", consolidate(3, "the sword"));
+    }),
+    test("preserves a trailing parenthetical", function() {
+      ASSERT_EQ("two swords (rusty)", consolidate(2, "sword (rusty)"));
+    }),
+    test("preserves a trailing bracketed note", function() {
+      ASSERT_EQ("two swords [magic]", consolidate(2, "sword [magic]"));
+    }),
+  }));
+}


### PR DESCRIPTION
Fixes the `ordinal()` suffix logic for numbers ending in 11, 12, and 13 in higher ranges (e.g., 111th, 211th), where the previous check only caught 11–13 and incorrectly applied the teen rule to numbers like 111 or 213. The condition now uses `num % 100` to correctly identify the teen exceptions regardless of the hundreds place.

Also improves `query_num()` to default `many` to `0` when omitted, coerces the value to a boolean with `!!many`, and tightens the argument validation to require `x` to be an integer rather than merely non-null.

Adds a test suite for the grammar simul_efuns covering `ordinal`, `int_string`, and `consolidate`, including edge cases for teens at higher magnitudes, negative numbers, articles being stripped, and trailing parentheticals or bracketed notes.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes grammar-related simul efun behavior and adds coverage for it.

- Corrects ordinal suffixes for teen endings in larger numbers.
- Normalizes `query_num()` optional argument handling.
- Adds grammar tests for ordinal, number strings, and consolidation.
</details>

<sub>Reviews (2): Last reviewed commit: ["tests"](https://github.com/gesslar/oxidus-mudlib/commit/e43368445955abb9956ce9b43dbd2698ef88511f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43716233)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->