### PR TITLE
Fix `glob_to_regex` trailing `/**` to match bare directory nodes; add `valid_read` gate to `ls`

### DIFF
--- a/adm/etc/security/access.lpml
+++ b/adm/etc/security/access.lpml
@@ -2,8 +2,11 @@
 //
 // Ordered: the FIRST rule whose glob matches the target file decides.
 // Glob syntax: * matches within one path segment, ** matches the rest
-// (including further slashes). A per-MUD override lives in the git-ignored
-// access.local.lpml; its rules are checked BEFORE these.
+// (including further slashes). A trailing "/**" also matches the directory
+// node itself, so "/adm/**" covers a bare "/adm" as well as "/adm/foo" -
+// commands need not append a slash before checking a directory path. A
+// per-MUD override lives in the git-ignored access.local.lpml; its rules
+// are checked BEFORE these.
 //
 // Capabilities:
 //   all            - anyone

--- a/adm/obj/master/security.lpc
+++ b/adm/obj/master/security.lpc
@@ -699,8 +699,10 @@ private nomask void load_access() {
 /**
  * Translates a path glob into an anchored regex. '*' matches within a
  * single path segment (no slash); '**' matches the remainder of the path
- * (slashes included). Everything else is matched literally, with regex
- * metacharacters escaped.
+ * (slashes included). A trailing '/**' additionally matches the directory
+ * node itself, so '/adm/**' covers '/adm' as well as '/adm/foo' - callers
+ * pass a bare directory path without a trailing slash and still match.
+ * Everything else is matched literally, with regex metacharacters escaped.
  *
  * @param {string} pattern - The glob pattern.
  * @returns {string} An anchored regex equivalent.
@@ -708,6 +710,16 @@ private nomask void load_access() {
 private nomask string glob_to_regex(string pattern) {
   string re = "";
   int i, n = strlen(pattern);
+  int subtree = 0;
+
+  // Fold a trailing '/**' so the directory node matches too: '/adm/**'
+  // becomes ^/adm(/.*)?$, matching '/adm', '/adm/', and '/adm/foo' but not
+  // '/administrator'. The bare '/**' catch-all is left untouched.
+  if(n > 3 && pattern[<3..] == "/**") {
+    pattern = pattern[0..<4];
+    n = strlen(pattern);
+    subtree = 1;
+  }
 
   for(i = 0; i < n; i++) {
     int c = pattern[i];
@@ -726,6 +738,9 @@ private nomask string glob_to_regex(string pattern) {
       re += "\\" + pattern[i..i];
     }
   }
+
+  if(subtree)
+    re += "(/.*)?";
 
   return "^" + re + "$";
 }

--- a/cmds/file/ls.lpc
+++ b/cmds/file/ls.lpc
@@ -41,7 +41,15 @@ mixed main(
   string cwd = tp->query_env("cwd");
   string path = resolve_path(cwd, arg);
 
-  // An existing directory: list its contents.
+  // Gate on the wizard's own identity. get_dir()'s own valid_read (in
+  // perform_ls) runs as the command object - a developer - so it only
+  // bounds the tool's reach, not this player's; this is the real per-wizard
+  // check.
+  if(!master()->valid_read(path, tp, "ls"))
+    return _error(tp, "ls: %s: Permission denied.", arg);
+
+  // An existing directory: list its contents. The trailing slash is
+  // get_dir()'s "list inside the directory" form.
   if(directory_exists(path))
     return perform_ls(append(path, "/"), flags);
 
@@ -71,8 +79,10 @@ private mixed perform_ls(string target, string *flags) {
     });
   }
 
-  // get_dir() returns 0 (not an array) when valid_read denies the path;
-  // an existing, readable directory returns ({}) when it is merely empty.
+  // get_dir() returns 0 (not an array) when the driver's own valid_read
+  // denies the path (checked as this command - a developer - so this only
+  // bounds the tool; the per-wizard gate is in main()). An existing,
+  // readable directory returns ({}) when it is merely empty.
   mixed *entries = get_dir(target, -1);
 
   if(!pointerp(entries))


### PR DESCRIPTION
## Fix directory-path access checks for `ls` and glob patterns

### Problem

The `ls` command was missing a per-wizard `valid_read` check before listing a directory. The internal `get_dir()` call runs as the command object (a developer), meaning it only bounded the tool's own reach — not the calling wizard's permissions. A wizard could list directories they should not have access to.

Additionally, glob patterns using a trailing `/**` (e.g., `/adm/**`) did not match the bare directory path itself (`/adm`). This meant access rules intended to cover an entire subtree silently failed when a command passed a directory path without a trailing slash.

### Changes

- **`ls`**: Added an explicit `valid_read` check against the calling player (`tp`) before proceeding with directory listing, ensuring the wizard's own permissions are enforced independently of the driver-level check inside `perform_ls`.
- **`glob_to_regex`**: A trailing `/**` pattern is now folded so that the generated regex matches both the directory node itself and everything beneath it (e.g., `/adm/**` matches `/adm`, `/adm/`, and `/adm/foo`, but not `/administrator`). The bare `/**` catch-all is left unchanged.
- **`access.lpml`**: Updated the comment to document the new trailing `/**` directory-matching behavior so rule authors understand they do not need to add a separate entry for the directory node.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR tightens file-listing access checks and updates subtree glob matching.

- Adds a player-scoped `valid_read` gate to `ls`.
- Makes trailing `/**` patterns match their directory node.
- Documents the updated access-rule behavior.
</details>

<sub>Reviews (1): Last reviewed commit: ["sec fixes"](https://github.com/gesslar/oxidus-mudlib/commit/d3d7a3d035e6ed8a45fe9c99e6cdc06b070ace45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44696662)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->