### PR TITLE
Fix `@file` doc comments: `.c` → `.lpc` across `std/` and `tests/`

### DIFF
--- a/std/classes/door.lpc
+++ b/std/classes/door.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/classes/door.c
+ * @file /std/classes/door.lpc
  *
  * Defines the Door class used to represent physical doors, gates, and other
  * passageways between rooms. Each door has state tracking (open/closed/locked),

--- a/std/classes/storage.lpc
+++ b/std/classes/storage.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/classes/storage.c
+ * @file /std/classes/storage.lpc
  *
  * Class definition for StorageOptions used in storage room implementations.
  *

--- a/std/cmd/ability.lpc
+++ b/std/cmd/ability.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/cmd/ability.c
+ * @file /std/cmd/ability.lpc
  *
  * Standard ability inheritance for commands. Provides the
  * framework for ability usage including condition checks,

--- a/std/cmd/reporter.lpc
+++ b/std/cmd/reporter.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/cmd/reporter.c
+ * @file /std/cmd/reporter.lpc
  *
  * Inherited by reporting commands such as bug, typo, and idea.
  * Handles the full report lifecycle: subject input, editor

--- a/std/consume/drink.lpc
+++ b/std/consume/drink.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/consume/drink.c
+ * @file /std/consume/drink.lpc
  *
  * Drink inheritable for objects that can be consumed.
  *

--- a/std/consume/food.lpc
+++ b/std/consume/food.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/consume/food.c
+ * @file /std/consume/food.lpc
  *
  * Food inheritable for objects that can be consumed.
  *

--- a/std/container/storage_object.lpc
+++ b/std/container/storage_object.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/container/storage_object.c
+ * @file /std/container/storage_object.lpc
  * Object for permanent or temporary storage, like shops or
  * armouries.
  *

--- a/std/daemon/discord_bot.lpc
+++ b/std/daemon/discord_bot.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/daemon/discord_bot.c
+ * @file /std/daemon/discord_bot.lpc
  * Discord server daemon
  *
  * @created 2024-07-06 - Gesslar

--- a/std/daemon/http_client.lpc
+++ b/std/daemon/http_client.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/daemon/http_client.c
+ * @file /std/daemon/http_client.lpc
  * This is a base HTTP client daemon that is intended to be
  * inherited by other objects to create a custom HTTP client. It
  * provides the ability to send HTTP requests to a server and

--- a/std/daemon/http_server.lpc
+++ b/std/daemon/http_server.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/daemon/http_server.c
+ * @file /std/daemon/http_server.lpc
  * This is an HTTP server that may be inherited by other objects
  * to create a custom HTTP server. It listens on a specified port
  * and accepts incoming connections.

--- a/std/daemon/virtual_map.lpc
+++ b/std/daemon/virtual_map.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/daemon/virtual_map.c
+ * @file /std/daemon/virtual_map.lpc
  * Daemon responsible for managing virtual maps for a zone.
  * All coordinates are in the format of z,y,x.
  *

--- a/std/daemon/websocket_client.lpc
+++ b/std/daemon/websocket_client.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/daemon/websocket_client.c
+ * @file /std/daemon/websocket_client.lpc
  * This is a base WebSocket client daemon that is intended to be
  * inherited by other objects to create a custom WS client. It
  * provides the ability to send start an HTTP session and then

--- a/std/equip/armour.lpc
+++ b/std/equip/armour.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/equip/armour.c
+ * @file /std/equip/armour.lpc
  *
  * Standard armour object. Extends clothing with defence
  * ratings and armour class (AC) for damage mitigation in

--- a/std/equip/equip.lpc
+++ b/std/equip/equip.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/equip/equip.c
+ * @file /std/equip/equip.lpc
  * Base equipment object that provides equip/unequip functionality.
  *
  * Inherited by armour, clothing, and weapon objects to provide

--- a/std/equip/weapon.lpc
+++ b/std/equip/weapon.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/equip/weapon.c
+ * @file /std/equip/weapon.lpc
  *
  * Standard weapon object providing wield/unwield functionality.
  *

--- a/std/ext/bank.lpc
+++ b/std/ext/bank.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/bank.c
+ * @file /std/ext/bank.lpc
  *
  * Extension module that provides banking commands for room objects.
  * Allows players to register accounts, deposit and withdraw currency,

