### PR TITLE
Refactor `quit.lpc`: consolidate logout logic into `exit_world`, inherit shared `CMD_QUIT` for ghosts

### DIFF
--- a/cmds/ghost/quit.lpc
+++ b/cmds/ghost/quit.lpc
@@ -1,36 +1,15 @@
 /**
  * @file /cmds/ghost/quit.lpc
- * Quit command for ghosts to disconnect from the mud.
  *
- * @created 2005-04-06 - Tacitus
- * @last_modified 2005-10-08 - Tacitus
+ * Quit command for ghosts. Same deal as regular livings.
+ *
+ * @created 2026-07-16 - Gesslar
+ * @last_modified 2026-07-16 - Gesslar
  *
  * @history
- * 2005-04-06 - Tacitus - Created
+ * 2026-07-16 - Gesslar - Created
  */
 
-#include <logs.h>
+#include <commands.h>
 
-inherit STD_CMD;
-
-mixed main(/** @type {STD_BODY} */ object caller, string _arg) {
-  caller->exit_world();
-  tell(caller, "Thank you for visiting " + mud_name() + ".\n");
-  caller->save_body();
-  log_file(LOG_LOGIN,
-    capitalize(caller->query_real_name())
-    + " logged out from " + query_ip_number(caller)
-    + " on " + ctime(time()) + "\n"
-  );
-  destruct(caller);
-
-  return 1;
-}
-
-string query_help(object _caller) {
-  return
-"SYNTAX: quit\n\n"
-"This command will save your character and disconnect you "
-"from the mud.\n\n"
-"See also: save";
-}
+inherit CMD_QUIT;

--- a/cmds/std/quit.lpc
+++ b/cmds/std/quit.lpc
@@ -1,0 +1,22 @@
+/**
+ * @file /cmds/std/quit.lpc
+ *
+ * Command to log out of the gane,
+ *
+ * @created 2026-07-16 - Gesslar
+ * @last_modified 2026-07-16 - Gesslar
+ *
+ * @history
+ * 2026-07-16 - Gesslar - Created
+ */
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string _str
+) {
+  tell(caller, "Y'all come back, now, y'hear?\n");
+
+  caller->exit_world();
+
+  return 1;
+}

--- a/std/living/player.lpc
+++ b/std/living/player.lpc
@@ -90,8 +90,8 @@ void enter_world(int reconnecting) {
 }
 
 /**
- * Handles the player leaving the game world. Executes any
- * quit-file commands, saves the body, and notifies the room.
+ * Handles the player leaving the game world. Executes any quit-file commands,
+ * saves the body, and notifies the room.
  *
  * @public
  */
@@ -103,10 +103,7 @@ void exit_world() {
     return;
 
   if(file_size(home_path(query_real_name()) + ".quit") > 0) {
-    cmds = explode(read_file(home_path(query_real_name()) + ".quit"), "\n");
-
-    if(sizeof(cmds) <= 0)
-      return;
+    cmds = explode_file(home_path(query_real_name()) + ".quit");
 
     for(i = 0; i < sizeof(cmds); i ++)
       catch(command(cmds[i]));
@@ -115,9 +112,16 @@ void exit_world() {
   set_last_login(time());
 
   if(environment())
-    tell_them(query_name()+ " leaves " + mud_name() + ".\n");
+    tell_them(`${query_name()} leaves ${mud_name()}.\n`);
+
+  log_file(LOG_LOGIN,
+    `${ldatetime()} ${capitalize(query_real_name())} logged out from `
+    `${query_ip_number()}\n`
+  );
 
   save_body();
+
+  remove();
 }
 
 /**


### PR DESCRIPTION
The ghost `quit` command has been refactored to inherit from a new shared `CMD_QUIT` base, removing its own inline implementation. A new standard quit command has been created at `cmds/std/quit.lpc` that handles logout messaging and calls `exit_world()`.

The logout logic in `exit_world()` has been consolidated: logging out the player, saving the body, and calling `remove()` are now all handled within `exit_world()` itself rather than being spread across individual quit command implementations. The login log entry has also been moved into `exit_world()`, using template literals for formatting, so it is written consistently regardless of which quit path is taken. A redundant early-return check on the quit-file command list has been removed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes the quit lifecycle in `exit_world()`. The main changes are:

- Adds a shared standard quit command.
- Makes ghost quit inherit the shared command.
- Moves logout logging, saving, and removal into `exit_world()`.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Astd%2Fliving%2Fplayer.lpc%3A124%0A**Quit%20Drops%20Player%20Inventory**%0A%0AThe%20new%20standard%20%60quit%60%20command%20reaches%20this%20%60remove%28%29%60%20call%20for%20every%20normal%20player%20logout.%20%60remove%28%29%60%20runs%20the%20body's%20%60event_remove%60%20hook%2C%20which%20disperses%20non-%60prevent_drop%60%20inventory%20into%20the%20current%20room%3B%20quitting%20now%20leaves%20carried%20items%20available%20for%20other%20players%20to%20take%20after%20the%20body%20has%20been%20saved.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=320&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["new quit command"](https://github.com/gesslar/oxidus-mudlib/commit/6c67731bdebc42c93f89da3f286a642ab606e4e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44712077)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->