### PR TITLE
Fix `ob_long` trailing newline handling

### DIFF
--- a/adm/simul_efun/object.lpc
+++ b/adm/simul_efun/object.lpc
@@ -749,14 +749,13 @@ string ob_long(object ob) {
   string long = ob->query_long() ?? "";
   string *xl = ob->query_extra_longs() ?? ({});
 
-  long = append(long, "\n");
   xl = filter(xl, (: stringp($1) && truthy($1) :));
   xl = map(xl, (: chop($1, "\n") :));
 
   if(sizeof(long) && sizeof(xl))
-    return `${long}\n${implode(xl, "\n")}`;
+    return `${append(long, "\n")}\n${implode(xl, "\n")}`;
   if(sizeof(long) && !sizeof(xl))
-    return long;
+    return append(long, "\n");
   if(!sizeof(long) && sizeof(xl))
     return implode(xl, "\n");
 


### PR DESCRIPTION
Fixes `ob_long` to avoid unconditionally appending a newline to `long` upfront, which previously caused a trailing newline to appear even when no extra longs were present. The newline is now only appended inline when it is actually needed — either as a separator before extra longs or as a terminator when returning the long description alone.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects newline handling in `ob_long`.

- Defers newline appending until a non-empty base long is returned.
- Keeps base-long output newline-terminated.
- Leaves extra-long joining unchanged.
</details>

<sub>Reviews (1): Last reviewed commit: ["fixing ob\_long"](https://github.com/gesslar/oxidus-mudlib/commit/846ce6c96ab9387ac2508ae51f67260148ebe888) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44321286)</sub>

**Context used:**

- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->