### PR TITLE
Fix `@file` doc comments: `.c` → `.lpc` extension in test files

### DIFF
--- a/tests/adm/simul_efun/lpml.errors.test.lpc
+++ b/tests/adm/simul_efun/lpml.errors.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/lpml.errors.test.c
+ * @file /tests/adm/simul_efun/lpml.errors.test.lpc
  *
  * Sad-path tests for lpml_decode(): malformed input must raise an error
  * (caught here with catch()). The test runner suppresses caught-error

--- a/tests/adm/simul_efun/lpml.includes.test.lpc
+++ b/tests/adm/simul_efun/lpml.includes.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/lpml.includes.test.c
+ * @file /tests/adm/simul_efun/lpml.includes.test.lpc
  *
  * Tests for lpml_decode() file-include preprocessing ("#path" values),
  * recursive includes, the \# literal-hash escape, and the

--- a/tests/adm/simul_efun/lpml.integration.test.lpc
+++ b/tests/adm/simul_efun/lpml.integration.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/lpml.integration.test.c
+ * @file /tests/adm/simul_efun/lpml.integration.test.lpc
  *
  * End-to-end decode of a realistic .lpml data file (the cave-bat monster
  * fixture). This exercises the features in combination — spacey keys,

--- a/tests/adm/simul_efun/lpml.keys.test.lpc
+++ b/tests/adm/simul_efun/lpml.keys.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/lpml.keys.test.c
+ * @file /tests/adm/simul_efun/lpml.keys.test.lpc
  *
  * Tests for lpml_decode() object-key handling: plain identifier keys,
  * quoted keys, single-quoted keys, YAML-style spacey keys (with spaces,

--- a/tests/adm/simul_efun/lpml.numbers.test.lpc
+++ b/tests/adm/simul_efun/lpml.numbers.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/lpml.numbers.test.c
+ * @file /tests/adm/simul_efun/lpml.numbers.test.lpc
  *
  * Tests for lpml_decode() number parsing: decimal ints, floats,
  * leading/trailing decimal points, exponents, sign prefixes, and the

--- a/tests/adm/simul_efun/lpml.scalars.test.lpc
+++ b/tests/adm/simul_efun/lpml.scalars.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/lpml.scalars.test.c
+ * @file /tests/adm/simul_efun/lpml.scalars.test.lpc
  *
  * Tests for lpml_decode() of top-level scalar values: booleans, null,
  * undefined, Infinity, NaN, the MAX_INT/MAX_FLOAT constants, and the

--- a/tests/adm/simul_efun/lpml.strings.test.lpc
+++ b/tests/adm/simul_efun/lpml.strings.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/lpml.strings.test.c
+ * @file /tests/adm/simul_efun/lpml.strings.test.lpc
  *
  * Tests for lpml_decode() string handling: double/single quotes, escape
  * sequences, \uXXXX unicode, adjacent-string concatenation (space vs. \n

--- a/tests/adm/simul_efun/lpml.structures.test.lpc
+++ b/tests/adm/simul_efun/lpml.structures.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/lpml.structures.test.c
+ * @file /tests/adm/simul_efun/lpml.structures.test.lpc
  *
  * Tests for lpml_decode() of objects and arrays: empty containers,
  * nesting, mixed-type arrays, trailing commas, and comment skipping

--- a/tests/adm/simul_efun/simple_list.test.lpc
+++ b/tests/adm/simul_efun/simple_list.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/simple_list.test.c
+ * @file /tests/adm/simul_efun/simple_list.test.lpc
  *
  * Tests for the simple_list() simul_efun.
  */

--- a/tests/adm/simul_efun/string.affix.test.lpc
+++ b/tests/adm/simul_efun/string.affix.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/string.affix.test.c
+ * @file /tests/adm/simul_efun/string.affix.test.lpc
  *
  * Tests for the affix simul_efuns from /adm/simul_efun/string.c:
  * append(), prepend(), chop(), starts_with(), and ends_with().

--- a/tests/adm/simul_efun/string.colour.test.lpc
+++ b/tests/adm/simul_efun/string.colour.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/string.colour.test.c
+ * @file /tests/adm/simul_efun/string.colour.test.lpc
  *
  * Tests for the colour-related simul_efuns from /adm/simul_efun/string.c:
  * no_ansi(), colour(), and colourp(). These delegate to COLOUR_D.

--- a/tests/adm/simul_efun/string.convert.test.lpc
+++ b/tests/adm/simul_efun/string.convert.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/string.convert.test.c
+ * @file /tests/adm/simul_efun/string.convert.test.lpc
  *
  * Tests for from_string() from /adm/simul_efun/string.c, which parses an LPC
  * value out of its string representation.

--- a/tests/adm/simul_efun/string.format.test.lpc
+++ b/tests/adm/simul_efun/string.format.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/string.format.test.c
+ * @file /tests/adm/simul_efun/string.format.test.lpc
  *
  * Tests for the formatting simul_efuns from /adm/simul_efun/string.c:
  * add_commas() and stringify().

--- a/tests/adm/simul_efun/string.search.test.lpc
+++ b/tests/adm/simul_efun/string.search.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/string.search.test.c
+ * @file /tests/adm/simul_efun/string.search.test.lpc
  *
  * Tests for the search / predicate simul_efuns from /adm/simul_efun/string.c:
  * reverse_strsrch(), pcre_strsrch(), is_numeric(), and sanitize_regex().

--- a/tests/adm/simul_efun/string.slice.test.lpc
+++ b/tests/adm/simul_efun/string.slice.test.lpc
@@ -1,6 +1,6 @@
 // @lpc-nocheck
 /**
- * @file /tests/adm/simul_efun/string.slice.test.c
+ * @file /tests/adm/simul_efun/string.slice.test.lpc
  *
  * Tests for the slicing / casing simul_efuns from /adm/simul_efun/string.c:
  * extract(), substr(), reverse_string(), and all_caps().


### PR DESCRIPTION
Correct `@file` doc comments in test files to use `.lpc` extension instead of `.c`

The `@file` tags in the file-level doc comments were referencing the old `.c` extension rather than the actual `.lpc` filenames. This brings the documented paths in line with the real filenames.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects file-level documentation paths in LPC test files.

- Updates `@file` tags from `.c` to `.lpc`.
- Aligns documented paths with the existing test filenames.
</details>

<sub>Reviews (3): Last reviewed commit: [".c to .lpc in file headers - part 4"](https://github.com/gesslar/oxidus-mudlib/commit/5db96b83313b681173bb8b6476c611ff58b35b49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44690130)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->