### PR TITLE
Update `@file` doc comments from `.c` to `.lpc` extension across all files

### DIFF
--- a/cmds/std/con.lpc
+++ b/cmds/std/con.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/std/con.c
+ * @file /cmds/std/con.lpc
  *
  * Check the condition of a living, including yourself.
  *

--- a/cmds/std/detail.lpc
+++ b/cmds/std/detail.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/std/detail.c
+ * @file /cmds/std/detail.lpc
  *
  * This command is used for detailing your description and other
  * features of your character.

--- a/cmds/std/set.lpc
+++ b/cmds/std/set.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/std/set.c
+ * @file /cmds/std/set.lpc
  *
  * Command to manage preferences in a player object.
  *

--- a/cmds/std/skills.lpc
+++ b/cmds/std/skills.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/std/skills.c
+ * @file /cmds/std/skills.lpc
  *
  * Command for players to check their skill progress.
  *

--- a/cmds/std/waypoint.lpc
+++ b/cmds/std/waypoint.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/std/waypoint.c
+ * @file /cmds/std/waypoint.lpc
  *
  * Command for managing waypoints.
  *

--- a/cmds/wiz/exits.lpc
+++ b/cmds/wiz/exits.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/exits.c
+ * @file /cmds/wiz/exits.lpc
  * Shows all the exits in the current room and where they lead.
  *
  * @created 2024-02-04 - Gesslar

--- a/cmds/wiz/killme.lpc
+++ b/cmds/wiz/killme.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/killme.c
+ * @file /cmds/wiz/killme.lpc
  * This command commands all NPCs in a room to attack you. It
  * does not change their current target if they are already
  * attacking someone else.

--- a/cmds/wiz/summon.lpc
+++ b/cmds/wiz/summon.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/summon.c
+ * @file /cmds/wiz/summon.lpc
  * Command to summon a player to your location.
  *
  * @created 2024-08-17 - Gesslar

--- a/cmds/wiz/touch.lpc
+++ b/cmds/wiz/touch.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/touch.c
+ * @file /cmds/wiz/touch.lpc
  * This command allows a wizard to create a new empty file.
  *
  * @created 2024-08-10 - Gesslar

--- a/d/cavern/cavern_base.lpc
+++ b/d/cavern/cavern_base.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/cavern/cavern_base.c
+ * @file /d/cavern/cavern_base.lpc
  * The base room for the caverns
  *
  * @created 2024-09-18 - Gesslar

--- a/d/cavern/cavern_daemon.lpc
+++ b/d/cavern/cavern_daemon.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/cavern/cavern_daemon.c
+ * @file /d/cavern/cavern_daemon.lpc
  *
  * Cavern zone daemon. Procedurally generates a multi-layer cavern
  * map using a drunkard's-walk carver over a wall-filled grid, links

--- a/d/cavern/controller.lpc
+++ b/d/cavern/controller.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/cavern/controller.c
+ * @file /d/cavern/controller.lpc
  *
  * Virtual controller for the caverns
  *

--- a/d/cavern/winding_caverns.lpc
+++ b/d/cavern/winding_caverns.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/cavern/winding_caverns.c
+ * @file /d/cavern/winding_caverns.lpc
  * Zone for the winding caverns
  *
  * @created 2024-09-18 - Gesslar

--- a/d/forest/controller.lpc
+++ b/d/forest/controller.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/forest/controller.c
+ * @file /d/forest/controller.lpc
  *
  * Virtual controller  The zone object for the forest.
  *

--- a/d/forest/forest_base.lpc
+++ b/d/forest/forest_base.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/forest/forest_base.c
+ * @file /d/village/forest/forest_base.lpc
  * The main forest room.
  *
  * @created 2024-08-21 - Gesslar

--- a/d/forest/forest_daemon.lpc
+++ b/d/forest/forest_daemon.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/forest/forest_daemon.c
+ * @file /d/forest/forest_daemon.lpc
  *
  * Virtual-map daemon for the forest area. Loads the forest map file
  * and supplies short descriptions, long descriptions, and exits for