--- a/std/ext/clean.lpc
+++ b/std/ext/clean.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/clean.c
+ * @file /std/ext/clean.lpc
  * Clean up routine
  *
  * @created 2022/08/24 - Gesslar

--- a/std/ext/currency.lpc
+++ b/std/ext/currency.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/currency.c
+ * @file /std/ext/currency.lpc
  *
  * Currency module that can be inherited for money handling. Provides
  * the transaction engine used by shops and other commerce modules,

--- a/std/ext/edible.lpc
+++ b/std/ext/edible.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/edible.c
+ * @file /std/ext/edible.lpc
  * This module is inherited in order to make something edible.
  *
  * @created 2024-08-06 - Gesslar

--- a/std/ext/http.lpc
+++ b/std/ext/http.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/http.c
+ * @file /std/ext/http.lpc
  * HTTP module with shared functions for use in HTTP operations
  *
  * @created 2024-07-05 - Gesslar

--- a/std/ext/loot.lpc
+++ b/std/ext/loot.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/loot.c
+ * @file /std/ext/loot.lpc
  * Loot module for anything.
  *
  * @created 2024-08-05 - Gesslar

--- a/std/ext/material.lpc
+++ b/std/ext/material.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/material.c
+ * @file /std/ext/material.lpc
  *
  * Material extension module. Inherited by items (see EXT_MATERIAL) to
  * track the materials an object is composed of (e.g. "wood", "iron",

--- a/std/ext/potable.lpc
+++ b/std/ext/potable.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/potable.c
+ * @file /std/ext/potable.lpc
  * This module is inherited in order to make something potable.
  *
  * @created 2024-08-06 - Gesslar

--- a/std/ext/proc.lpc
+++ b/std/ext/proc.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/proc.c
+ * @file /std/ext/proc.lpc
  * Module for handling procs for objects.
  *
  * @created 2024-10-06 - Gesslar

--- a/std/ext/shop.lpc
+++ b/std/ext/shop.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/shop.c
+ * @file /std/ext/shop.lpc
  *
  * Inventory-based shop module. Inherited by rooms that wish to buy
  * and sell items via a persistent storage object. Provides the

--- a/std/ext/shop_menu.lpc
+++ b/std/ext/shop_menu.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/shop_menu.c
+ * @file /std/ext/shop_menu.lpc
  * A module to enable a shop that uses a menu instead of an
  * inventory.
  *

--- a/std/ext/unicode.lpc
+++ b/std/ext/unicode.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/unicode.c
+ * @file /std/ext/unicode.lpc
  * Module for handling unicode characters.
  *
  * Portions of this were delightfully and unabashedly stolen from the Lima base

--- a/std/ext/uses.lpc
+++ b/std/ext/uses.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/ext/uses.c
+ * @file /std/ext/uses.lpc
  * This module is inherited in order to provide consumabling.
  *
  * @created 2024-08-06 - Gesslar

--- a/std/living/act.lpc
+++ b/std/living/act.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/act.c
+ * @file /std/living/act.lpc
  * Call-out based action module
  *
  * @created 2024-08-08 - Gesslar

--- a/std/living/advancement.lpc
+++ b/std/living/advancement.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/advancement.c
+ * @file /std/living/advancement.lpc
  *
  * Per-living XP and level state. Tracks current level, a temporary
  * level modifier (used by boons and curses), and accumulated

--- a/std/living/alias.lpc
+++ b/std/living/alias.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/alias.c
+ * @file /std/living/alias.lpc
  *
  * Per-living alias storage module. Holds the personal aliases belonging
  * to a single living, mapping each alias name to its expansion string,

--- a/std/living/appearance.lpc
+++ b/std/living/appearance.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/appearance.c
+ * @file /std/living/appearance.lpc
  * Handles the appearance of living objects
  *
  * @created 2024-07-30 - Gesslar

--- a/std/living/attributes.lpc
+++ b/std/living/attributes.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/attributes.c
+ * @file /std/living/attributes.lpc
  * Player attributes.
  *
  * @created 2024-07-30 - Gesslar

--- a/std/living/body.lpc
+++ b/std/living/body.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/body.c
+ * @file /std/living/body.lpc
  *
  * Body object that is shared by players and NPCs.
  *

--- a/std/living/boon.lpc
+++ b/std/living/boon.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/boon.c
+ * @file /std/living/boon.lpc
  * Buffs/debuffs and other boons for living objects.
  *
  * @created 2024-07-30 - Gesslar

--- a/std/living/combat.lpc
+++ b/std/living/combat.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/combat.c
+ * @file /std/living/combat.lpc
  *
  * Combat module for living objects. Drives the per-round attack loop, threat
  * tracking for current and recently-seen enemies, hit-chance and damage

--- a/std/living/communication.lpc
+++ b/std/living/communication.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/communication.c
+ * @file /std/living/communication.lpc
  *
  * Per-living history buffers for inbound says, tells, and whispers,
  * along with the most recent sender for tell and whisper reply

--- a/std/living/damage.lpc
+++ b/std/living/damage.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/damage.c
+ * @file /std/living/damage.lpc
  *
  * Damage delivery and receipt for living objects. Provides the
  * attacker-side entry point (deliver_damage) and the victim-side

--- a/std/living/decision.lpc
+++ b/std/living/decision.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/decision.c
+ * @file /std/living/decision.lpc
  * Decision making for living objects.
  *
  * Converted from: https://www.npmjs.com/package/utility-ai

--- a/std/living/ed.lpc
+++ b/std/living/ed.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/user/ed.c
+ * @file /std/user/ed.lpc
  * Object to handle interacting with basic or advanced editor.
  *
  * @created 2024-07-20 - Gesslar

--- a/std/living/env.lpc
+++ b/std/living/env.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/env.c
+ * @file /std/living/env.lpc
  *
  * Environment variables and preferences for living objects. Environment
  * variables hold session/shell state (working directory, current file,

--- a/std/living/equipment.lpc
+++ b/std/living/equipment.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/user/include/equipment.c
+ * @file /std/user/include/equipment.lpc
  * Equipment system for livings
  *
  * @created 2024-07-29 - Gesslar

--- a/std/living/ghost.lpc
+++ b/std/living/ghost.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/ghost.c
+ * @file /std/living/ghost.lpc
  * You're a ghost OooOoOOOOoOOoOooooOOo
  *
  * @created 2024-07-28 - Gesslar

--- a/std/living/living.lpc
+++ b/std/living/living.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/living.c
+ * @file /std/living/living.lpc
  * Setup and adjustments for living values of living beings.
  *
  * @created 2024-07-30 - Gesslar

--- a/std/living/module.lpc
+++ b/std/living/module.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/module.c
+ * @file /std/living/module.lpc
  * Module management for user objects
  *
  * @created 2024-07-29 - Gesslar

--- a/std/living/pager.lpc
+++ b/std/living/pager.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/user/pager.c
+ * @file /std/user/pager.lpc
  * Pager object for displaying text to the user in a paginated
  * format.
  *

--- a/std/living/player.lpc
+++ b/std/living/player.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/player.c
+ * @file /std/living/player.lpc
  * Player object for user characters. Handles the lifecycle of a
  * player body including login, logout, heartbeat, persistence,
  * environment variables, and GMCP integration.

--- a/std/living/race.lpc
+++ b/std/living/race.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/user/race.c
+ * @file /std/user/race.lpc
  * Race stuff
  *
  * @created 2024-07-25 - Gesslar

--- a/std/living/skills.lpc
+++ b/std/living/skills.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/living/skills.c
+ * @file /std/living/skills.lpc
  *
  * Trainable skills for living objects.
  *

--- a/std/living/visibility.lpc
+++ b/std/living/visibility.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/user/visibility.c
+ * @file /std/user/visibility.lpc
  * Object for determining whether a living can see things
  *
  * @created 2024-07-23 - Gesslar

--- a/std/living/vitals.lpc
+++ b/std/living/vitals.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/user/vitals.c
+ * @file /std/user/vitals.lpc
  * Vitals for livings
  *
  * @created 2024-07-24 - Gesslar

--- a/std/mobs/insect.lpc
+++ b/std/mobs/insect.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/mobs/insect.c
+ * @file /std/mobs/insect.lpc
  * Virtual insects
  *
  * @created 2024-08-20 - Gesslar

--- a/std/mobs/mammal.lpc
+++ b/std/mobs/mammal.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/mobs/mammal.c
+ * @file /std/mobs/mammal.lpc
  * Virtual mammals
  *
  * @created 2024-08-20 - Gesslar

--- a/std/mobs/monster.lpc
+++ b/std/mobs/monster.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/mobs/monster.c
+ * @file /std/mobs/monster.lpc
  *
  * Standard monster inheritable for all types of monsters
  *

--- a/std/mobs/rodent.lpc
+++ b/std/mobs/rodent.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/mobs/rodent.c
+ * @file /std/mobs/rodent.lpc
  * Virtual rodents
  *
  * @created 2024-08-20 - Gesslar

--- a/std/module_base.lpc
+++ b/std/module_base.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/module_base.c
+ * @file /std/module_base.lpc
  *
  * Base class for modules that can be attached to any object.
  * Modules are cloned objects that attach to an owner and provide

--- a/std/modules/mob/combat_memory.lpc
+++ b/std/modules/mob/combat_memory.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/modules/mob/combat_memory.c
+ * @file /std/modules/mob/combat_memory.lpc
  * NPC combat memory module
  *
  * @created 2024-07-29 - Gesslar

--- a/std/modules/module.lpc
+++ b/std/modules/module.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/modules/module.c
+ * @file /std/modules/module.lpc
  *
  * Base class for modules that attach to mobile (living) objects.
  * Inherits from STD_MODULE_BASE to provide the core attach/detach

--- a/std/modules/race/ghost.lpc
+++ b/std/modules/race/ghost.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/modules/race/ghost.c
+ * @file /std/modules/race/ghost.lpc
  * Ghost racial module
  *
  * @created 2024-07-25 - Gesslar

--- a/std/modules/race/human.lpc
+++ b/std/modules/race/human.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/modules/race/human.c
+ * @file /std/modules/race/human.lpc
  * Human racial module
  *
  * @created 2024-07-25 - Gesslar

--- a/std/modules/race/race.lpc
+++ b/std/modules/race/race.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/modules/race/race.c
+ * @file /std/modules/race/race.lpc
  * Race body module
  *
  * @created 2024-07-25 - Gesslar

--- a/std/modules/room/resource.lpc
+++ b/std/modules/room/resource.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/modules/room/resource.c
+ * @file /std/modules/room/resource.lpc
  *
  * Added to rooms that can have resources.
  *

--- a/std/object/command.lpc
+++ b/std/object/command.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/command.c
+ * @file /std/object/command.lpc
  *
  * Replacement for add_action, allowing for mixed results and more flexible
  * command handling.

--- a/std/object/container.lpc
+++ b/std/object/container.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/container.c
+ * @file /std/object/container.lpc
  * Container inheritable for objects that can hold other objects.
  *
  * @created 2024-07-23 - Gesslar

--- a/std/object/contents.lpc
+++ b/std/object/contents.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/contents.c
+ * @file /std/object/contents.lpc
  * Handles the capacity and contents of an object, providing
  * inventory management and mass/capacity tracking.
  *

--- a/std/object/cooldown.lpc
+++ b/std/object/cooldown.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/cooldown.c
+ * @file /std/object/cooldown.lpc
  * Manages time-limited actions via cooldown timers.
  *
  * @created 2024-09-15 - Gesslar

--- a/std/object/description.lpc
+++ b/std/object/description.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/description.c
+ * @file /std/object/description.lpc
  * Functions and variables for object descriptions
  *
  * @created 2024-01-31 - Gesslar

--- a/std/object/heartbeat.lpc
+++ b/std/object/heartbeat.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/heartbeat.c
+ * @file /std/object/heartbeat.lpc
  * Provides event management that synchronizes with an object's
  * heartbeat cycle. Events can be attached to execute during
  * heartbeats, which may vary in frequency due to buffs or status

--- a/std/object/id.lpc
+++ b/std/object/id.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/id.c
+ * @file /std/object/id.lpc
  * Manages object identifiers and adjectives for item recognition
  * and command parsing.
  *

--- a/std/object/init.lpc
+++ b/std/object/init.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/init.c
+ * @file /std/object/init.lpc
  * Manages object initialization callbacks when objects encounter
  * each other in the game world.
  *

--- a/std/object/inventory.lpc
+++ b/std/object/inventory.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/inventory.c
+ * @file /std/object/inventory.lpc
  *
  * Inventory inheritable for objects that can hold other objects.
  * Provides registration and automated spawning of items and NPCs

--- a/std/object/item.lpc
+++ b/std/object/item.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/item.c
+ * @file /std/object/item.lpc
  * Base implementation for physical game items that can be
  * manipulated, carried, and moved between containers.
  *

--- a/std/object/module.lpc
+++ b/std/object/module.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/module.c
+ * @file /std/object/module.lpc
  *
  * Module management for any object. Allows attaching and
  * detaching cloned module objects that provide additional

--- a/std/object/object.lpc
+++ b/std/object/object.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/object.c
+ * @file /std/object/object.lpc
  * Base object implementation that provides core functionality
  * for all game objects.
  *

--- a/std/object/persist.lpc
+++ b/std/object/persist.lpc
@@ -1,7 +1,7 @@
 /* Do not remove the headers from this file! see /USAGE for more info. */
 
 /**
- * @file /std/object/persist.c
+ * @file /std/object/persist.lpc
  * Provides persistence capabilities allowing objects to save and
  * restore their state to/from strings or files.
  *

--- a/std/object/setup.lpc
+++ b/std/object/setup.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/setup.c
+ * @file /std/object/setup.lpc
  * Provides a standardised setup and teardown chain for objects,
  * ensuring proper initialization and cleanup order.
  *

--- a/std/object/stats.lpc
+++ b/std/object/stats.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/stats.c
+ * @file /std/object/stats.lpc
  * Tracks creation time, age, and creator information for objects.
  *
  * @created 2024-02-04 - Gesslar

--- a/std/object/value.lpc
+++ b/std/object/value.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/value.c
+ * @file /std/object/value.lpc
  *
  * Handles monetary value tracking for physical objects.
  *

--- a/std/object/weight.lpc
+++ b/std/object/weight.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/object/weight.c
+ * @file /std/object/weight.lpc
  * Handles mass and weight mechanics for objects in the game.
  *
  * @created 2024-02-18 - Gesslar

--- a/std/room/door.lpc
+++ b/std/room/door.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/room/door.c
+ * @file /std/room/door.lpc
  *
  * Room door management system that handles door states, synchronization between
  * connected rooms, and player interactions. Uses the Door class to track door

--- a/std/room/exits.lpc
+++ b/std/room/exits.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/room/exits.c
+ * @file /std/room/exits.lpc
  * Exits are the connections between rooms.
  *
  * @created 2024-09-13 - Gesslar

--- a/std/room/items.lpc
+++ b/std/room/items.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/room/items.c
+ * @file /std/room/items.lpc
  * Manages item descriptions within rooms for examination.
  *
  * @created 2024-09-13 - Gesslar

--- a/std/room/room.lpc
+++ b/std/room/room.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/room/room.c
+ * @file /std/room/room.lpc
  * A generic room object that can be inherited by any room.
  *
  * @created 2024-08-11 - Gesslar

--- a/std/room/storage.lpc
+++ b/std/room/storage.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/room/storage.c
+ * @file /std/room/storage.lpc
  * This is a room that enables players to access storage. Inherit
  * from this class to create a storage room.
  *

--- a/std/room/terrain.lpc
+++ b/std/room/terrain.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/room/terrain.c
+ * @file /std/room/terrain.lpc
  * Terrain types
  *
  * @created 2024-08-19 - Gesslar

--- a/std/room/zone.lpc
+++ b/std/room/zone.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/room/zone.c
+ * @file /std/room/zone.lpc
  *
  * Room-side zone module. Lets a room declare which zone it belongs
  * to via set_zone(); the room is then registered with that zone

--- a/std/test/runner.lpc
+++ b/std/test/runner.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/test/runner.c
+ * @file /std/test/runner.lpc
  * Base for area test runners. An area runner inherits this and
  * has no other obligation — run_tests() globs *.test.c siblings
  * of the inheriting runner, clones each, calls run(), and

--- a/std/test/test.lpc
+++ b/std/test/test.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/test/test.c
+ * @file /std/test/test.lpc
  * Base for individual test files. A test file inherits this,
  * registers suites in setup() via describe()/test(), and is
  * cloned and invoked by a STD_TEST_RUNNER.

--- a/std/zones/zone.lpc
+++ b/std/zones/zone.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /std/zones/zone.c
+ * @file /std/zones/zone.lpc
  *
  * Base daemon for a zone. A zone is a logical grouping of rooms
  * — rooms register themselves with their zone via the room-side

--- a/tests/adm/simul_efun/array.functional.test.lpc
+++ b/tests/adm/simul_efun/array.functional.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/array.functional.test.c
+ * @file /tests/adm/simul_efun/array.functional.test.lpc
  *
  * Tests for callback-applying simul_efuns in
  * /adm/simul_efun/array.c — reduce(), each(), find(),

--- a/tests/adm/simul_efun/array.misc.test.lpc
+++ b/tests/adm/simul_efun/array.misc.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/array.misc.test.c
+ * @file /tests/adm/simul_efun/array.misc.test.lpc
  *
  * Tests for the leftover one-off array simul_efuns:
  * array_columns(), and sum_array().

--- a/tests/adm/simul_efun/array.mutation.test.lpc
+++ b/tests/adm/simul_efun/array.mutation.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/array.mutation.test.c
+ * @file /tests/adm/simul_efun/array.mutation.test.lpc
  *
  * Tests for the in-place ref-based array simul_efuns:
  * pop, push, shift, unshift, set_push, set_unshift,

--- a/tests/adm/simul_efun/array.predicate.test.lpc
+++ b/tests/adm/simul_efun/array.predicate.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/array.predicate.test.c
+ * @file /tests/adm/simul_efun/array.predicate.test.lpc
  *
  * Tests for boolean-query simul_efuns in
  * /adm/simul_efun/array.c — uniformp(), includes(),

--- a/tests/adm/simul_efun/array.sort.test.lpc
+++ b/tests/adm/simul_efun/array.sort.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/array.sort.test.c
+ * @file /tests/adm/simul_efun/array.sort.test.lpc
  *
  * Tests for the sort wrappers in /adm/simul_efun/array.c —
  * sort_alpha(), sort_num(), sort_float(),

--- a/tests/adm/simul_efun/array.transform.test.lpc
+++ b/tests/adm/simul_efun/array.transform.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/array.transform.test.c
+ * @file /tests/adm/simul_efun/array.transform.test.lpc
  *
  * Tests for the return-new-array simul_efuns in
  * /adm/simul_efun/array.c. Covers distinct_array, uniq_array, reverse_array,

--- a/tests/adm/simul_efun/base64.test.lpc
+++ b/tests/adm/simul_efun/base64.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/base64.test.c
+ * @file /tests/adm/simul_efun/base64.test.lpc
  *
  * Tests for base64_encode() and base64_decode() simul_efuns.
  */

--- a/tests/adm/simul_efun/colour.test.lpc
+++ b/tests/adm/simul_efun/colour.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/colour.test.c
+ * @file /tests/adm/simul_efun/colour.test.lpc
  *
  * Tests for the gradient_hex() simul_efun.
  */

--- a/tests/adm/simul_efun/daemon.test.lpc
+++ b/tests/adm/simul_efun/daemon.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/daemon.test.c
+ * @file /tests/adm/simul_efun/daemon.test.lpc
  *
  * Tests for the daemon-accessor simul_efuns.
  */

--- a/tests/adm/simul_efun/data.test.lpc
+++ b/tests/adm/simul_efun/data.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/data.test.c
+ * @file /tests/adm/simul_efun/data.test.lpc
  *
  * Tests for the data_value, data_write, data_del, and data_inc
  * simul_efuns from /adm/simul_efun/data.c.

--- a/tests/adm/simul_efun/lpml.encode.test.lpc
+++ b/tests/adm/simul_efun/lpml.encode.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/lpml.encode.test.c
+ * @file /tests/adm/simul_efun/lpml.encode.test.lpc
  *
  * Tests for lpml_encode() (LPC value -> JSON text) and decode/encode
  * roundtrips. lpml_encode emits standard JSON: undefined -> null,


### PR DESCRIPTION
Correct `@file` tags in doc comments from `.c` to `.lpc` extension across all standard library and test files.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects `@file` documentation tags to use `.lpc` paths.

- Updates tags across `std/` source files.
- Updates tags in simul-efun test files.
- Leaves executable LPC code and test definitions unchanged.
</details>

<sub>Reviews (3): Last reviewed commit: ["part 3"](https://github.com/gesslar/oxidus-mudlib/commit/25a7b0ddb7dad3d259686283f96259db95f99a4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44690124)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->