### PR TITLE
Update `@file` doc tags from `.c` to `.lpc` across all files

### DIFF
--- a/adm/daemons/action.lpc
+++ b/adm/daemons/action.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/action.c
+ * @file /adm/daemons/action.lpc
  *
  * A message composition and delivery system for handling in-game
  * actions and their resulting messages. This daemon manages how

--- a/adm/daemons/advance.lpc
+++ b/adm/daemons/advance.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/advance.c
+ * @file /adm/daemons/advance.lpc
  * Daemon to handle XP and leveling
  *
  * @created 2024-07-28 - Gesslar

--- a/adm/daemons/alarm.lpc
+++ b/adm/daemons/alarm.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/alarm.c
+ * @file /adm/daemons/alarm.lpc
  *
  * Alarm daemon. Schedules and executes recurring or one-shot events
  * defined in the configured alarms directory (see the ALARMS_PATH

--- a/adm/daemons/alias.lpc
+++ b/adm/daemons/alias.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/alias.c
+ * @file /adm/daemons/alias.lpc
  *
  * The alias daemon. Loads alias definitions from ETC_ALIASES, grouped
  * by security group, and resolves any alias at the head of a player's

--- a/adm/daemons/bank.lpc
+++ b/adm/daemons/bank.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/bank.c
+ * @file /adm/daemons/bank.lpc
  *
  * Bank daemon responsible for managing player bank accounts,  including
  * creation, balance queries, deposits/withdrawals, wiping, removal, and

--- a/adm/daemons/body.lpc
+++ b/adm/daemons/body.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/body.c
+ * @file /adm/daemons/body.lpc
  * Handles body instantiation
  *
  * @created 2024-07-28 - Gesslar

--- a/adm/daemons/boot.lpc
+++ b/adm/daemons/boot.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/boot.c
+ * @file /adm/daemons/boot.lpc
  * Daemon to manage incrementing boot number and calling the
  * boot alarm.
  *

--- a/adm/daemons/cache.lpc
+++ b/adm/daemons/cache.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/cache.c
+ * @file /adm/daemons/cache.lpc
  *
  * A daemon that reads files and caches the result for later consumption.
  * Cached records are keyed by resolved path and invalidated automatically

--- a/adm/daemons/colour.lpc
+++ b/adm/daemons/colour.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/colour.c
+ * @file /adm/daemons/colour.lpc
  *
  * Colour Parser daemon for handling and converting colour codes in text.
  * Provides functionality for colour code substitution, text wrapping, and

--- a/adm/daemons/config.lpc
+++ b/adm/daemons/config.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/config.c
+ * @file /adm/daemons/config.lpc
  *
  * Configuration management daemon that provides a centralized system for
  * game settings. Uses a cascading configuration pattern where default values

--- a/adm/daemons/coord.lpc
+++ b/adm/daemons/coord.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/coord.c
+ * @file /adm/daemons/coord.lpc
  *
  * Coordinate daemon to hold room data
  *

--- a/adm/daemons/crawler.lpc
+++ b/adm/daemons/crawler.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/crawler.c
+ * @file /adm/daemons/crawler.lpc
  *
  * Crawls the game world room by room, deriving a coordinate grid for every
  * reachable room and handing the result to COORD_D. The crawl is kicked off

--- a/adm/daemons/currency.lpc
+++ b/adm/daemons/currency.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/currency.c
+ * @file /adm/daemons/currency.lpc
  *
  * Currency daemon. Loads the configured currency denominations and
  * their relative values, exposes ordered lookups, and converts amounts

--- a/adm/daemons/db.lpc
+++ b/adm/daemons/db.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/db.c
+ * @file /adm/daemons/db.lpc
  *
  * Database daemon providing SQLite3 database management and query
  * execution. Handles database creation, table management, and

--- a/adm/daemons/death.lpc
+++ b/adm/daemons/death.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/death.c
+ * @file /adm/daemons/death.lpc
  *
  * Handles death and revival event logging. Listens for player
  * death and revival signals and records them to the death log.

--- a/adm/daemons/discord/chatter.lpc
+++ b/adm/daemons/discord/chatter.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/chatter.c
+ * @file /adm/daemons/modules/chatter.lpc
  * Chatter Discord Bot Example
  *
  * @created 2024-07-08 - Gesslar

--- a/adm/daemons/github_issues.lpc
+++ b/adm/daemons/github_issues.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/github_issues.c
+ * @file /adm/daemons/github_issues.lpc
  *
  * Daemon to handle GitHub issues. Uses the GitHub Issues API to
  * create issues in the mud's GitHub repository.

--- a/adm/daemons/gmcp.lpc
+++ b/adm/daemons/gmcp.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/gmcp.c
+ * @file /adm/daemons/gmcp.lpc
  *
  * GMCP (Generic Mud Communication Protocol) daemon responsible for handling
  * all GMCP-related communications between the MUD and clients.

--- a/adm/daemons/grapevine.lpc
+++ b/adm/daemons/grapevine.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/grapevine.c
+ * @file /adm/daemons/grapevine.lpc
  * Grapevine WebSockets client
  *
  * @created 2024-07-17 - Gesslar

--- a/adm/daemons/help.lpc
+++ b/adm/daemons/help.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/help.c
+ * @file /adm/daemons/help.lpc
  *
  * Help! Daemon!
  *

--- a/adm/daemons/httpc.lpc
+++ b/adm/daemons/httpc.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/httpc.c
+ * @file /adm/daemons/httpc.lpc
  * HTTP client daemon to fetch data from the web
  * and return it to the caller via callback
  *

--- a/adm/daemons/lines.lpc
+++ b/adm/daemons/lines.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/lines.c
+ * @file /adm/daemons/lines.lpc
  *
  * Daemon that handles line-drawing character substitution. Maps
  * Unicode box-drawing characters to ASCII or screenreader

--- a/adm/daemons/loot.lpc
+++ b/adm/daemons/loot.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/loot.c
+ * @file /adm/daemons/loot.lpc
  *
  * Daemon responsible for handling the loot system, including item
  * drops, coin drops, and automatic valuation.

--- a/adm/daemons/message.lpc
+++ b/adm/daemons/message.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/message.c
+ * @file /adm/daemons/message.lpc
  * Message routines and functions
  *
  * @created 2024-07-28 - Gesslar

--- a/adm/daemons/modules/gmcp/Char.lpc
+++ b/adm/daemons/modules/gmcp/Char.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/gmcp/Char.c
+ * @file /adm/daemons/modules/gmcp/Char.lpc
  *
  * GMCP module to handle Char.* packages.
  *

--- a/adm/daemons/modules/gmcp/Client.lpc
+++ b/adm/daemons/modules/gmcp/Client.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/gmcp/Client.c
+ * @file /adm/daemons/modules/gmcp/Client.lpc
  *
  * GMCP module to handle Client.* packages. Forwards client-side
  * GUI installation directives to the player.

--- a/adm/daemons/modules/gmcp/Comm.lpc
+++ b/adm/daemons/modules/gmcp/Comm.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/gmcp/Comm.c
+ * @file /adm/daemons/modules/gmcp/Comm.lpc
  *
  * GMCP module to handle Comm.* packages.
  *

--- a/adm/daemons/modules/gmcp/Core.lpc
+++ b/adm/daemons/modules/gmcp/Core.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/gmcp/Core.c
+ * @file /adm/daemons/modules/gmcp/Core.lpc
  *
  * GMCP module to handle Core.* packages.
  *

--- a/adm/daemons/modules/gmcp/Room.lpc
+++ b/adm/daemons/modules/gmcp/Room.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/gmcp/Room.c
+ * @file /adm/daemons/modules/gmcp/Room.lpc
  *
  * GMCP module to handle Room.* packages. Sends room descriptions
  * and travel breadcrumbs to the player's client.

--- a/adm/daemons/modules/message/combat.lpc
+++ b/adm/daemons/modules/message/combat.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/message/combat.c
+ * @file /adm/daemons/modules/message/combat.lpc
  * Combat messaging module for the message daemon
  *
  * @created 2024-07-28 - Gesslar

--- a/adm/daemons/modules/virtual/admin.lpc
+++ b/adm/daemons/modules/virtual/admin.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/virtual/admin.c
+ * @file /adm/daemons/modules/virtual/admin.lpc
  * The virtual daemon that is responsible for creating player
  * objects.
  *

--- a/adm/daemons/modules/virtual/dev.lpc
+++ b/adm/daemons/modules/virtual/dev.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/virtual/dev.c
+ * @file /adm/daemons/modules/virtual/dev.lpc
  * The virtual daemon that is responsible for creating player
  * objects.
  *

--- a/adm/daemons/modules/virtual/ghost.lpc
+++ b/adm/daemons/modules/virtual/ghost.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/virtual/ghost.c
+ * @file /adm/daemons/modules/virtual/ghost.lpc
  * The virtual daemon that is responsible for creating player
  * objects.
  *

--- a/adm/daemons/modules/virtual/ob.lpc
+++ b/adm/daemons/modules/virtual/ob.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/virtual/ob.c
+ * @file /adm/daemons/modules/virtual/ob.lpc
  * Base module for virtual objects
  *
  * @created 2024-08-22 - Gesslar

--- a/adm/daemons/modules/virtual/storage.lpc
+++ b/adm/daemons/modules/virtual/storage.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/modules/virtual/storage.c
+ * @file /adm/daemons/modules/virtual/storage.lpc
  * This virtual daemon is responsible for creating virtual
  * storage objects. If the path passed is /storage/public/...
  * then the object created will be a shared storage object.

--- a/adm/daemons/movement.lpc
+++ b/adm/daemons/movement.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/movement.c
+ * @file /adm/daemons/movement.lpc
  *
  * Daemon that provides movement checks, etc.
  *

--- a/adm/daemons/mssp.lpc
+++ b/adm/daemons/mssp.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/mssp.c
+ * @file /adm/daemons/mssp.lpc
  *
  * MSSP (Mud Server Status Protocol) daemon. Called by the master object to
  * respond to the get_mud_stats() apply. Dynamic and driver hard-coded values

--- a/adm/daemons/persist.lpc
+++ b/adm/daemons/persist.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/persist.c
+ * @file /adm/daemons/persist.lpc
  *
  * Persist daemon that periodically saves all registered persistent
  * objects. Discovers persistent objects at startup and responds to

--- a/adm/daemons/resource.lpc
+++ b/adm/daemons/resource.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/resource.c
+ * @file /adm/daemons/resource.lpc
  *
  * Resource daemon for daemoning resources.
  *

--- a/adm/daemons/signal.lpc
+++ b/adm/daemons/signal.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/signal.c
+ * @file /adm/daemons/signal.lpc
  *
  * Signal daemon that provides a system-wide event notification system.
  * Manages registration, dispatch, and cleanup of signal handlers (slots).

--- a/adm/daemons/swap.lpc
+++ b/adm/daemons/swap.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/swap.c
+ * @file /adm/daemons/swap.lpc
  *
  * Temporary storage daemon that provides a safe way to persist data across
  * object destruction and recreation. Acts as a holding space for data that

--- a/adm/daemons/time.lpc
+++ b/adm/daemons/time.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/time.c
+ * @file /adm/daemons/time.lpc
  * This is the game's time daemon. It is responsible for keeping
  * track of the game's time and date. It also provides functions for converting
  * the game's time to real time and vice versa.

--- a/adm/daemons/virtual.lpc
+++ b/adm/daemons/virtual.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/virtual.c
+ * @file /adm/daemons/virtual.lpc
  * Daemon for virtual objects
  *
  * @created 2024-02-04 - Gesslar

--- a/adm/daemons/vnum.lpc
+++ b/adm/daemons/vnum.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/vnum.c
+ * @file /adm/daemons/vnum.lpc
  * Daemon to store room vnums
  *
  * @created 2024-08-18 - Gesslar

--- a/adm/daemons/websocket_echo.lpc
+++ b/adm/daemons/websocket_echo.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/daemons/websocket_echo.c
+ * @file /adm/daemons/websocket_echo.lpc
  * Test websocket with echo.websocket.org
  *
  * @created 2024-07-05 - Gesslar

--- a/adm/obj/login.lpc
+++ b/adm/obj/login.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/obj/login.c
+ * @file /adm/obj/login.lpc
  *
  * Login object cloned for each new connection. Handles account
  * authentication, character selection, character creation, and

--- a/adm/obj/master/security.lpc
+++ b/adm/obj/master/security.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/obj/master/security.c
+ * @file /adm/obj/master/security.lpc
  *
  * Security subsystem inherited by the master object. Implements the
  * role/group model and (eventually) the driver validation applies.

--- a/adm/simul_efun/base64.lpc
+++ b/adm/simul_efun/base64.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/simul_efun/base64.c
+ * @file /adm/simul_efun/base64.lpc
  *
  * Simul-efun implementation of Base64 encoding and decoding functions.
  * Provides functionality to encode strings/buffers to Base64 and decode

--- a/adm/simul_efun/data.lpc
+++ b/adm/simul_efun/data.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/simul_efun/data.c
+ * @file /adm/simul_efun/data.lpc
  *
  * Simple key-value data storage system for file-based persistence.
  * Provides functions for reading, writing, and manipulating data

--- a/adm/simul_efun/description.lpc
+++ b/adm/simul_efun/description.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/simul_efun/description.c
+ * @file /adm/simul_efun/description.lpc
  *
  * Simul-efun implementation of object description handling functions.
  * Provides standardized methods for retrieving and formatting object

--- a/adm/simul_efun/directory.lpc
+++ b/adm/simul_efun/directory.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/simul_efun/directory.c
+ * @file /adm/simul_efun/directory.lpc
  *
  * Directory manipulation and query simul-efuns. Provides secure methods
  * for creating directory hierarchies and retrieving directory paths.

--- a/adm/simul_efun/english.lpc
+++ b/adm/simul_efun/english.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/simul_efun/english.c
+ * @file /adm/simul_efun/english.lpc
  *
  * English language processing simul-efuns for text manipulation and grammar.
  * Provides functions for capitalization, articles, and pronoun generation

--- a/adm/simul_efun/existence.lpc
+++ b/adm/simul_efun/existence.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/simul_efun/exists.c
+ * @file /adm/simul_efun/exists.lpc
  *
  * Simul-efuns for checking existence of files, directories, and user data.
  * Provides consistent interfaces for validating filesystem resources.

--- a/adm/simul_efun/file.lpc
+++ b/adm/simul_efun/file.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/simul_efun/file.c
+ * @file /adm/simul_efun/file.lpc
  *
  * File manipulation and querying simul-efuns. Provides secure methods for
  * reading, writing, and managing files, including logging and temporary files.

--- a/adm/simul_efun/function.lpc
+++ b/adm/simul_efun/function.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/simul_efun/function.c
+ * @file /adm/simul_efun/function.lpc
  *
  * Advanced function manipulation and callback handling simul-efuns. Provides
  * tools for function validation, callback assembly, call tracing, and delayed

--- a/adm/simul_efun/object.lpc
+++ b/adm/simul_efun/object.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/simul_efun/object.c
+ * @file /adm/simul_efun/object.lpc
  *
  * Object manipulation and querying simul-efuns. Provides utilities for
  * finding, filtering and managing game objects, including specialized

--- a/adm/simul_efun/prompt.lpc
+++ b/adm/simul_efun/prompt.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /adm/simul_efun/prompt.c
+ * @file /adm/simul_efun/prompt.lpc
  *
  * Player input prompts driven by callbacks. Provides interactive,
  * input_to-based flows for collecting passwords (with attempt limits

--- a/cmds/ability/punch.lpc
+++ b/cmds/ability/punch.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ability/punch.c
+ * @file /cmds/ability/punch.lpc
  *
  * Punch command
  *

--- a/cmds/ability/strike.lpc
+++ b/cmds/ability/strike.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ability/strike.c
+ * @file /cmds/ability/strike.lpc
  *
  * Strike command
  *

--- a/cmds/action/close.lpc
+++ b/cmds/action/close.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/close.c
+ * @file /cmds/action/close.lpc
  *
  * Command to close a container or door.
  *

--- a/cmds/action/dispose.lpc
+++ b/cmds/action/dispose.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/dispose.c
+ * @file /cmds/action/dispose.lpc
  *
  * Command to dispose of dead bodies.
  *

--- a/cmds/action/drink.lpc
+++ b/cmds/action/drink.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/drink.c
+ * @file /cmds/action/drink.lpc
  *
  * Drink command.
  *

--- a/cmds/action/duel.lpc
+++ b/cmds/action/duel.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/duel.c
+ * @file /cmds/action/duel.lpc
  *
  * Command to start combat with another living.
  *

--- a/cmds/action/eat.lpc
+++ b/cmds/action/eat.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/eat.c
+ * @file /cmds/action/eat.lpc
  *
  * Eat command.
  *

--- a/cmds/action/eq.lpc
+++ b/cmds/action/eq.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/eq.c
+ * @file /cmds/action/eq.lpc
  *
  * List all your equipped items.
  *

--- a/cmds/action/go.lpc
+++ b/cmds/action/go.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/go.c
+ * @file /cmds/action/go.lpc
  *
  * The go command.
  *

--- a/cmds/action/look.lpc
+++ b/cmds/action/look.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/look.c
+ * @file /cmds/action/look.lpc
  *
  * Command to look at things and the room and stuff.
  *

--- a/cmds/action/nibble.lpc
+++ b/cmds/action/nibble.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/nibble.c
+ * @file /cmds/action/nibble.lpc
  *
  * Nibble command.
  *

--- a/cmds/action/open.lpc
+++ b/cmds/action/open.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/open.c
+ * @file /cmds/action/open.lpc
  *
  * Command to open a container or door.
  *

--- a/cmds/action/put.lpc
+++ b/cmds/action/put.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/put.c
+ * @file /cmds/action/put.lpc
  *
  * Command to put an object into a container.
  *

--- a/cmds/action/remove.lpc
+++ b/cmds/action/remove.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/remove.c
+ * @file /cmds/action/remove.lpc
  *
  * Command to remove worn items.
  *

--- a/cmds/action/say.lpc
+++ b/cmds/action/say.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/say.c
+ * @file /cmds/action/say.lpc
  *
  * A command to say something to the room.
  *

--- a/cmds/action/sip.lpc
+++ b/cmds/action/sip.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/sip.c
+ * @file /cmds/action/sip.lpc
  *
  * Sip command.
  *

--- a/cmds/action/travel.lpc
+++ b/cmds/action/travel.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/travel.c
+ * @file /cmds/action/travel.lpc
  *
  * Command to run to common destinations from your current
  * location. Requires GMCP.

--- a/cmds/action/unwield.lpc
+++ b/cmds/action/unwield.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/unwield.c
+ * @file /cmds/action/unwield.lpc
  *
  * Unwield command.
  *

--- a/cmds/action/use.lpc
+++ b/cmds/action/use.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/use.c
+ * @file /cmds/action/use.lpc
  *
  * General use command for things and stuff.
  *

--- a/cmds/action/wear.lpc
+++ b/cmds/action/wear.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/wear.c
+ * @file /cmds/action/wear.lpc
  *
  * Wear command.
  *

--- a/cmds/action/wield.lpc
+++ b/cmds/action/wield.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/action/wield.c
+ * @file /cmds/action/wield.lpc
  *
  * Wield command.
  *

--- a/cmds/file/cp.lpc
+++ b/cmds/file/cp.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/file/cp.c
+ * @file /cmds/file/cp.lpc
  *
  * Copy command.
  *

--- a/cmds/file/ls.lpc
+++ b/cmds/file/ls.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/file/ls.c
+ * @file /cmds/file/ls.lpc
  *
  * List files and directories
  *

--- a/cmds/file/mkdir.lpc
+++ b/cmds/file/mkdir.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/file/mkdir.c
+ * @file /cmds/file/mkdir.lpc
  *
  * Command to create a directory.
  *

--- a/cmds/file/mv.lpc
+++ b/cmds/file/mv.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/file/mv.c
+ * @file /cmds/file/mv.lpc
  *
  * Move a file or directory.
  *

--- a/cmds/file/rmdir.lpc
+++ b/cmds/file/rmdir.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/file/rmdir.c
+ * @file /cmds/file/rmdir.lpc
  *
  * Command to remove a directory.
  *

--- a/cmds/file/tail.lpc
+++ b/cmds/file/tail.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/file/tail.c
+ * @file /cmds/file/tail.lpc
  *
  * Command to print the last 20 lines of a file.
  *

--- a/cmds/ghost/bug.lpc
+++ b/cmds/ghost/bug.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ghost/bug.c
+ * @file /cmds/ghost/bug.lpc
  * Bug command for reporting bugs.
  *
  * @created 2024-07-07 - Gesslar

--- a/cmds/ghost/date.lpc
+++ b/cmds/ghost/date.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ghost/date.c
+ * @file /cmds/ghost/date.lpc
  * Date command displaying the current mud time.
  *
  * @created 2005-11-10 - Tacitus

--- a/cmds/ghost/go.lpc
+++ b/cmds/ghost/go.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ghost/go.c
+ * @file /cmds/ghost/go.lpc
  * Command for moving around in the game as a ghost.
  *
  * @created 2024-02-03 - Gesslar

--- a/cmds/ghost/help.lpc
+++ b/cmds/ghost/help.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ghost/help.c
+ * @file /cmds/ghost/help.lpc
  * Help command for looking up help files and command help.
  *
  * @created 2005-10-08 - Tacitus

--- a/cmds/ghost/idea.lpc
+++ b/cmds/ghost/idea.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ghost/idea.c
+ * @file /cmds/ghost/idea.lpc
  * Command for reporting ideas.
  *
  * @created 2024-07-13 - Gesslar

--- a/cmds/ghost/look.lpc
+++ b/cmds/ghost/look.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ghost/look.c
+ * @file /cmds/ghost/look.lpc
  * Ghost look command, inherits the standard look command.
  *
  * @created 2024-02-03 - Gesslar

--- a/cmds/ghost/quit.lpc
+++ b/cmds/ghost/quit.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ghost/quit.c
+ * @file /cmds/ghost/quit.lpc
  * Quit command for ghosts to disconnect from the mud.
  *
  * @created 2005-04-06 - Tacitus

--- a/cmds/ghost/uptime.lpc
+++ b/cmds/ghost/uptime.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ghost/uptime.c
+ * @file /cmds/ghost/uptime.lpc
  * Uptime command displaying how long the mud has been running.
  *
  * @created 2005-04-08 - Tacitus

--- a/cmds/ghost/version.lpc
+++ b/cmds/ghost/version.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ghost/version.c
+ * @file /cmds/ghost/version.lpc
  * Version command displaying mudlib and driver information.
  *
  * @created 2006-05-05 - Tacitus

--- a/cmds/ghost/who.lpc
+++ b/cmds/ghost/who.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/ghost/who.c
+ * @file /cmds/ghost/who.lpc
  * Who command displaying currently connected users.
  *
  * @created 2005-04-08 - Tacitus

--- a/cmds/object/update.lpc
+++ b/cmds/object/update.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/object/update.c
+ * @file /cmds/object/update.lpc
  *
  * A command to update objects! Neat, huh?
  *

--- a/cmds/spell/embers.lpc
+++ b/cmds/spell/embers.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/spell/embers.c
+ * @file /cmds/spell/embers.lpc
  *
  * Embers spell.
  *

--- a/cmds/spell/motes.lpc
+++ b/cmds/spell/motes.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/spell/motes.c
+ * @file /cmds/spell/motes.lpc
  * Motes spell.
  *
  * @created 2024-08-09 - Gesslar

--- a/cmds/spell/shard.lpc
+++ b/cmds/spell/shard.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/spell/shard.c
+ * @file /cmds/spell/shard.lpc
  *
  * Shard spell.
  *

--- a/cmds/spell/shock.lpc
+++ b/cmds/spell/shock.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/spell/shock.c
+ * @file /cmds/spell/shock.lpc
  *
  * Shock spell.
  *

--- a/cmds/spell/wither.lpc
+++ b/cmds/spell/wither.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/spell/wither.c
+ * @file /cmds/spell/wither.lpc
  *
  * Wither spell.
  *


### PR DESCRIPTION
Correct `@file` tags in doc comments to use `.lpc` extension instead of `.c` across all daemons, simul-efuns, commands, and modules.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects `@file` documentation paths across LPC source files.

- Replaces `.c` suffixes with `.lpc` in file headers.
- Updates daemon, simul-efun, command, and module annotations.
- Corrects affected documentation paths without changing executable code.
</details>

<sub>Reviews (3): Last reviewed commit: ["updated"](https://github.com/gesslar/oxidus-mudlib/commit/2e5479e8e0c19e508b4b0a2782f68d228eb8be9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44690111)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->