### PR TITLE
Add `cd.lpc` file command

### DIFF
--- a/adm/obj/master/security.lpc
+++ b/adm/obj/master/security.lpc
@@ -107,9 +107,9 @@ private nomask nosave string ROLES_FILE_CUSTOM = "adm/custom/security/roles.map"
 private nomask nosave mapping *access_rules = ({});
 
 /**
- * When set, path-access refusals are enforced; when clear (the default),
- * they run in shadow mode - logged but permitted. Cached from
- * SECURITY_ENFORCE_PATHS at setup.
+ * When set, path-access refusals are enforced; when clear, they run in
+ * shadow mode - logged but permitted. Cached from SECURITY_ENFORCE_PATHS
+ * (default set) at setup.
  *
  * @type {int}
  */
@@ -647,9 +647,10 @@ private nomask mapping load_roles() {
  *
  * valid_read/valid_write resolve the caller's identity against the
  * ordered access table (access.lpml, plus the git-ignored override
- * access.local.lpml). It ships in SHADOW MODE: refusals are logged but
- * still permitted, so the table can be tuned against real traffic before
- * it bites. Flip SECURITY_ENFORCE_PATHS to enforce.
+ * access.local.lpml). Enforcement is gated on SECURITY_ENFORCE_PATHS:
+ * when set (the default in default.lpml) refusals are denied; when clear
+ * the layer runs in shadow mode - refusals are logged but still permitted,
+ * so the table can be tuned against real traffic before it bites.
  *
  * This is guardrails against fat-finger writes into /adm, not an ACL
  * engine - keep it at that altitude.
@@ -824,8 +825,8 @@ private nomask int access_ok(string file, object user, string op) {
 
 /**
  * Shadow-aware wrapper around access_ok used by valid_read/valid_write.
- * Refusals are logged either way; when SECURITY_ENFORCE_PATHS is off (the
- * default) the refusal is permitted anyway (shadow mode), otherwise it is
+ * Refusals are logged either way; when SECURITY_ENFORCE_PATHS is off the
+ * refusal is permitted anyway (shadow mode), otherwise (the default) it is
  * enforced.
  *
  * @param {string} file - The target file path.

--- a/cmds/file/cd.lpc
+++ b/cmds/file/cd.lpc
@@ -1,0 +1,36 @@
+/**
+ * @file /cmds/file/cd.lpc
+ *
+ * Change to another director, or your home, wizard!
+ *
+ * @created 2026-07-15 - Gesslar
+ * @last_modified 2026-07-15 - Gesslar
+ *
+ * @history
+ * 2026-07-15 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  string path;
+
+  if(!str) {
+    path = home_path(caller);
+  } else {
+    path = resolve_path(caller->query_env("cwd"), str);
+  }
+
+  if(!master()->valid_read(path, caller, "cd"))
+    return _error("Permission denied.");
+
+  if(!directory_exists(path))
+    return _error("No such path: %s", path);
+
+  caller->set_env("cwd", path);
+
+  return _ok("Working directory set to: %s", path);
+}

--- a/cmds/file/cp.lpc
+++ b/cmds/file/cp.lpc
@@ -55,7 +55,7 @@ mixed main(
   if(original == destination)
     return _error(caller, "Original and destination are the same.");
 
-  if(!master()->valid_write(destination, this_object(), "cp"))
+  if(!master()->valid_write(destination, caller, "cp"))
     return _error(caller, "Permission denied.");
 
   int result = cp(original, destination);


### PR DESCRIPTION
Adds a `cd` command that allows wizards to change their current working directory. When called without arguments, it navigates to the caller's home directory. When given a path, it resolves it relative to the current working directory and updates the `cwd` environment variable accordingly. Returns an error if the specified path does not exist.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a wizard `cd` command and updates file-command access handling. The main changes are:

- Adds `cmds/file/cd.lpc` for changing the caller’s working directory.
- Checks read access and directory existence before updating `cwd`.
- Uses the invoking player for `cp` destination-write authorization.
- Clarifies the default path-security enforcement setting.
</details>

<sub>Reviews (2): Last reviewed commit: ["new cd command"](https://github.com/gesslar/oxidus-mudlib/commit/60b1ea4f948eef244480db8ea49b9e2eaa94a63e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44693875)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->