### PR TITLE
Add `dest.lpc` object command, remove `getoid` and `find_ob` sefuns

### DIFF
--- a/adm/include/simul_efun.h
+++ b/adm/include/simul_efun.h
@@ -173,28 +173,26 @@ varargs float dim_sigmoid(mixed val, mixed scale, mixed k);
 
 // File: object.c
 int caller_is(mixed ob);
-int getoid(object ob);
-int same_env_check(object ob1, object ob2, int top_env);
+varargs int same_env_check(object ob1, object ob2, int top_env);
 object *get_livings(mixed names, object room);
 object *get_players(mixed names, object room);
-object *present_clones(string file, object room);
+object *present_clones(mixed file, object room);
 object *present_livings(object room);
 object *present_players(object room);
 object *present_npcs(object room);
 object get_living(string name, object room);
 object get_player(string name, object room);
 object this_body();
+object this_caller();
+varargs object get_object(string str, object player);
+varargs mixed get_objects(string str, object player, int no_arr);
 varargs object top_environment(object ob);
 varargs object *all_environment(object ob);
-varargs mixed get_objects(string str, object player, int no_arr);
-varargs object find_ob(mixed ob, mixed cont);
-varargs object get_object(string str, object player);
-varargs object find_targets(object tp, string str, object env, function f);
+varargs object *find_targets(object tp, string str, object env, function f);
 varargs object find_target(object tp, string str, object env, function f);
 varargs object *clones(mixed file, int env_only);
 varargs mixed *accessible_objects(object container, object pov);
 varargs object *accessible_objects_flat(object container, object pov);
-object shutdown_d();
 
 // File: predicates.c
 int roomp(object ob);

