### PR TITLE
Add `ob_short`, `ob_long` sefuns and `look.lpc` action command

### DIFF
--- a/adm/include/simul_efun.h
+++ b/adm/include/simul_efun.h
@@ -193,6 +193,8 @@ varargs object find_target(object tp, string str, object env, function f);
 varargs object *clones(mixed file, int env_only);
 varargs mixed *accessible_objects(object container, object pov);
 varargs object *accessible_objects_flat(object container, object pov);
+string ob_short(object ob);
+string ob_long(object ob);
 
 // File: predicates.c
 int roomp(object ob);

--- a/adm/simul_efun/object.lpc
+++ b/adm/simul_efun/object.lpc
@@ -697,3 +697,68 @@ varargs mixed *accessible_objects(object container, object pov) {
 varargs object *accessible_objects_flat(object container, object pov) {
   return flatten(accessible_objects(container, pov));
 }
+
+/**
+ * Builds the composite short description for an object.
+ *
+ * Combines the object's base short with any extra shorts, rendering
+ * each extra short parenthesized and space-separated after the base.
+ * When the base short is absent, only the extra shorts are returned;
+ * when both are absent, an empty string is returned.
+ *
+ * @param {STD_OBJECT} ob - The object whose short description to build.
+ * @returns {string} The composite short description, or "" if ob is not an
+ *  object or has nothing to show.
+ */
+string ob_short(object ob) {
+  if(!objectp(ob))
+    return "";
+
+  string short = ob->query_short() ?? "";
+  string *xs = ob->query_extra_shorts() ?? ({});
+
+  xs = filter(xs, (: stringp($1) && truthy($1) :));
+
+  if(sizeof(short) && sizeof(xs))
+    return `${short} ${implode(map(xs, (: `(${$1})` :)), " ")}`;
+  if(sizeof(short) && !sizeof(xs))
+    return short;
+  if(!sizeof(short) && sizeof(xs))
+    return implode(map(xs, (: `(${$1})` :)), " ");
+
+  return "";
+}
+
+/**
+ * Builds the composite long description for an object.
+ *
+ * Combines the object's base long with any extra longs, each on its
+ * own line beneath the base. The base long is newline-terminated and
+ * each extra long is stripped of a trailing newline before joining.
+ * When the base long is absent, only the extra longs are returned;
+ * when both are absent, an empty string is returned.
+ *
+ * @param {STD_OBJECT} ob - The object whose long description to build.
+ * @returns {string} The composite long description, or "" if ob is not an
+ *  object or has nothing to show.
+ */
+string ob_long(object ob) {
+  if(!objectp(ob))
+    return "";
+
+  string long = ob->query_long() ?? "";
+  string *xl = ob->query_extra_longs() ?? ({});
+
+  long = append(long, "\n");
+  xl = filter(xl, (: stringp($1) && truthy($1) :));
+  xl = map(xl, (: chop($1, "\n") :));
+
+  if(sizeof(long) && sizeof(xl))
+    return `${long}\n${implode(xl, "\n")}`;
+  if(sizeof(long) && !sizeof(xl))
+    return long;
+  if(!sizeof(long) && sizeof(xl))
+    return implode(xl, "\n");
+
+  return "";
+}

--- a/cmds/action/look.lpc
+++ b/cmds/action/look.lpc
@@ -1,0 +1,93 @@
+/**
+ * @file /cmds/action/look.c
+ *
+ * Command to look at things and the room and stuff.
+ *
+ * @created 2026-07-13 - Gesslar
+ * @last_modified 2026-07-13 - Gesslar
+ *
+ * @history
+ * 2026-07-13 - Gesslar - Created
+ */
+
+inherit STD_ACT;
+
+mixed identify_filename(object ob, int vm);
+mixed describe_environment(object tp);
+
+mixed main(
+  /** @type {STD_PLAYER} */ object tp,
+  string arg
+) {
+  if(!environment(tp))
+    return "You don't see anything.";
+
+  if(falsy(arg))
+    return describe_environment(tp);
+
+  return "You don't see that here.";
+}
+
+/**
+ *
+ * @param {STD_OBJECT} ob
+ * @param vm
+ */
+mixed identify_filename(object ob, int vm) {
+  vm = !!vm;
+
+  string fn = file_name(ob);
+
+  if(virtualp(ob)) {
+    if(vm == 0) {
+      if(ob->query_virtual_master())
+        return `${fn} [V]`;
+      else
+        return `${fn} [VM]`;
+    } else {
+      string virt = ob->query_virtual_master();
+
+      if(!virt)
+        return `${fn} [Virtual]`;
+      else
+        return `${fn} [${virt}]`;
+    }
+  } else {
+    return fn;
+  }
+}
+
+mixed describe_environment(
+  /** @type {STD_PLAYER} */ object tp
+) {
+  /** @type {STD_ROOM} */ object env = environment(tp);
+  string result = "";
+
+  if(devp(tp)) {
+    if(tp->query_pref("look_filename") == "on") {
+      string fn = `{{069}}${identify_filename(env, 1)}{{res}}`;
+
+      result += append(fn, "\n");
+    }
+  }
+
+  string short = ob_short(env);
+  if(truthy(short)) {
+    result += append(short, "\n");
+  }
+
+  string long = ob_long(env);
+  if(truthy(long))
+    result += append(long, "\n");
+
+  string *exits = env->query_exit_ids();
+  if(sizeof(exits)) {
+    if(truthy(long)) {
+      result += "\n";
+    }
+
+    result += `You may go ${simple_list(exits, "and")}.`;
+  }
+
+  return result;
+}


### PR DESCRIPTION
Adds two new simul-efuns, `ob_short` and `ob_long`, that build composite short and long descriptions for objects by combining their base descriptions with any extra shorts or longs. Extra shorts are parenthesized and space-separated after the base; extra longs are appended on their own lines beneath the base.

Introduces a new `look` action command that uses these simul-efuns to describe the player's environment. For developers with the `look_filename` preference enabled, the room's filename is displayed at the top. The description includes the room's short, its long, and a list of available exits.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds composite object descriptions and a room look command. The main changes are:

- Adds `ob_short` and `ob_long` simul-efuns.
- Adds declarations for the new simul-efuns.
- Adds `look` output for room descriptions, filenames, and exits.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aadm%2Fsimul_efun%2Fobject.lpc%3A749-757%0A**Empty%20Long%20Still%20Adds%20Gaps**%0A%0ARooms%20with%20no%20base%20long%20and%20at%20least%20one%20extra%20long%20still%20render%20with%20two%20leading%20newlines.%20%60query_long%28%29%60%20returns%20%600%60%20for%20an%20unset%20long%2C%20which%20becomes%20%60%22%22%60%3B%20%60append%28long%2C%20%22%5Cn%22%29%60%20then%20makes%20it%20non-empty%2C%20so%20the%20base-plus-extras%20branch%20runs%20and%20inserts%20another%20newline.%20The%20extras-only%20branch%20is%20therefore%20unreachable%2C%20and%20%60look%60%20displays%20blank%20lines%20before%20the%20first%20extra%20description.%0A%0A%60%60%60suggestion%0A%20%20string%20long%20%3D%20ob-%3Equery_long%28%29%20%3F%3F%20%22%22%3B%0A%20%20string%20*xl%20%3D%20ob-%3Equery_extra_longs%28%29%20%3F%3F%20%28%7B%7D%29%3B%0A%0A%20%20xl%20%3D%20filter%28xl%2C%20%28%3A%20stringp%28%241%29%20%26%26%20truthy%28%241%29%20%3A%29%29%3B%0A%20%20xl%20%3D%20map%28xl%2C%20%28%3A%20chop%28%241%2C%20%22%5Cn%22%29%20%3A%29%29%3B%0A%0A%20%20if%28sizeof%28long%29%29%0A%20%20%20%20long%20%3D%20append%28long%2C%20%22%5Cn%22%29%3B%0A%0A%20%20if%28sizeof%28long%29%20%26%26%20sizeof%28xl%29%29%0A%20%20%20%20return%20%60%24%7Blong%7D%24%7Bimplode%28xl%2C%20%22%5Cn%22%29%7D%60%3B%0A%60%60%60%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=309&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["adding basic look command"](https://github.com/gesslar/oxidus-mudlib/commit/0ba586bd76fe2c37da648ff05c8ca82a48af3268) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44214095)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->