--- a/d/forest/shadowy_forest.lpc
+++ b/d/forest/shadowy_forest.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/forest/shadowy_forest.c
+ * @file /d/village/forest/shadowy_forest.lpc
  * Zone object for the Shadowy Forest.
  *
  * @created 2024-09-02 - Gesslar

--- a/d/maze/controller.lpc
+++ b/d/maze/controller.lpc
@@ -1,6 +1,6 @@
 /**
  *
- * @file /d/maze/controller.c
+ * @file /d/maze/controller.lpc
  *
  * Virtual controller for the maze
  *

--- a/d/maze/maze_base.lpc
+++ b/d/maze/maze_base.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/maze/maze_base.c
+ * @file /d/maze/maze_base.lpc
  * The maze base room.
  *
  * @created 2024-09-04 - Gesslar

--- a/d/maze/maze_daemon.lpc
+++ b/d/maze/maze_daemon.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/maze/maze_daemon.c
+ * @file /d/maze/maze_daemon.lpc
  *
  * Virtual map daemon for the maze area. Procedurally generates a
  * three-dimensional maze using a depth-first search algorithm, then

--- a/d/maze/twisty_maze.lpc
+++ b/d/maze/twisty_maze.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/wastes/wastes.c
+ * @file /d/wastes/wastes.lpc
  * Zone object for the wastes
  *
  * @created 2024-09-02 - Gesslar

--- a/d/std/freezer.lpc
+++ b/d/std/freezer.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/std/freezer.c
+ * @file /d/std/freezer.lpc
  * Room where bodies can hang out while not inhabited.
  *
  * @created 2024-08-11 - Gesslar

--- a/d/thornwick/bramble_thicket.lpc
+++ b/d/thornwick/bramble_thicket.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/bramble_thicket.c
+ * @file /d/thornwick/bramble_thicket.lpc
  * The heart of the blight, north of the green. The hamlet's tough beast.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/thornwick/chapel.lpc
+++ b/d/thornwick/chapel.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/chapel.c
+ * @file /d/thornwick/chapel.lpc
  * The Chapel of Saint Brae, the one kept place in a dead hamlet.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/thornwick/chapel_yard.lpc
+++ b/d/thornwick/chapel_yard.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/chapel_yard.c
+ * @file /d/thornwick/chapel_yard.lpc
  * The overgrown churchyard, east of the green. Crows haunt the stones.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/thornwick/controller.lpc
+++ b/d/thornwick/controller.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/controller.c
+ * @file /d/thornwick/controller.lpc
  * Virtual server for the Thornwick zone.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/thornwick/hollow_road1.lpc
+++ b/d/thornwick/hollow_road1.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/hollow_road1.c
+ * @file /d/thornwick/hollow_road1.lpc
  * The foot of the Hollow Road, where Olum's tended verges give out.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/thornwick/hollow_road2.lpc
+++ b/d/thornwick/hollow_road2.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/hollow_road2.c
+ * @file /d/thornwick/hollow_road2.lpc
  * The Sunken Lane, deep between its banks. Crows keep this stretch.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/thornwick/hollow_road3.lpc
+++ b/d/thornwick/hollow_road3.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/hollow_road3.c
+ * @file /d/thornwick/hollow_road3.lpc
  * The Rise, where the road crests and Thornwick lies revealed.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/thornwick/old_bridge.lpc
+++ b/d/thornwick/old_bridge.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/old_bridge.c
+ * @file /d/thornwick/old_bridge.lpc
  * The toll bridge over Bramble Brook, where the hollow opens to the sky.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/thornwick/ruined_cottage.lpc
+++ b/d/thornwick/ruined_cottage.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/ruined_cottage.c
+ * @file /d/thornwick/ruined_cottage.lpc
  * The soundest of the dead cottages, off the west of the green.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/thornwick/thornwick.lpc
+++ b/d/thornwick/thornwick.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/thornwick.c
+ * @file /d/thornwick/thornwick.lpc
  * Zone object for Thornwick, the abandoned hamlet up the Hollow Road.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/thornwick/thornwick_base.lpc
+++ b/d/thornwick/thornwick_base.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/thornwick_base.c
+ * @file /d/thornwick/thornwick_base.lpc
  * General inherit for the Thornwick area. Sets the shared zone and the
  * default terrain (the road that threads the whole hamlet together), and
  * provides a lightweight per-room spawner registered via add_reset.

--- a/d/thornwick/thornwick_green.lpc
+++ b/d/thornwick/thornwick_green.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/thornwick/thornwick_green.c
+ * @file /d/thornwick/thornwick_green.lpc
  * Thornwick Green, the dead heart of the hamlet. The area hub.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/tunnels/tunnels_base.lpc
+++ b/d/tunnels/tunnels_base.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/tunnels/tunnels_base.c
+ * @file /d/tunnels/tunnels_base.lpc
  *
  * Inheritable base for the virtual tunnel rooms. Sets up terrain
  * and zone, delegates room population to the tunnels daemon, and

--- a/d/tunnels/tunnels_daemon.lpc
+++ b/d/tunnels/tunnels_daemon.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/tunnels/tunnels_daemon.c
+ * @file /d/tunnels/tunnels_daemon.lpc
  *
  * Virtual map daemon for the underground tunnels area. Loads the
  * tunnels map file and supplies short, long, and exit data to the

--- a/d/tunnels/twisting_tunnels.lpc
+++ b/d/tunnels/twisting_tunnels.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/tunnels/twisting_tunnels.c
+ * @file /d/village/tunnels/twisting_tunnels.lpc
  * Zone object for the Twisting Tunnels.
  *
  * @created 2024-09-02 - Gesslar

--- a/d/village/bakery.lpc
+++ b/d/village/bakery.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/bakery.c
+ * @file /d/village/bakery.lpc
  * A cozy bakery in Olum village.
  *
  * @created 2024-08-01 - Gesslar

--- a/d/village/centre.lpc
+++ b/d/village/centre.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/centre.c
+ * @file /d/village/centre.lpc
  * The commmunity centre
  *
  * @created 2024-08-12 - Gesslar

--- a/d/village/field/controller.lpc
+++ b/d/village/field/controller.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/field/controller.c
+ * @file /d/village/field/controller.lpc
  *
  * Virtual controller for the field
  *

--- a/d/village/field/field_base.lpc
+++ b/d/village/field/field_base.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/field/field_base.c
+ * @file /d/village/field/field_base.lpc
  *
  *  This is the inheritable for the virtual field rooms.
  *

--- a/d/village/field/field_daemon.lpc
+++ b/d/village/field/field_daemon.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/field/field_daemon.c
+ * @file /d/village/field/field_daemon.lpc
  *
  * Daemon backing the village field virtual area. Provides the room
  * setup helpers (exits, shorts, longs) used by the field's virtual

--- a/d/village/field/lush_field.lpc
+++ b/d/village/field/lush_field.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/field/field.c
+ * @file /d/village/field/field.lpc
  *
  * Zone object for the field
  *

--- a/d/village/financier.lpc
+++ b/d/village/financier.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/financier.c
+ * @file /d/village/financier.lpc
  * Financier's office
  *
  * @created 2024-02-29 - Gesslar

--- a/d/village/lockers.lpc
+++ b/d/village/lockers.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/lockers.c
+ * @file /d/village/lockers.lpc
  * A place for villagers to store their personal belongings.
  *
  * @created 2024-08-13 - Gesslar

--- a/d/village/manor/bedroom1.lpc
+++ b/d/village/manor/bedroom1.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/bedroom1.c
+ * @file /d/village/house/bedroom1.lpc
  * A bedroom in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/bedroom2.lpc
+++ b/d/village/manor/bedroom2.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/bedroom2.c
+ * @file /d/village/house/bedroom2.lpc
  * A bedroom in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/conservatory.lpc
+++ b/d/village/manor/conservatory.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/conservatory.c
+ * @file /d/village/house/conservatory.lpc
  * A conservatory in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/foyer.lpc
+++ b/d/village/manor/foyer.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/foyer.c
+ * @file /d/village/house/foyer.lpc
  * The foyer of the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/hall1.lpc
+++ b/d/village/manor/hall1.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/hall1.c
+ * @file /d/village/house/hall1.lpc
  * The first hall in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/hall2.lpc
+++ b/d/village/manor/hall2.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/hall2.c
+ * @file /d/village/house/hall2.lpc
  * The second hall in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/hall3.lpc
+++ b/d/village/manor/hall3.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/hall3.c
+ * @file /d/village/house/hall3.lpc
  * The third hall in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/hall4.lpc
+++ b/d/village/manor/hall4.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/hall4.c
+ * @file /d/village/house/hall4.lpc
  * The fourth hall in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/hall5.lpc
+++ b/d/village/manor/hall5.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/hall5.c
+ * @file /d/village/house/hall5.lpc
  * The fifth hall in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/kitchen.lpc
+++ b/d/village/manor/kitchen.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/kitchen.c
+ * @file /d/village/house/kitchen.lpc
  * A kitchen in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/landing.lpc
+++ b/d/village/manor/landing.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/landing.c
+ * @file /d/village/house/landing.lpc
  * The landing in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/library.lpc
+++ b/d/village/manor/library.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/library.c
+ * @file /d/village/house/library.lpc
  * A library in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/manor.lpc
+++ b/d/village/manor/manor.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/manor.c
+ * @file /d/village/house/manor.lpc
  * Inheritable for the opulent manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/obj/iron_chest.lpc
+++ b/d/village/manor/obj/iron_chest.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/container/iron_chest.c
+ * @file /obj/container/iron_chest.lpc
  * A sturdy iron chest that can be locked and unlocked. This
  * container provides secure storage for valuable items and can be placed in
  * rooms or carried, though its significant weight makes transport challenging.

--- a/d/village/manor/obj/manor_key.lpc
+++ b/d/village/manor/obj/manor_key.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/manor/obj/manor_key.c
+ * @file /d/village/manor/obj/manor_key.lpc
  *
  * The key to open the chest.
  *

--- a/d/village/manor/porch.lpc
+++ b/d/village/manor/porch.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/porch.c
+ * @file /d/village/house/porch.lpc
  * A porch in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/salon.lpc
+++ b/d/village/manor/salon.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/salon.c
+ * @file /d/village/house/salon.lpc
  * A salon in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/manor/washroom.lpc
+++ b/d/village/manor/washroom.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/house/washroom.c
+ * @file /d/village/house/washroom.lpc
  * A washroom in the manor.
  *
  * @created 2024-09-13 - Gesslar

--- a/d/village/olum.lpc
+++ b/d/village/olum.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/olum.c
+ * @file /d/village/olum.lpc
  * Zone file for the village of Olum
  *
  * @created 2024-02-04 - Gesslar

--- a/d/village/shop.lpc
+++ b/d/village/shop.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/shop.c
+ * @file /d/village/shop.lpc
  * A basic shop in Olum village.
  *
  * @created 2024-08-01 - Gesslar

--- a/d/village/square.lpc
+++ b/d/village/square.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/square.c
+ * @file /d/village/square.lpc
  * Square of the village of Olum
  *
  * @created 2024-02-04 - Gesslar

--- a/d/village/tailor.lpc
+++ b/d/village/tailor.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/tailor.c
+ * @file /d/village/tailor.lpc
  * A refined tailor's shop in the affluent quarter of Olum village.
  *
  * @created 2026-07-02 - Gesslar

--- a/d/village/village_base.lpc
+++ b/d/village/village_base.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/village_base.c
+ * @file /d/village/village_base.lpc
  * General inherit for the village area
  *
  * @created 2024-02-04 - Gesslar

--- a/d/village/village_path1.lpc
+++ b/d/village/village_path1.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/village_path1.c
+ * @file /d/village/village_path1.lpc
  * Path through the village
  *
  * @created 2024-02-04 - Gesslar

--- a/d/village/village_path2.lpc
+++ b/d/village/village_path2.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/village_path2.c
+ * @file /d/village/village_path2.lpc
  * Path through the village
  *
  * @created 2024-02-04 - Gesslar

--- a/d/village/village_path3.lpc
+++ b/d/village/village_path3.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/village_path3.c
+ * @file /d/village/village_path3.lpc
  * Path through the village
  *
  * @created 2024-02-04 - Gesslar

--- a/d/village/village_path4.lpc
+++ b/d/village/village_path4.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/village_path4.c
+ * @file /d/village/village_path4.lpc
  * Path through the village
  *
  * @created 2024-02-04 - Gesslar

--- a/d/village/village_path5.lpc
+++ b/d/village/village_path5.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/village_path5.c
+ * @file /d/village/village_path5.lpc
  * Path through the village
  *
  * @created 2024-08-12 - Gesslar

--- a/d/village/village_path6.lpc
+++ b/d/village/village_path6.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/village_path6.c
+ * @file /d/village/village_path6.lpc
  * The fraying western edge of Olum, out past the last kept houses.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/village/village_path7.lpc
+++ b/d/village/village_path7.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/village/village_path7.c
+ * @file /d/village/village_path7.lpc
  * The last of Olum, where the track meets open field and the road north.
  *
  * @created 2026-06-15 - Gesslar

--- a/d/wastes/barren_wasteland.lpc
+++ b/d/wastes/barren_wasteland.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/wastes/wastes.c
+ * @file /d/wastes/wastes.lpc
  * Zone object for the wastes
  *
  * @created 2024-09-02 - Gesslar

--- a/d/wastes/controller.lpc
+++ b/d/wastes/controller.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/wastes/controller.c
+ * @file /d/wastes/controller.lpc
  *
  * Virtual controller for the wastes
  *

--- a/d/wastes/wastes_base.lpc
+++ b/d/wastes/wastes_base.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/wastes/wastes_base.c
+ * @file /d/wastes/wastes_base.lpc
  * The wastes room.
  *
  * @created 2024-08-30 - Gesslar

--- a/d/wastes/wastes_daemon.lpc
+++ b/d/wastes/wastes_daemon.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /d/wastes/wastes_daemon.c
+ * @file /d/wastes/wastes_daemon.lpc
  *
  * Virtual map daemon for the wastes. Generates a procedural terrain
  * map using simplex noise, carves a river through it, classifies

--- a/lib/coin.lpc
+++ b/lib/coin.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/mudlib/coin.c
+ * @file /obj/mudlib/coin.lpc
  * A coin object
  *
  * @created 2024-02-19 - Gesslar

--- a/lib/corpse.lpc
+++ b/lib/corpse.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /lib/corpse.c
+ * @file /lib/corpse.lpc
  *
  * Corpses oooOooOooOooO
  *

--- a/lib/daemon/discord_bot.lpc
+++ b/lib/daemon/discord_bot.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/daemon/discord_bot.c
+ * @file /std/daemon/discord_bot.lpc
  * Discord server daemon
  *
  * @created 2024-07-06 - Gesslar

--- a/lib/key.lpc
+++ b/lib/key.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/mudlib/key.c
+ * @file /obj/mudlib/key.lpc
  *
  * Base for keys.
  *

--- a/lib/striker.lpc
+++ b/lib/striker.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/mudlib/striker.c
+ * @file /obj/mudlib/striker.lpc
  *
  * Object that can be used to strike against another object to begin a fire.
  *

--- a/obj/armour/armour.lpc
+++ b/obj/armour/armour.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/armour/armour.c
+ * @file /obj/armour/armour.lpc
  *
  * Base armour inheritable for virtual armour items
  *

--- a/obj/clothing/clothing.lpc
+++ b/obj/clothing/clothing.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/clothing/clothing.c
+ * @file /obj/clothing/clothing.lpc
  *
  * Base clothing inheritable for virtual clothing items
  *

--- a/obj/container/backpack.lpc
+++ b/obj/container/backpack.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/container/backpack.c
+ * @file /obj/container/backpack.lpc
  * A small wearable container that allows players to store and carry
  * items. The backpack functions both as a piece of clothing that can be worn and
  * as a container that can hold various objects. It comes with a closure mechanism

--- a/obj/container/bag_holding.lpc
+++ b/obj/container/bag_holding.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/container/bag_holding.c
+ * @file /obj/container/bag_holding.lpc
  * A bag holding object
  *
  * @created 2024-08-07 - Gesslar

--- a/obj/drink/drink.lpc
+++ b/obj/drink/drink.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/drink/drink.c
+ * @file /obj/drink/drink.lpc
  *
  * Base drink inheritable for virtual drink items
  *

--- a/obj/effect/burn.lpc
+++ b/obj/effect/burn.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/effect/burn.c
+ * @file /obj/effect/burn.lpc
  *
  * Burn effect — a fire-typed damage-over-time that lives inside
  * its victim and ticks for a configured number of pulses. Attached

--- a/obj/effect/ice_shard.lpc
+++ b/obj/effect/ice_shard.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/effect/ice_shard.c
+ * @file /obj/effect/ice_shard.lpc
  *
  * Ice shard effect — a magical shard of ice embedded in the victim
  * by the shard spell. Sits silently while attached, then shatters

--- a/obj/effect/wither.lpc
+++ b/obj/effect/wither.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/effect/wither.c
+ * @file /obj/effect/wither.lpc
  *
  * Withering shadow effect — a clinging tendril of magical shadow
  * that weakens its victim's defenses for a fixed duration. Applies

--- a/obj/food/food.lpc
+++ b/obj/food/food.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/food/food.c
+ * @file /obj/food/food.lpc
  *
  * Base food inheritable for virtual food items
  *

--- a/obj/general/campfire.lpc
+++ b/obj/general/campfire.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/general/campfire.c
+ * @file /obj/general/campfire.lpc
  *
  * A small campfire.
  *

--- a/obj/general/firekit.lpc
+++ b/obj/general/firekit.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/general/firekit.c
+ * @file /obj/general/firekit.lpc
  *
  * This object will create a fire used in a room.
  *

--- a/obj/general/firesteel.lpc
+++ b/obj/general/firesteel.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/general/firesteel.c
+ * @file /obj/general/firesteel.lpc
  *
  * Firesteel object.
  *

--- a/obj/general/flint.lpc
+++ b/obj/general/flint.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/loot/flint.c
+ * @file /obj/loot/flint.lpc
  *
  * Striker object that is called flint.
  *

--- a/obj/loot/loot.lpc
+++ b/obj/loot/loot.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/loot/loot.c
+ * @file /obj/loot/loot.lpc
  * Base loot inheritable. This is for vendor trash, etc.
  *
  * @created 2024-08-20 - Gesslar

--- a/obj/node/node.lpc
+++ b/obj/node/node.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/resource/resource_node.c
+ * @file /obj/resource/resource_node.lpc
  *
  * This object is the base world resource spawn that exists in the game world.
  *

--- a/obj/weapon/piercing/rusty_sword.lpc
+++ b/obj/weapon/piercing/rusty_sword.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /obj/weapon/piercing/rusty_sword.c
+ * @file /obj/weapon/piercing/rusty_sword.lpc
  * A basic sword for stabbing things
  *
  * @created 2024-08-04 - Gesslar


### PR DESCRIPTION
Correct the `@file` tags in JSDoc headers across the codebase to use the `.lpc` extension instead of the outdated `.c` extension. Also adds a missing newline at the end of `cmds/wiz/summon.lpc`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects outdated source extensions in LPC file headers.

- Updates `@file` tags from `.c` to `.lpc`.
- Adds a final newline to `cmds/wiz/summon.lpc`.
</details>

<sub>Reviews (3): Last reviewed commit: ["part 2"](https://github.com/gesslar/oxidus-mudlib/commit/e6ea26c5efe63bf696a432cef67b98086262fcb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44690115)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->