### PR TITLE
Add `ls.lpc` file command, `get_dir.h` header, and file metadata to `as_file`/`as_directory`

### DIFF
--- a/adm/etc/security/access.lpml
+++ b/adm/etc/security/access.lpml
@@ -31,7 +31,7 @@
   { path: "/data/**",               read: "all",            write: "all", },
   { path: "/adm/etc/secret/**",     read: "role:admin",     write: "role:admin", },
   { path: "/adm/etc/**",            read: "all",            write: "role:admin", },
-  { path: "/adm/**",                read: "role:admin",     write: "role:admin", },
+  { path: "/adm/**",                read: "role:developer", write: "role:admin", },
   { path: "/home/*/*/**",           read: "all",            write: "self", },
   { path: "/doc/**",                read: "all",            write: "role:developer", },
   { path: "/include/**",            read: "all",            write: "role:developer", },

--- a/adm/simul_efun/file.lpc
+++ b/adm/simul_efun/file.lpc
@@ -13,6 +13,7 @@
  */
 
 #include <simul_efun.h>
+#include <get_dir.h>
 
 /**
  * Ensures a file's parent directories exist.
@@ -525,6 +526,7 @@ mapping as_directory(string str) {
     "ext": ext,
     "path": str,
     "directory": true,
+    "modified": info[0][GD_FILE_MODIFIED],
   ]);
 }
 
@@ -560,12 +562,18 @@ mapping as_file(string str) {
     ext = name[dot+1..];
   }
 
+  int *st = stat(str);
+
   return ([
     "name": name,
     "base": base,
     "ext": ext,
     "path": str,
     "file": true,
+    "size": st[0],
+    "modified": st[1],
+    "loaded": st[2],
+    "created": st[3],
   ]);
 }
 

--- a/cmds/file/ls.lpc
+++ b/cmds/file/ls.lpc
@@ -1,0 +1,254 @@
+/**
+ * @file /cmds/file/ls.c
+ *
+ * List files and directories
+ *
+ * @created 2026-07-14 - Gesslar
+ * @last_modified 2026-07-14 - Gesslar
+ *
+ * @history
+ * 2026-07-14 - Gesslar - Created
+ */
+
+#include <get_dir.h>
+
+inherit STD_CMD;
+
+private mixed perform_ls(string target, string *flags);
+private mapping resolve_entry(string dir, mixed *entry);
+private mapping decorate_entry(mapping entry);
+private string *format_ls(mapping *entries, string *flags);
+private int sort_listing(mapping a, mapping b);
+
+mixed main(
+  /** @type {STD_PLAYER} */ object tp,
+  string arg
+) {
+  if(falsy(arg))
+    arg = ".";
+
+  mixed flags;
+  if(sscanf(arg, "-%s %s", flags, arg) == 2) {
+    flags = explode(flags, "");
+  } else if(sscanf(arg, "-%s", flags) == 1) {
+    // Flags with no path (e.g. "ls -l") — list the current directory.
+    flags = explode(flags, "");
+    arg = ".";
+  } else {
+    flags = ({});
+  }
+
+  string cwd = tp->query_env("cwd");
+  string path = resolve_path(cwd, arg);
+
+  // An existing directory: list its contents.
+  if(directory_exists(path))
+    return perform_ls(append(path, "/"), flags);
+
+  // An existing file: list the single entry.
+  if(file_exists(path))
+    return perform_ls(path, flags);
+
+  // Neither, but a wildcard means get_dir() will glob it — an empty
+  // match there is a legitimate "nothing matched", not a bad path.
+  if(strsrch(path, "*") != -1 || strsrch(path, "?") != -1)
+    return perform_ls(path, flags);
+
+  // A concrete path that resolves to nothing: say so, rather than
+  // returning an empty listing that looks like an empty directory.
+  return _error(tp, "ls: %s: No such file or directory.", arg);
+}
+
+private mixed perform_ls(string target, string *flags) {
+  // dir_file() splits a "dir/leaf" path; a bare directory (trailing
+  // slash) has no leaf, so it returns ({}) and target IS the directory.
+  string *df = dir_file(target);
+
+  if(!sizeof(df)) {
+    df = ({
+      target,
+      ""
+    });
+  }
+
+  // get_dir() returns 0 (not an array) when valid_read denies the path;
+  // an existing, readable directory returns ({}) when it is merely empty.
+  mixed *entries = get_dir(target, -1);
+
+  if(!pointerp(entries))
+    return _error(this_body(), "ls: %s: Permission denied.", target);
+
+  mapping *resolved = map(entries, (: resolve_entry($(df[0]), $1) :));
+  mapping *sorted = sort_array(resolved, (: sort_listing :));
+  mapping *decorated = map(sorted, (: decorate_entry :));
+  string  *formatted = format_ls(decorated, flags);
+
+  string *out = ({ df[0] }) + formatted;
+
+  return out;
+}
+
+private mapping resolve_entry(string dir, mixed *entry) {
+  string path = `${dir}${entry[GD_FILE_NAME]}`;
+
+  if(entry[GD_FILE_SIZE] == -2) {
+    return as_directory(path);
+  } else {
+    return as_file(path);
+  }
+}
+
+private nosave mapping __defaults = ([
+  "directory":  "5087b4",
+  "source":     "b0cabf",
+  "loaded":     "04e5ad",
+  "header":     "a2c5b2",
+  "save":       "c5baa5",
+  "data":       "9e93d4",
+  "other":      "bbb",
+]);
+
+private string get_object_colour(string kind) {
+  string colour = this_body()->query_pref(`ls_${kind ?? "other"}`);
+
+  colour ??= __defaults[kind ?? "other"];
+
+  return `{{${colour}}}`;
+}
+
+private mapping decorate_entry(mapping entry) {
+  mapping work = copy(entry);
+
+  if(work.directory) {
+    work["decoration"] = `${get_object_colour("directory")} `;
+  } else {
+    if(work.ext == "lpc" || work.ext == "c") {
+      if(work.loaded)
+        work["decoration"] = `${get_object_colour("loaded")}*`;
+      else
+        work["decoration"] = `${get_object_colour("source")} `;
+    } else if(work.ext == "lpml" || work.ext == "json5" || work.ext == "json") {
+      work["decoration"] = `${get_object_colour("data")} `;
+    } else if(work.ext == "h") {
+      work["decoration"] = `${get_object_colour("header")} `;
+    } else if(work.ext == chop(__SAVE_EXTENSION__, ".", 1)) {
+      work["decoration"] = `${get_object_colour("save")} `;
+    } else {
+      work["decoration"] = `${get_object_colour("other")} `;
+    }
+  }
+
+  return work;
+}
+
+private string *format_ls_short(mapping *entries, string *flags);
+private string *format_ls_long(mapping *entries, string *flags);
+
+private string *format_ls(mapping *entries, string *flags) {
+  if(includes(flags, "l"))
+    return format_ls_long(entries, flags);
+
+  return format_ls_short(entries, flags);
+}
+
+private string *format_ls_short(mapping *entries, string *_flags) {
+  int items = sizeof(entries);
+
+  if(!items)
+    return ({});
+
+  int longest = max(map(entries, (: strlen($1.name) :)));
+  int cell = longest + 2;                    // glyph + name + 1-space gap
+  int columns = max(({ 1, 80 / cell }));
+  int rows = (items + columns - 1) / columns;
+  string *result = ({});
+
+  for(int r = 0; r < rows; r++) {
+    string line = "";
+    int last_col = (items - 1 - r) / rows;   // last populated column this row
+
+    for(int c = 0; c < columns; c++) {
+      int idx = c * rows + r;
+
+      if(idx >= items)
+        break;
+
+      // Don't pad the final cell of a row; avoids trailing whitespace.
+      if(c == last_col)
+        line += sprintf(
+          "%s%s{{res}}",
+          entries[idx].decoration,
+          entries[idx].name
+        );
+      else
+        line += sprintf(
+          "%s%-*s{{res}}",
+          entries[idx].decoration,
+          cell - 1,
+          entries[idx].name
+        );
+    }
+
+    result += ({ line });
+  }
+
+  return result;
+}
+
+private nosave int DATE_THRESHOLD = 15_552_000;
+
+private string *format_ls_long(mapping *entries, string *_flags) {
+  int now = time();
+  int past = now - DATE_THRESHOLD;
+
+  string *result = map(
+    entries,
+    function(mapping entry, int now, int past) {
+      string date;
+
+      if(entry.modified < past || entry.modified > now) {
+        date = strftime("%_2d %b %_5Y", entry.modified);
+      } else {
+        date = strftime("%_2d %b %5R", entry.modified);
+      }
+
+      if(entry.directory) {
+        return sprintf(
+          "%5s %-12s %s%s{{res}}",
+          " ",
+          date,
+          entry.decoration,
+          entry.name
+        );
+      } else {
+        string size;
+
+        if(entry.size < 1_000) {
+          size = sprintf("%d", entry.size);
+        } else if(entry.size < 100_000) {
+          size = sprintf("%.1fk", entry.size / 1_000.0);
+        } else if(entry.size < 1_000_000) {
+          size = sprintf("%dk", entry.size / 1_000);
+        } else if(entry.size < 100_000_000) {
+          size = sprintf("%.1fM", entry.size / 1_000_000.0);
+        } else {
+          size = sprintf("%dM", entry.size / 1_000_000);
+        }
+
+        return sprintf(
+          "%5s %-12s %s%s{{res}}",
+          size,
+          date,
+          entry.decoration,
+          entry.name
+        );
+      }
+    }, now, past
+  );
+
+  return result;
+}
+
+private int sort_listing(mapping a, mapping b) {
+  return strcmp(lower_case(a.name), lower_case(b.name));
+}

