### PR TITLE
Add tests for `identify()` and `j()` simul_efuns

### DIFF
--- a/tests/adm/simul_efun/identify.test.lpc
+++ b/tests/adm/simul_efun/identify.test.lpc
@@ -1,0 +1,99 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/identify.test.lpc
+ * @description Tests for the identify() and j() simul_efuns from
+ *              /adm/simul_efun/identify.lpc — recursive string serializers.
+ *              identify() emits LPC-literal syntax (({ }), ([ ])); j() emits
+ *              JSON-like syntax ([], {}). Both escape strings and handle every
+ *              LPC type.
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+void setup() {
+  describe("identify scalars", ({
+    test("an integer", function() {
+      ASSERT_EQ("5", identify(5));
+    }),
+    test("a negative integer", function() {
+      ASSERT_EQ("-3", identify(-3));
+    }),
+    test("zero", function() {
+      ASSERT_EQ("0", identify(0));
+    }),
+    test("undefined", function() {
+      ASSERT_EQ("UNDEFINED", identify(undefined));
+    }),
+    test("a string is quoted", function() {
+      ASSERT_EQ("\"hi\"", identify("hi"));
+    }),
+    test("a newline in a string is escaped", function() {
+      ASSERT_EQ("\"a\\nb\"", identify("a\nb"));
+    }),
+  }));
+
+  describe("identify arrays", ({
+    test("an empty array", function() {
+      ASSERT_EQ("({ })", identify(({})));
+    }),
+    test("an array of integers", function() {
+      ASSERT_EQ("({ 1, 2, 3 })", identify(({ 1, 2, 3 })));
+    }),
+    test("an array of strings", function() {
+      ASSERT_EQ("({ \"a\", \"b\" })", identify(({ "a", "b" })));
+    }),
+    test("a nested array", function() {
+      ASSERT_EQ("({ 1, ({ 2, 3 }) })", identify(({ 1, ({ 2, 3 }) })));
+    }),
+  }));
+
+  describe("identify mappings", ({
+    test("an empty mapping", function() {
+      ASSERT_EQ("([ ])", identify(([])));
+    }),
+    test("a single-pair mapping", function() {
+      ASSERT_EQ("([ \"a\" : 1 ])", identify(([ "a": 1 ])));
+    }),
+  }));
+
+  describe("identify objects", ({
+    test("an object renders as OBJ(...)", function() {
+      ASSERT_EQ(0, strsrch(identify(this_object()), "OBJ("));
+    }),
+  }));
+
+  describe("j scalars", ({
+    test("an integer", function() {
+      ASSERT_EQ("5", j(5));
+    }),
+    test("undefined", function() {
+      ASSERT_EQ("undefined", j(undefined));
+    }),
+    test("a string is quoted", function() {
+      ASSERT_EQ("\"hi\"", j("hi"));
+    }),
+  }));
+
+  describe("j arrays", ({
+    test("an empty array", function() {
+      ASSERT_EQ("[]", j(({})));
+    }),
+    test("an array of integers", function() {
+      ASSERT_EQ("[1, 2, 3]", j(({ 1, 2, 3 })));
+    }),
+  }));
+
+  describe("j mappings", ({
+    test("an empty mapping", function() {
+      ASSERT_EQ("{}", j(([])));
+    }),
+    test("a single-pair mapping", function() {
+      ASSERT_EQ("{\"a\": 1}", j(([ "a": 1 ])));
+    }),
+    test("a mapping with a nested array value", function() {
+      ASSERT_EQ("{\"a\": [1, 2]}", j(([ "a": ({ 1, 2 }) ])));
+    }),
+  }));
+}


### PR DESCRIPTION
Add tests for `identify()` and `j()` simul_efuns

Covers both serializers defined in `/adm/simul_efun/identify.lpc` across all supported LPC types:

- **`identify()`** — LPC-literal syntax (`({ })`, `([ ])`)
  - Scalars: integers (positive, negative, zero), `undefined`, and quoted strings with escape handling (`\n`)
  - Arrays: empty, integer elements, string elements, and nested arrays
  - Mappings: empty and single key-value pair
  - Objects: verifies output begins with `OBJ(`

- **`j()`** — JSON-like syntax (`[]`, `{}`)
  - Scalars: integers, `undefined`, and quoted strings
  - Arrays: empty and integer elements
  - Mappings: empty, single key-value pair, and a mapping with a nested array value

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds coverage for the `identify()` and `j()` simul_efuns. The main changes are:

- Adds scalar serialization tests.
- Adds array and mapping serialization tests.
- Adds an object serialization check for `identify()`.
</details>

<sub>Reviews (2): Last reviewed commit: ["tests"](https://github.com/gesslar/oxidus-mudlib/commit/01fc43753f86380a4e02ab4687a8167ad839094c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43716250)</sub>

<!-- /greptile_comment -->