### PR TITLE
Refactor file commands: update `cwf` env on `cp`, `mv`, `tail`; reformat code in `mkdir`, `rmdir`, `passwd`

### DIFF
--- a/cmds/file/cp.lpc
+++ b/cmds/file/cp.lpc
@@ -26,30 +26,26 @@ void setup() {
     "destination.";
 }
 
-mixed main(/** @type {STD_PLAYER} */ object caller,
-    string str) {
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
   string original, destination;
 
-  if(!str
-  || sscanf(str, "%s %s", original, destination) != 2)
+  if(!str || sscanf(str, "%s %s", original, destination) != 2)
     return _usage(caller);
 
-  original = resolve_path(
-    caller->query_env("cwd"), original);
-  destination = resolve_path(
-    caller->query_env("cwd"), destination);
+  original = resolve_path(caller->query_env("cwd"), original);
+  destination = resolve_path(caller->query_env("cwd"), destination);
 
   if(!file_exists(original))
-    return _error(caller,
-      "No such file: %s", original);
+    return _error(caller, "No such file: %s", original);
 
-  if(directory_exists(destination)
-  || destination[<1] == '/') {
-    int pos;
-
+  if(directory_exists(destination) || destination[<1] == '/') {
     destination = append(destination, "/");
 
-    pos = strsrch(original, "/", -1);
+    int pos = strsrch(original, "/", -1);
+
     if(pos != -1)
       destination += original[(pos + 1)..];
     else
@@ -57,19 +53,17 @@ mixed main(/** @type {STD_PLAYER} */ object caller,
   }
 
   if(original == destination)
-    return _error(caller,
-      "Original and destination are the same.");
+    return _error(caller, "Original and destination are the same.");
 
-  if(!master()->valid_write(
-      destination, this_object(), "cp"))
+  if(!master()->valid_write(destination, this_object(), "cp"))
     return _error(caller, "Permission denied.");
 
-  cp(original, destination) < 0
-    ? _error(caller,
-        "Unable to copy %s to %s.",
-        original, destination)
-    : _ok(caller, "%s copied to %s",
-        original, destination);
+  int result = cp(original, destination);
 
-  return 1;
+  if(result < 0) {
+    return _error(caller, "Unable to copy %s to %s.", original, destination);
+  } else {
+    caller->set_env("cwf", destination);
+    return _ok(caller, "%s copied to %s", original, destination);
+  }
 }

--- a/cmds/file/mkdir.lpc
+++ b/cmds/file/mkdir.lpc
@@ -21,8 +21,10 @@ void setup() {
     "be created in the current working directory.";
 }
 
-mixed main(/** @type {STD_PLAYER} */ object caller,
-    string str) {
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
   int result;
 
   if(!str)
@@ -42,8 +44,7 @@ mixed main(/** @type {STD_PLAYER} */ object caller,
   result = mkdir(str);
 
   if(result)
-    return _ok(caller,
-      "Directory created: %s", str);
+    return _ok(caller, "Directory created: %s", str);
   else
     return _error(caller, "Could not create directory: %s", str);
 }

--- a/cmds/file/mv.lpc
+++ b/cmds/file/mv.lpc
@@ -28,17 +28,21 @@ void setup() {
     "* If the destination is a file, an error will be returned.";
 }
 
-mixed main(/** @type {STD_PLAYER} */ object caller, string str) {
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
   string origin, dest;
 
   if(!str || !sscanf(str, "%s %s", origin, dest))
     return _usage(caller);
 
-  origin = resolve_path(caller->query_env("cwd"), origin);
-  dest = resolve_path(caller->query_env("cwd"), dest);
+  string cwd = caller->query_env("cwd");
+  origin = resolve_path(cwd, origin);
+  dest = resolve_path(cwd, dest);
 
-  if(!master()->valid_write(origin, caller, "mv")
-      || !master()->valid_write(dest, caller, "mv")
+  if(   !master()->valid_write(origin, caller, "mv")
+     || !master()->valid_write(dest, caller, "mv")
     ) {
     return _error(caller, "Permission denied.");
   }
@@ -55,6 +59,9 @@ mixed main(/** @type {STD_PLAYER} */ object caller, string str) {
 
   if(stringp(e))
     return _error("Error moving: %s", e);
+
+  if(file_exists(dest))
+    caller->set_env("cwf", dest);
 
   return _ok(caller, "Moved %s to %s", origin, dest);
 }

--- a/cmds/file/rmdir.lpc
+++ b/cmds/file/rmdir.lpc
@@ -21,27 +21,29 @@ void setup() {
     "wish to remove must be empty before it can be deleted).";
 }
 
-mixed main(/** @type {STD_PLAYER} */ object caller,
-    string str) {
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+    string str
+  ) {
+
   if(!str)
     return _usage(caller);
 
-  str = resolve_path(caller->query_env("cwd"), str);
+  string cwd = caller->query_env("cwd");
+  string path = resolve_path(cwd, str);
 
-  if(!directory_exists(str) || file_exists(str))
-    return _error(caller,
-      "%s is not a directory.", str);
+  if(!directory_exists(path) || file_exists(path))
+    return _error(caller, "%s is not a directory.", path);
 
-  if(sizeof(get_dir(str + "/")))
-    return _error(caller, "%s is not empty.", str);
+  if(sizeof(get_dir(path + "/")))
+    return _error(caller, "%s is not empty.", path);
 
-  if(!master()->valid_write(str, caller, "rmdir"))
+  if(!master()->valid_write(path, caller, "rmdir"))
     return _error(caller, "Permission denied.");
 
-  rmdir(str)
-    ? _ok(caller, "Directory removed: %s", str)
-    : _error(caller,
-        "Could not remove directory: %s", str);
-
-  return 1;
+  int result = rmdir(path);
+  if(result)
+    return _ok(caller, "Directory removed: %s", path);
+  else
+    return _error(caller, "Could not remove directory: %s", path);
 }

--- a/cmds/file/tail.lpc
+++ b/cmds/file/tail.lpc
@@ -19,21 +19,22 @@ void setup() {
     "This command prints the last 20 lines of a specified file.";
 }
 
-mixed main(/** @type {STD_PLAYER} */ object caller,
-    string file) {
-  string *out;
-
-  if(!file)
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  if(!str)
     return _usage(caller);
 
-  file = resolve_file(caller, file);
+  string file = resolve_file(caller, str);
 
   if(!file_exists(file))
-    return _error(caller,
-      "File does not exist: %s", file);
+    return _error(caller, "No such file: %s", file);
 
-  out = explode(tail(file, 20), "\n");
+  string *out = explode(tail(file, 20), "\n");
   out = ({ "=== " + file + " ===" }) + out;
+
+  caller->set_env("cwf", file);
 
   return out;
 }

--- a/cmds/std/passwd.lpc
+++ b/cmds/std/passwd.lpc
@@ -54,6 +54,12 @@ private void new_password(string str, object tp) {
     input_to((:confirm_password:), I_NOECHO | I_NOESC, str, tp);
 }
 
+/**
+ *
+ * @param str
+ * @param pass
+ * @param {STD_PLAYER} tp
+ */
 private void confirm_password(string str, string pass, object tp) {
     if(str == pass) {
         _ok("Password accepted.");


### PR DESCRIPTION
After a successful `cp`, `mv`, or `tail` operation, the caller's `cwf` environment variable is now updated to reflect the destination or target file path, keeping the current working file in sync with recent file operations.

The `rmdir` command now correctly returns the result of `_ok` or `_error` rather than discarding the return value and always returning `1`. Similarly, `cp` now captures the result of the copy operation into a variable before branching, making the success and error paths explicit return statements.

A JSDoc annotation was added to `confirm_password` in the `passwd` command to document its parameters.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR keeps the current working file in sync with file commands. The main changes are:

- Update `cwf` after successful `cp`, `mv`, and `tail` commands.
- Return command helper results directly from `cp` and `rmdir`.
- Reformat `mkdir` and document `confirm_password` parameters.
</details>

<sub>Reviews (2): Last reviewed commit: ["some cleaning up"](https://github.com/gesslar/oxidus-mudlib/commit/3cd85843197abb9954b2801161f2c6403cac4416) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44690109)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->