### PR TITLE
Delegate `set_virtual_master` to modules; validate virtual master is set before returning result

### DIFF
--- a/adm/daemons/modules/virtual/ghost.lpc
+++ b/adm/daemons/modules/virtual/ghost.lpc
@@ -13,7 +13,6 @@
 inherit STD_DAEMON;
 
 public nomask object compile_object(string file) {
-  string name;
   object ob;
   string e;
   string type = query_file_name();
@@ -27,6 +26,8 @@ public nomask object compile_object(string file) {
     log_file("VIRTUAL", e);
     return 0;
   }
+
+  ob->set_virtual_master(STD_GHOST);
 
   return ob;
 }

--- a/adm/daemons/modules/virtual/ob.lpc
+++ b/adm/daemons/modules/virtual/ob.lpc
@@ -52,5 +52,7 @@ public nomask object compile_object(string file) {
     return 0;
   }
 
+  obj->set_virtual_master(base_file);
+
   return obj;
 }

--- a/adm/daemons/modules/virtual/storage.lpc
+++ b/adm/daemons/modules/virtual/storage.lpc
@@ -21,8 +21,7 @@
 
 inherit STD_DAEMON;
 
-public nomask object compile_object(string file) {
-  string name;
+public nomask object compile_object(string _file) {
   object ob;
   string e;
 
@@ -35,6 +34,8 @@ public nomask object compile_object(string file) {
 
   if(!ob)
     return 0;
+
+  ob->set_virtual_master(STD_STORAGE_OBJECT);
 
   return ob;
 }

--- a/adm/daemons/virtual.lpc
+++ b/adm/daemons/virtual.lpc
@@ -40,7 +40,13 @@ public nomask object compile_object(string file) {
         return 0;
       }
 
-      result->set_virtual_master(file + "." + extension);
+      if(!result->query_virtual_master()) {
+        result->remove();
+
+        log_file("VIRTUAL", `No virtual master set for ${file}.`);
+
+        return 0;
+      }
 
       return result;
     }
@@ -85,6 +91,14 @@ public nomask object compile_object(string file) {
       e = catch(result = call_other(module, "compile_object", file));
       if(e) {
         log_file("VIRTUAL", e);
+        return 0;
+      }
+
+      if(!result->query_virtual_master()) {
+        result->remove();
+
+        log_file("VIRTUAL", `No virtual master set for ${file}.`);
+
         return 0;
       }
 


### PR DESCRIPTION
The virtual master is now set within the module that handles object compilation (`ob.lpc`) rather than being assigned externally in `virtual.lpc` after the fact. This moves responsibility for setting the virtual master closer to where the object is created.

To enforce correctness, `virtual.lpc` now validates that the virtual master has been set after compilation. If it has not been set, the object is removed and an error is logged to the `VIRTUAL` log file, preventing partially initialized virtual objects from entering the game.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves virtual-master assignment into the modules that create virtual objects. The main changes are:

- Ghost, object, and storage modules now set their virtual master.
- The virtual compiler validates the master before returning an object.
- Invalid virtual objects are removed and logged.
</details>

<sub>Reviews (2): Last reviewed commit: ["fixies"](https://github.com/gesslar/oxidus-mudlib/commit/7b0bcfd52c7141ae15d9c1c1cfef61daf3aac250) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44857619)</sub>

**Context used:**

- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->