--- a/adm/obj/login.lpc
+++ b/adm/obj/login.lpc
@@ -111,9 +111,8 @@ public void gmcp_authenticated(string _username, string char) {
   if(old_body = find_player(char)) {
     write_file(
       log_dir() + LOG_LOGIN,
-      capitalize(old_body->query_real_name()) + " (" + getoid(old_body) +
-      ") reconnected from " + query_ip_number(this_object()) +
-      " on " + ctime(time()) + "\n"
+      capitalize(old_body->query_real_name()) + " reconnected from " +
+        query_ip_number(this_object()) + " on " + ctime(time()) + "\n"
     );
 
     if(interactive(old_body)) {
@@ -395,7 +394,7 @@ private void character_menu_input(string str, string prompt) {
 
   write_file(
     log_dir() + LOG_LOGIN,
-    capitalize(characters[i]) + " (" + getoid(body) + ") logged in from " +
+    capitalize(characters[i]) + " logged in from " +
     query_ip_number(this_object()) + " on " + ctime(time()) + "\n"
   );
 
@@ -443,7 +442,7 @@ private void new_character(string str) {
 
   write_file(
     log_dir() + LOG_LOGIN,
-    capitalize(str) + " (" + getoid(body) + ") logged in from " +
+    capitalize(str) + " logged in from " +
     query_ip_number(this_object()) + " on " + ctime(time()) + "\n"
   );
 
@@ -513,8 +512,9 @@ private void reconnect(string str, string name) {
     tell(this_object(), "You have chosen not to reconnect to your old body.\n");
     write_file(
       log_dir() + LOG_LOGIN,
-      capitalize(str) + " (" + getoid(body) + ") logged in from " +
-      query_ip_number(this_object()) + " on " + ctime(time()) + "\n");
+      capitalize(str) + " logged in from " + query_ip_number(this_object()) +
+      " on " + ctime(time()) + "\n"
+    );
 
     enter_world(name, 0);
   }

--- a/adm/simul_efun/object.lpc
+++ b/adm/simul_efun/object.lpc
@@ -19,24 +19,6 @@
 //Tacitus @ LPUniversity
 //Grouped on October 22nd, 2005
 
-/**
- * Retrieves the unique object ID of the given object as assigned
- * by the driver. For example:
- *
- * @param {object} ob - The object to get the ID of.
- * @returns {int}. The unique object ID.
- * @example
- * object knife = new("/obj/knife"); // obj/knife#232
- * get_oid(knife); // 232
- */
-int getoid(object ob) {
-  int id;
-
-  sscanf(file_name(ob || previous_object()), "%*s#%d", id);
-
-  return id;
-}
-
 /*
 //      get_object() and get_objects()
 //      Created by Pallando@Ephemeral Dale   (92-06)
@@ -69,9 +51,9 @@ int getoid(object ob) {
  * @see get_objects
  * @example
  * get_object("sword");           // Basic search
- * get_object("@orc");           // Environment of orc
+ * get_object("@orc");            // Environment of orc
  * get_object("me", this_body()); // The player themselves
- * get_object("here");           // Current room
+ * get_object("here");            // Current room
  */
 varargs object get_object(string str, object player) {
   object what;
@@ -238,63 +220,6 @@ varargs mixed get_objects(string str, object player, int no_arr) {
   }
 
   return get_object(str, player);
-}
-
-/*
-  NB
-
-  It would be fairly simple to combine these two functions into one
-  varargs object get_object(string str, object player, int arr_poss)
-  which will only return a single object unless the array_possible flag
-  is passed.
-
-  I have chosen not to do this however, since some muds may not wish to
-  use the more complicated search routines and keeping get_objects() as
-  a seperate simul_efun makes it easier to disable.
-*/
-/**
- * Finds an object within a container using precise criteria.
- *
- * @param {mixed} ob - Target object or filename
- * @param {mixed} [cont] - Container to search in
- * @returns {object} Matching object or 0 if not found
- * @see find_targets
- * @example
- * find_ob("sword", this_body());
- * find_ob("/obj/weapon/sword#12", room);
- */
-varargs object find_ob(mixed ob, mixed cont) {
-
-  // First let's deal with dest.
-  if(nullp(cont))
-    cont = previous_object();
-
-  if(stringp(cont))
-    cont = load_object(cont);
-
-  if(objectp(ob))
-    return present(ob, cont) ? ob : 0;
-
-  if(stringp(ob)) {
-    if(ob[0] == '/') {
-      object *obs = all_inventory(cont);
-
-      if(strsrch(ob, "#") > -1) {
-        foreach(object o in obs) {
-          if(file_name(o) == ob)
-            return o;
-        }
-      } else {
-        ob = chop(chop(ob, ".lpc", -1), ".c", -1);
-        foreach(object o in obs) {
-          if(base_name(o) == ob)
-            return o;
-        }
-      }
-    }
-  }
-
-  return 0;
 }
 
 /**
@@ -740,8 +665,6 @@ varargs mixed *accessible_objects(object container, object pov) {
 
   if(!container->inventory_accessible())
     return 0;
-  // if(!container->is_container() || !container->is_content_accessible(pov))
-  //   return 0;
 
   if(!sizeof(contents = all_inventory(container)))
     return 0;
@@ -759,28 +682,6 @@ varargs mixed *accessible_objects(object container, object pov) {
 
   return result;
 }
-
-// mixed accessible_objects(object ob)
-// {
-//    mixed ret = ({});
-//    object *inv;
-//    object *next_inv;
-
-//    if (!ob->inventory_accessible())
-//       return 0;
-//    inv = all_inventory(ob);
-//    if (!sizeof(inv))
-//       return 0;
-//    foreach (object item in inv)
-//    {
-//       next_inv = accessible_objects(item);
-//       if (!next_inv)
-//          ret += ({item});
-//       else
-//          ret += ({item, next_inv});
-//    }
-//    return ret;
-// }
 
 /**
  * Retrieves a flat array of objects that can be reached within a container.

--- a/cmds/object/dest.lpc
+++ b/cmds/object/dest.lpc
@@ -1,0 +1,80 @@
+/**
+ * @file /cmds/object/dest.lpc
+ *
+ * Destruct an object.
+ *
+ * @created 2026-07-14 - Gesslar
+ * @last_modified 2026-07-14 - Gesslar
+ *
+ * @history
+ * 2026-07-14 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text = "dest <target|file>";
+}
+
+private int can_destruct(object tp, object ob);
+
+mixed main(
+  /** @type {STD_PLAYER} */ object tp,
+  string arg
+) {
+  if(!arg)
+    return _usage(tp);
+
+  // First let's try by path, because if we do it by get_object first, it'll
+  // try to load it when it's a path.
+  string path = resolve_path(tp->query_env("cwd") ?? "", arg);
+  string code_file = source_file(path);
+  if(file_size(code_file) >= 0) {
+    /** @type {STD_OBJECT} */ object ob = find_object(code_file);
+    if(ob) {
+      string dested = file_name(ob);
+
+      if(!can_destruct(tp, ob))
+        return _error("You do not have permission to destruct %s", dested);
+
+      catch(ob->remove());
+      if(ob)
+        catch(destruct(ob));
+
+      return _ok(tp, "Destructed %s", dested);
+    } else {
+      return _info("%s is not loaded", code_file);
+    }
+  }
+
+  /** @type {STD_OBJECT} */ object ob = get_object(arg, tp);
+  if(!ob)
+    return _error("No such object %s", arg);
+
+  string dested = file_name(ob);
+
+  if(!can_destruct(tp, ob))
+    return _error("You do not have permission to destruct %s", dested);
+
+  catch(ob->remove());
+  if(ob)
+    catch(destruct(ob));
+
+  return _ok("Destructed %s", dested);
+}
+
+private int can_destruct(object tp, object ob) {
+  if(living(ob) && userp(ob)) {
+    if(ownerp(tp)) {
+      return 1;
+    }
+
+    if(adminp(tp)) {
+      return !ownerp(ob);
+    }
+
+    return 0;
+  }
+
+  return 1;
+}


### PR DESCRIPTION
Adds a new `dest` command for destructing objects by target name or file path, with permission checks that prevent non-owners from destructing player objects and prevent admins from destructing owner-level players.

Removes `getoid` and `find_ob` simul-efuns, along with commented-out dead code in `accessible_objects`. Login logs are updated to drop the object ID from login/reconnect entries. `find_targets` return type is corrected to `object *`, `same_env_check` and `present_clones` signatures are loosened, and `this_caller` is added to the simul-efun header.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a destruction command and removes obsolete object helpers. The main changes are:

- Add `dest` target and path handling.
- Protect interactive player bodies from selected destruction paths.
- Remove `getoid` and `find_ob` simul-efuns.
- Align simul-efun declarations with implementations.
- Remove object IDs from login logs.
</details>

<details open><summary><h3>Security Review</h3></summary>

The new `dest` permission predicate permits destruction of every non-interactive target. When non-admin callers can invoke the command, this includes loaded rooms, daemons, items, and NPCs.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acmds%2Fobject%2Fdest.lpc%3A79%0A**Unrestricted%20Non-Player%20Destruction**%0A%0AThis%20default%20allows%20every%20target%20that%20is%20not%20both%20%60living%28%29%60%20and%20%60userp%28%29%60.%20When%20%60dest%60%20is%20available%20to%20a%20non-admin%20caller%2C%20that%20caller%20can%20destroy%20any%20loaded%20room%2C%20daemon%2C%20item%2C%20or%20NPC%20by%20path%20because%20both%20lookup%20paths%20reach%20%60can_destruct%28%29%60%20before%20%60remove%28%29%60%20and%20%60destruct%28%29%60.%20Restrict%20this%20fallback%20to%20the%20command's%20intended%20privileged%20users%20or%20ownership%20scope.%0A%0A%23%23%23%20Issue%202%20of%202%0Aadm%2Fsimul_efun%2Fobject.lpc%3A19%0A**Removed%20Sefuns%20Remain%20Documented**%0A%0A%60doc%2Fsefun%2Fgetoid.help%60%20and%20%60doc%2Fsefun%2Ffind_ob.help%60%20still%20advertise%20the%20removed%20simul-efuns.%20The%20help%20system%20will%20direct%20users%20to%20functions%20that%20no%20longer%20exist%2C%20so%20remove%20or%20update%20those%20help%20entries%20with%20this%20API%20removal.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=307&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["stuff"](https://github.com/gesslar/oxidus-mudlib/commit/906cae130594edb19566e1319baced06797d1871) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44192025)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->