### PR TITLE
Add `save.lpc` std command

### DIFF
--- a/cmds/std/save.lpc
+++ b/cmds/std/save.lpc
@@ -1,0 +1,23 @@
+/**
+ * @file /cmds/std/save.lpc
+ *
+ * Command to (needlessly) save yourself.
+ *
+ * @created 2026-07-16 - Gesslar
+ * @last_modified 2026-07-16 - Gesslar
+ *
+ * @history
+ * 2026-07-16 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string _str
+) {
+  if(caller->save_body())
+    return "Saved.";
+
+  return "Could not save your data.";
+}


### PR DESCRIPTION
Adds a `save` command that allows players to manually trigger a save of their character data, returning a confirmation message on success or an error message on failure.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a standard command for players to save their character data. The main changes are:
- Adds `cmds/std/save.lpc`.
- Calls the player's existing `save_body()` method.
- Returns a success or failure message.
</details>

<sub>Reviews (2): Last reviewed commit: ["new save command"](https://github.com/gesslar/oxidus-mudlib/commit/87a0647320ee024c040979738de60b7e1a7d5bfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44712083)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->