### PR TITLE
Add `pwd.lpc` file command

### DIFF
--- a/cmds/file/pwd.lpc
+++ b/cmds/file/pwd.lpc
@@ -1,0 +1,18 @@
+/**
+ * @file /cmds/file/pwd.lpc
+ *
+ * Command to print your current working directory.
+ *
+ * @created 2026-07-16 - Gesslar
+ * @last_modified 2026-07-16 - Gesslar
+ *
+ * @history
+ * 2026-07-16 - Gesslar - Created
+ */
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string _str
+) {
+  return `Current working directory: ${caller->query_env("cwd")}`;
+}


### PR DESCRIPTION
Adds a `pwd` command that displays the player's current working directory by reading their `cwd` environment variable.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a command for displaying the current working directory. The main change is:

- Adds `cmds/file/pwd.lpc` to return the caller's `cwd` environment value.
</details>

<sub>Reviews (2): Last reviewed commit: ["new pwd command"](https://github.com/gesslar/oxidus-mudlib/commit/82f8791e5c8859bf34ee61ce200996a72e60e083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44712079)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->