--- a/cmds/file/mkdir.lpc
+++ b/cmds/file/mkdir.lpc
@@ -34,8 +34,7 @@ mixed main(/** @type {STD_PLAYER} */ object caller,
     return _error(caller, "%s already a file.", str);
 
   if(directory_exists(str))
-    return _error(caller,
-      "%s already a directory.", str);
+    return _error(caller, "%s already a directory.", str);
 
   if(!master()->valid_write(str, caller, "mkdir"))
     return _error(caller, "Permission denied.");
@@ -46,6 +45,5 @@ mixed main(/** @type {STD_PLAYER} */ object caller,
     return _ok(caller,
       "Directory created: %s", str);
   else
-    return _error(caller,
-      "Could not create directory: %s", str);
+    return _error(caller, "Could not create directory: %s", str);
 }

--- a/include/get_dir.h
+++ b/include/get_dir.h
@@ -1,0 +1,8 @@
+#ifndef __GET_DIR_H__
+#define __GET_DIR_H__
+
+#define GD_FILE_NAME      0
+#define GD_FILE_SIZE      1
+#define GD_FILE_MODIFIED  2
+
+#endif // __GET_DIR_H__

--- a/std/cmd/cmd.lpc
+++ b/std/cmd/cmd.lpc
@@ -116,7 +116,6 @@ string resolve_dir(object tp, string arg) {
   /** @type {STD_ITEM} */ object ob = get_object(arg);
   string dir;
 
-
   if(ob) {
     string *parts;
     string file;


### PR DESCRIPTION
Adds a new `ls` command for listing files and directories with short (columnar) and long (`-l`) display modes. Entries are colour-coded by type (directory, loaded source, unloaded source, data, header, save, other), with colours overridable via player preferences. The long format shows human-readable file sizes and dates, using a recent-vs-old threshold to switch between time-of-day and year display.

To support the command, `as_file` and `as_directory` in the file simul_efun now include modification timestamps, and `as_file` also exposes size, load status, and creation time. A new `get_dir.h` header defines the `GD_FILE_*` index constants used when calling `get_dir()`.

The `/adm/*` access rule is relaxed so developers can read top-level `adm` entries (previously admin-only), while write access remains restricted to admins.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds file listing support and exposes file metadata for command output. The main changes are:

- Adds `ls` with short and long listing formats.
- Adds `get_dir()` entry index constants.
- Adds file size, timestamps, and load-state metadata.
- Expands developer read access under `/adm` while retaining admin-only writes.
</details>

<sub>Reviews (2): Last reviewed commit: ["new ls command"](https://github.com/gesslar/oxidus-mudlib/commit/693291807de516a29b29b4a613869e07b40e6043) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44663364)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->