### PR TITLE
Fix pronoun bugs, improve `article` sound-awareness, add `vowel` sefun, add tests

### DIFF
--- a/adm/simul_efun/english.lpc
+++ b/adm/simul_efun/english.lpc
@@ -135,7 +135,7 @@ string possessive_pronoun(mixed ob) {
   else
     __gender = ob->query_gender() || "neuter";
 
-  if(stringp(ob))
+  if(!stringp(__gender))
     return "its";
 
   switch(__gender) {
@@ -255,10 +255,10 @@ string subjective(mixed ob) {
   else if(objectp(ob))
     __gender = ob->query_gender() || "neuter";
 
-  if(!stringp(ob))
+  if(!stringp(__gender))
     return "it";
 
-  switch(ob) {
+  switch(__gender) {
     case "male" : return "he";
     case "female" : return "she";
     case "other" : return "they";
@@ -268,27 +268,72 @@ string subjective(mixed ob) {
 }
 
 /**
+ * Tests whether a character code is an ASCII vowel, in either case.
+ *
+ * @param {int} c - The character code to test.
+ * @returns {int} 1 if `c` is a/e/i/o/u (upper or lower case), 0 otherwise.
+ * @example
+ * vowel('a');  // 1
+ * vowel('A');  // 1
+ * vowel('z');  // 0
+ */
+int vowel(int c) {
+  return pcre_match(sprintf("%c", c), "[aeiouAEIOU]");
+}
+
+/**
  * Determines the appropriate article for a word.
+ *
+ * Chooses "a"/"an" by the following word's sound rather than just its
+ * first letter: silent-h words take "an" ("an hour", "an honest"), and
+ * "yoo"-sounding "us..." words take "a" ("a use", "a user") while
+ * "an usher" is preserved by judging the letter after the "us".
  *
  * @param {string} str - Word to check
  * @param {int} [definite=0] - Use "the" instead of "a/an"
- * @returns {string} Appropriate article (the/a/an)
+ * @returns {string} Appropriate article (the/a/an), or "" if str isn't a string
  * @example
- * article("elephant");     // Returns "an"
- * article("bear", 1);      // Returns "the"
+ * article("elephant");  // Returns "an"
+ * article("hour");      // Returns "an"
+ * article("user");      // Returns "a"
+ * article("bear", 1);   // Returns "the"
  */
 varargs string article(string str, int definite) {
+  string word;
+  int first, an;
+
   if(!stringp(str))
     return "";
 
   if(definite)
     return "the";
 
-  else
-    if(of(str[0], ({ 'a', 'e', 'i', 'o', 'u' })))
-      return "an";
-    else
-      return "a";
+  word = lower_case(str);
+
+  while(strlen(word) && word[0] == ' ')
+    word = word[1..];
+
+  if(!strlen(word))
+    return "a";
+
+  first = word[0];
+  an = 0;
+
+  // "us..." sounds like "yoos" (a consonant onset) when a vowel follows,
+  // so judge by the letter after the "us": "a use"/"a user", "an usher".
+  if(strlen(word) >= 2 && word[0..1] == "us") {
+    first = strlen(word) > 2 ? word[2] : 0;
+    an = 1;
+  }
+
+  // Silent-h words sound vowel-initial.
+  if(pcre_match(word, "^(hour|honest|honou?r|heir)"))
+    first = 'o';
+
+  if(vowel(first))
+    an = !an;
+
+  return an ? "an" : "a";
 }
 
 /**

--- a/tests/adm/simul_efun/__fixtures/gendered.lpc
+++ b/tests/adm/simul_efun/__fixtures/gendered.lpc
@@ -1,0 +1,16 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/__fixtures/gendered.lpc
+ * @description Minimal clonable fixture for english.test.lpc. Exposes
+ *              query_gender() and query_name() so the pronoun and possessive
+ *              sefuns can be exercised on their object-input path.
+ */
+
+private string gender = "neuter";
+private string name = "Robin";
+
+void set_gender(string g) { gender = g; }
+string query_gender() { return gender; }
+
+void set_name(string n) { name = n; }
+string query_name() { return name; }

--- a/tests/adm/simul_efun/english.test.lpc
+++ b/tests/adm/simul_efun/english.test.lpc
@@ -1,0 +1,283 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/english.test.lpc
+ * @description Tests for the english simul_efuns from /adm/simul_efun/english.lpc:
+ *              cap_words, cap_significant_words, the possessive/pronoun family
+ *              (possessive_noun, possessive_proper_noun, possessive_pronoun,
+ *              possessive, reflexive, objective, subjective), article handling
+ *              (article, article_of, add_article, remove_article), and
+ *              number_word.
+ *
+ * The pronoun/possessive functions accept either a gender string or an object
+ * with query_gender()/query_name(); both paths are exercised via the
+ * __fixtures/gendered clone.
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+private nosave object gob;
+
+void setup() {
+  gob = clone_object(__DIR__ "__fixtures/gendered");
+
+  describe("cap_words", ({
+    test("capitalizes each word", function() {
+      ASSERT_EQ("Hello World", cap_words("hello world"));
+    }),
+    test("capitalizes every word regardless of significance", function() {
+      ASSERT_EQ("The Quick Brown Fox", cap_words("the quick brown fox"));
+    }),
+    test("a single word", function() {
+      ASSERT_EQ("Hello", cap_words("hello"));
+    }),
+  }));
+
+  describe("cap_significant_words", ({
+    test("leaves insignificant words lowercase", function() {
+      ASSERT_EQ("the Tale of Two Cities",
+        cap_significant_words("the tale of two cities"));
+    }),
+    test("title flag forces the first word", function() {
+      ASSERT_EQ("The Tale of Two Cities",
+        cap_significant_words("the tale of two cities", 1));
+    }),
+  }));
+
+  describe("possessive_noun", ({
+    test("adds 's to a normal noun", function() {
+      ASSERT_EQ("cat's", possessive_noun("cat"));
+    }),
+    test("adds only an apostrophe to a noun ending in s", function() {
+      ASSERT_EQ("James'", possessive_noun("James"));
+    }),
+    test("uses query_name() for an object", function() {
+      gob->set_name("Robin");
+      ASSERT_EQ("Robin's", possessive_noun(gob));
+    }),
+    test("an object whose name ends in s gets only an apostrophe", function() {
+      gob->set_name("Brutus");
+      ASSERT_EQ("Brutus'", possessive_noun(gob));
+    }),
+    test("a non-string, non-object yields its", function() {
+      ASSERT_EQ("its", possessive_noun(5));
+    }),
+  }));
+
+  describe("possessive_proper_noun", ({
+    test("always adds 's, even after s", function() {
+      ASSERT_EQ("James's", possessive_proper_noun("James"));
+    }),
+    test("adds 's to a normal noun", function() {
+      ASSERT_EQ("cat's", possessive_proper_noun("cat"));
+    }),
+    test("a non-string, non-object yields its", function() {
+      ASSERT_EQ("its", possessive_proper_noun(5));
+    }),
+  }));
+
+  describe("possessive_pronoun", ({
+    test("male gender string yields his", function() {
+      ASSERT_EQ("his", possessive_pronoun("male"));
+    }),
+    test("female gender string yields hers", function() {
+      ASSERT_EQ("hers", possessive_pronoun("female"));
+    }),
+    test("other gender string yields theirs", function() {
+      ASSERT_EQ("theirs", possessive_pronoun("other"));
+    }),
+    test("an unknown gender yields its", function() {
+      ASSERT_EQ("its", possessive_pronoun("neuter"));
+    }),
+    test("uses query_gender() for an object", function() {
+      gob->set_gender("female");
+      ASSERT_EQ("hers", possessive_pronoun(gob));
+    }),
+  }));
+
+  describe("possessive", ({
+    test("male yields his", function() {
+      ASSERT_EQ("his", possessive("male"));
+    }),
+    test("female yields her", function() {
+      ASSERT_EQ("her", possessive("female"));
+    }),
+    test("other yields their", function() {
+      ASSERT_EQ("their", possessive("other"));
+    }),
+    test("unknown yields its", function() {
+      ASSERT_EQ("its", possessive("neuter"));
+    }),
+  }));
+
+  describe("reflexive", ({
+    test("male yields himself", function() {
+      ASSERT_EQ("himself", reflexive("male"));
+    }),
+    test("female yields herself", function() {
+      ASSERT_EQ("herself", reflexive("female"));
+    }),
+    test("other yields themself", function() {
+      ASSERT_EQ("themself", reflexive("other"));
+    }),
+    test("unknown yields itself", function() {
+      ASSERT_EQ("itself", reflexive("neuter"));
+    }),
+  }));
+
+  describe("objective", ({
+    test("male yields him", function() {
+      ASSERT_EQ("him", objective("male"));
+    }),
+    test("female yields her", function() {
+      ASSERT_EQ("her", objective("female"));
+    }),
+    test("other yields them", function() {
+      ASSERT_EQ("them", objective("other"));
+    }),
+    test("unknown yields it", function() {
+      ASSERT_EQ("it", objective("neuter"));
+    }),
+  }));
+
+  describe("subjective", ({
+    test("male gender string yields he", function() {
+      ASSERT_EQ("he", subjective("male"));
+    }),
+    test("female gender string yields she", function() {
+      ASSERT_EQ("she", subjective("female"));
+    }),
+    test("other gender string yields they", function() {
+      ASSERT_EQ("they", subjective("other"));
+    }),
+    test("unknown yields it", function() {
+      ASSERT_EQ("it", subjective("neuter"));
+    }),
+    test("uses query_gender() for an object", function() {
+      gob->set_gender("female");
+      ASSERT_EQ("she", subjective(gob));
+    }),
+  }));
+
+  describe("vowel", ({
+    test("a lowercase vowel", function() {
+      ASSERT_EQ(1, vowel('a'));
+    }),
+    test("an uppercase vowel", function() {
+      ASSERT_EQ(1, vowel('A'));
+    }),
+    test("a consonant is not a vowel", function() {
+      ASSERT_EQ(0, vowel('z'));
+    }),
+    test("a digit is not a vowel", function() {
+      ASSERT_EQ(0, vowel('1'));
+    }),
+  }));
+
+  describe("article", ({
+    test("a consonant-initial word takes 'a'", function() {
+      ASSERT_EQ("a", article("bear"));
+    }),
+    test("a vowel-initial word takes 'an'", function() {
+      ASSERT_EQ("an", article("elephant"));
+    }),
+    test("an uppercase vowel word still takes 'an'", function() {
+      ASSERT_EQ("an", article("Apple"));
+    }),
+    test("a silent-h 'hour' takes 'an'", function() {
+      ASSERT_EQ("an", article("hour"));
+    }),
+    test("a silent-h 'honest' takes 'an'", function() {
+      ASSERT_EQ("an", article("honest"));
+    }),
+    test("a silent-h 'heir' takes 'an'", function() {
+      ASSERT_EQ("an", article("heir"));
+    }),
+    test("a 'yoo'-sounding 'user' takes 'a'", function() {
+      ASSERT_EQ("a", article("user"));
+    }),
+    test("a 'yoo'-sounding 'use' takes 'a'", function() {
+      ASSERT_EQ("a", article("use"));
+    }),
+    test("'usher' keeps its vowel sound and takes 'an'", function() {
+      ASSERT_EQ("an", article("usher"));
+    }),
+    test("the definite flag forces 'the'", function() {
+      ASSERT_EQ("the", article("bear", 1));
+    }),
+    test("a non-string yields empty", function() {
+      ASSERT_EQ("", article(5));
+    }),
+  }));
+
+  describe("article_of", ({
+    test("extracts a leading 'the'", function() {
+      ASSERT_EQ("the", article_of("the book"));
+    }),
+    test("extracts a leading 'an'", function() {
+      ASSERT_EQ("an", article_of("an apple"));
+    }),
+    test("extracts a leading 'a'", function() {
+      ASSERT_EQ("a", article_of("a cat"));
+    }),
+    test("no article yields empty", function() {
+      ASSERT_EQ("", article_of("bear"));
+    }),
+    test("an empty string errors", function() {
+      string err = catch(article_of(""));
+      ASSERT_NE(0, err);
+    }),
+  }));
+
+  describe("add_article", ({
+    test("prepends 'an' to a vowel word", function() {
+      ASSERT_EQ("an elephant", add_article("elephant"));
+    }),
+    test("prepends 'a' to a consonant word", function() {
+      ASSERT_EQ("a bear", add_article("bear"));
+    }),
+    test("the definite flag prepends 'the'", function() {
+      ASSERT_EQ("the bear", add_article("bear", 1));
+    }),
+    test("uses the sound-aware article for 'an hour'", function() {
+      ASSERT_EQ("an hour", add_article("hour"));
+    }),
+    test("uses the sound-aware article for 'a user'", function() {
+      ASSERT_EQ("a user", add_article("user"));
+    }),
+    test("leaves an already-articled string alone", function() {
+      ASSERT_EQ("the bear", add_article("the bear"));
+    }),
+  }));
+
+  describe("remove_article", ({
+    test("removes a leading 'the'", function() {
+      ASSERT_EQ("bear", remove_article("the bear"));
+    }),
+    test("removes a leading 'an'", function() {
+      ASSERT_EQ("apple", remove_article("an apple"));
+    }),
+    test("leaves an unarticled string alone", function() {
+      ASSERT_EQ("bear", remove_article("bear"));
+    }),
+  }));
+
+  describe("number_word", ({
+    test("zero is 'no'", function() {
+      ASSERT_EQ("no", number_word(0));
+    }),
+    test("one", function() {
+      ASSERT_EQ("one", number_word(1));
+    }),
+    test("nine", function() {
+      ASSERT_EQ("nine", number_word(9));
+    }),
+    test("ten falls back to the numeric string", function() {
+      ASSERT_EQ("10", number_word(10));
+    }),
+    test("a larger number is its numeric string", function() {
+      ASSERT_EQ("42", number_word(42));
+    }),
+  }));
+}


### PR DESCRIPTION
Fixes two bugs in `possessive_pronoun` and `subjective` where the gender-check condition and switch expression incorrectly tested the raw input (`ob`) instead of the resolved `__gender` string, causing wrong pronouns to be returned for object inputs.

Improves `article` to choose "a"/"an" based on pronunciation rather than spelling alone. Silent-h words ("hour", "honest", "heir", "honour") now correctly take "an", and "us..." words that produce a "yoo" onset ("user", "use") now correctly take "a" while vowel-sounding "us..." words ("usher") are preserved with "an". Adds a `vowel` helper that tests whether a character code is an ASCII vowel.

Adds a test suite for `english.lpc` covering `cap_words`, `cap_significant_words`, the full possessive and pronoun family (`possessive_noun`, `possessive_proper_noun`, `possessive_pronoun`, `possessive`, `reflexive`, `objective`, `subjective`), `vowel`, `article`, `article_of`, `add_article`, `remove_article`, and `number_word`. Both the string and object input paths for pronoun/possessive functions are exercised via a new minimal `gendered` fixture object.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes English pronoun handling and expands article selection behavior.

- Resolves gender strings before selecting pronouns.
- Adds vowel detection and sound-aware `a`/`an` handling.
- Adds fixture-based coverage for English simul-efuns.
</details>

<sub>Reviews (2): Last reviewed commit: ["tests"](https://github.com/gesslar/oxidus-mudlib/commit/7b0856bc4388bd520127d17689d507824b5c5561) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43716240)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
</details>

<!-- /greptile_comment -->