### PR TITLE
Add `update.lpc` object command

### DIFF
--- a/cmds/object/update.lpc
+++ b/cmds/object/update.lpc
@@ -1,0 +1,163 @@
+/**
+ * @file /cmds/object/update.c
+ *
+ * A command to update objects! Neat, huh?
+ *
+ * @created 2026-07-13 - Gesslar
+ * @last_modified 2026-07-13 - Gesslar
+ *
+ * @history
+ * 2026-07-13 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+private nomask mapping resolve_target(mixed target, string kind);
+private nomask void generate_graph(mapping target, string kind);
+private nomask mixed reload_it(mixed target);
+private nomask mixed perform_update(object tp, mapping target);
+
+mixed main(
+  /** @type {STD_PLAYER} */ object tp,
+  string arg
+) {
+  string target;
+  mapping to_update;
+
+  if(!arg)
+    to_update = resolve_target(tp->query_env("cwf"), "single");
+  else if(arg == "-r")
+    to_update = resolve_target(tp->query_env("cwf"), "shallow");
+  else if(sscanf(arg, "-r %s", target) == 1)
+    to_update = resolve_target(target, "shallow");
+  else if(arg == "-R")
+    to_update = resolve_target(tp->query_env("cwf"), "deep");
+  else if(sscanf(arg, "-R %s", target) == 1)
+    to_update = resolve_target(target, "deep");
+  else
+    to_update = resolve_target(arg, "single");
+
+  if(!to_update) {
+    if(!tp->query_env("cwf"))
+      return _error(tp, "You do not have a current working file.");
+    else
+      return _error(tp, "Invalid target for update.");
+  }
+
+  if(includes(to_update.graph, base_name()))
+    return _error("The update command may not be updated in this manner. "
+                  "Destruct it instead.");
+
+  tp->set_env("cwf", to_update.file);
+
+  return perform_update(tp, to_update);
+}
+
+private nomask mapping resolve_target(mixed target, string kind) {
+  if(stringp(target)) {
+    if(cfile_exists(target)) {
+      if(find_object(target)) {
+        return resolve_target(find_object(target), kind);
+      }
+    }
+
+    return resolve_target(get_object(target), kind);
+  }
+
+  if(!objectp(target))
+    return 0;
+
+  mapping new_target = ([
+    "file": base_name(target),
+    "object": target,
+    "virtual": false,
+    "virtual_master": undefined,
+  ]);
+
+  if(virtualp(target)) {
+    new_target["virtual"] = true;
+    new_target["virtual_master"] =
+      /** @type {STD_OBJECT} */ (target)->query_virtual_master();
+  }
+
+  generate_graph(new_target, kind);
+
+  return new_target;
+}
+
+private nomask void process_leaf(object ob, mixed ref *graph, int recurse: (: 0 :)) {
+  string *list = inherit_list(ob);
+
+  if(!sizeof(list))
+    return;
+
+  if(recurse) {
+    foreach(string file in list) {
+      object sub_ob = load_object(file);
+      process_leaf(sub_ob, ref graph, recurse);
+    }
+  }
+
+  push(ref graph, list);
+}
+
+private nomask void generate_graph(mapping target, string kind) {
+  target["graph"] = ({});
+
+  if(kind != "single") {
+    if(kind == "shallow")
+      process_leaf(target["object"], ref target["graph"], 0);
+    if(kind == "deep")
+      process_leaf(target["object"], ref target["graph"], 1);
+  }
+
+  if(target.virtual)
+    push(ref target["graph"], ({target.virtual_master}));
+  else
+    push(ref target["graph"], ({target.file}));
+
+  target["graph"] = flatten(target["graph"]);
+}
+
+private nomask mixed reload_it(mixed target) {
+  /** @type {STD_OBJECT} */ object ob = find_object(target);
+  /** @type {STD_PLAYER*} */ object *livs = present_players(ob);
+
+  if(objectp(ob))
+    catch(ob->remove());
+  else
+    return;
+
+  if(ob)
+    destruct(ob);
+
+  string err = catch(ob = load_object(target));
+  if(err)
+    return err;
+
+  if(sizeof(livs))
+    livs->move(ob);
+}
+
+private nomask mixed perform_update(object tp, mapping target) {
+  foreach(string file in target.graph) {
+    string err = reload_it(file);
+    if(err) {
+      if(target.virtual) {
+        return _error("Unable to update %O (%O):\n%s => %s", target.file, target.virtual_master, file, err);
+      } else {
+        return _error("Unable to update %O:\n%s => %s", target.file, file, err);
+      }
+    }
+
+    _ok(tp, "%s => OK", file);
+  }
+
+  if(target.virtual && objectp(target["object"])) {
+    if(roomp(target["object"])) {
+      reload_it(target["object"]);
+    }
+  }
+
+  return 1;
+}


### PR DESCRIPTION
Adds an `update` command for reloading objects in-game without requiring a full server restart.

The command supports three modes of operation:

- **Single update** (default): Reloads only the target object
- **Shallow recursive** (`-r`): Reloads the target along with its direct inherited files
- **Deep recursive** (`-R`): Reloads the target and recursively traverses the entire inheritance chain

When no target is specified, the command operates on the current working file from the player's environment. After a successful update, the current working file is updated to reflect the resolved target.

The command handles virtual objects by tracking their virtual master and ensuring it is included in the reload graph. Any players present in a room being reloaded are moved back into the newly loaded object after the reload completes. The command also prevents itself from being updated through this mechanism, requiring a destruct instead.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an in-game command for reloading objects. The main changes are:
- Adds single-object reloads.
- Adds shallow and deep inheritance reload modes.
- Handles virtual objects and moves players back into reloaded rooms.
- Updates the current working file after a successful target resolution.
</details>

<sub>Reviews (3): Last reviewed commit: ["new"](https://github.com/gesslar/oxidus-mudlib/commit/06cc412eca1674f9c6e96d08620bbdc5494b0546) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44157314)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->