### PR TITLE
Add inventory object listing to `describe_environment` in `look.lpc`

### DIFF
--- a/cmds/action/look.lpc
+++ b/cmds/action/look.lpc
@@ -89,5 +89,25 @@ mixed describe_environment(
     result += `You may go ${simple_list(exits, "and")}.`;
   }
 
+  object *obs = all_inventory(env);
+  obs = filter(obs, (: $(tp)->can_see($1) :));
+  obs -= ({ tp });
+
+  object *non_livs = filter(obs, (: !living($1) :));
+  object *livs = filter(obs, (: living :));
+  obs = non_livs + livs;
+
+  string *shorts = map(obs, (: ob_short :));
+  shorts = filter(shorts, (: strlen :));
+
+  if(sizeof(shorts)) {
+    string obs_desc = implode(shorts, "\n") + "\n";
+
+    if(sizeof(result))
+      result += "\n\n";
+
+    result += obs_desc;
+  }
+
   return result;
 }


### PR DESCRIPTION
Add visible inventory objects to environment description

When looking at a room, objects and living beings present in the environment are now listed below the room description and exits. Non-living objects are displayed first, followed by living beings. Only objects visible to the player are included, and the player themselves is excluded from the list.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds visible inventory entries to room descriptions.

- Lists visible objects after the room description and exits.
- Places non-living objects before living beings.
- Excludes the viewing player and empty descriptions.
</details>

<sub>Reviews (4): Last reviewed commit: ["updating look to include objects"](https://github.com/gesslar/oxidus-mudlib/commit/fc26ac70e5744e6366f22d190fdfeb64cc5bcca1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44857634)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->