### PR TITLE
Rename `cmds/wiz/` to `cmds/dev/`; update paths and privileges from `[cmd_wiz]` to `[cmd_dev]`

### DIFF
--- a/.claude/skills/command-creation/SKILL.md
+++ b/.claude/skills/command-creation/SKILL.md
@@ -25,7 +25,7 @@ You are helping create or modify commands for Oxidus. Commands are LPC files tha
 | Directory | Purpose | Config File |
 |---|---|---|
 | `cmds/std/` | Standard player commands | `adm/etc/standard_paths` |
-| `cmds/wiz/` | Wizard/developer commands | `adm/etc/wizard_paths` |
+| `cmds/dev/` | Wizard/developer commands | `adm/etc/wizard_paths` |
 | `cmds/adm/` | Admin commands | `adm/etc/wizard_paths` |
 | `cmds/file/` | File-related commands | `adm/etc/wizard_paths` |
 | `cmds/object/` | Object manipulation commands | `adm/etc/wizard_paths` |
@@ -320,7 +320,7 @@ mixed main(object tp, string arg) {
 ## Complete Example: Wizard Command with _error/_ok
 
 ```lpc
-// /cmds/wiz/force.lpc
+// /cmds/dev/force.lpc
 
 inherit STD_CMD;
 

--- a/.claude/skills/mud-configuration/SKILL.md
+++ b/.claude/skills/mud-configuration/SKILL.md
@@ -46,7 +46,7 @@ int chance = mud_config("RESOURCE.GLOBAL_SPAWN_CHANCE");
 int chance = mud_config("RESOURCE")["GLOBAL_SPAWN_CHANCE"];
 ```
 
-### mudconfig command — `/cmds/wiz/mudconfig.lpc`
+### mudconfig command — `/cmds/dev/mudconfig.lpc`
 
 Wizard command that dumps all current configuration via `pretty_map()`. No arguments.
 

--- a/.claude/skills/mud-telnet/SKILL.md
+++ b/.claude/skills/mud-telnet/SKILL.md
@@ -114,7 +114,7 @@ greppable output. With it off, `_ok` etc. print just the bare message.
 **Precede every in-game command with the `claude` command**, e.g.
 `claude updating the score command`. This writes a timestamped line to the
 `claude` log (`/log/claude`) and pings any online admin so they can watch
-the session in real time. It's a `cmds/wiz/` command, so it requires the
+the session in real time. It's a `cmds/dev/` command, so it requires the
 dev/wiz access the `claude` character already has.
 
 ```text

--- a/.claude/skills/signal-system/SKILL.md
+++ b/.claude/skills/signal-system/SKILL.md
@@ -203,7 +203,7 @@ All defined in `include/signal.h`. String-based identifiers with category prefix
 | `SIG_PLAYER_DIED` | `"player:died"` | `std/living/body.lpc` | (object player, object killer) | Player death |
 | `SIG_PLAYER_REVIVED` | `"player:revived"` | `std/living/ghost.lpc` | (object player) | Player revival |
 | `SIG_PLAYER_ADVANCED` | `"player:advanced"` | `adm/daemons/advance.lpc` | (object player, mixed level) | Level up |
-| `SIG_USER_ENV_CHANGED` | `"player:env-changed"` | `cmds/wiz/env.lpc` | (object user, string var, string val) | Env variable changed |
+| `SIG_USER_ENV_CHANGED` | `"player:env-changed"` | `cmds/dev/env.lpc` | (object user, string var, string val) | Env variable changed |
 | `SIG_USER_PREF_CHANGED` | `"player:pref-changed"` | `cmds/std/set.lpc` | (object user, string pref, string val) | Preference changed |
 
 Note: `SIG_USER_ENV_CHANGED` and `SIG_USER_PREF_CHANGED` use the `SIG_PLAYER` prefix despite having `SIG_USER` names.

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -25,7 +25,7 @@ Follow `/lpc-coding-style` for all formatting.
 | `/std/test/test.lpc` | `STD_TEST` — base for individual test files |
 | `/std/test/runner.lpc` | `STD_TEST_RUNNER` — base for area runners |
 | `/include/test.h` | Assertion macros (system include: `#include <test.h>`) |
-| `/cmds/wiz/runtests.lpc` | The `runtests` wizard command |
+| `/cmds/dev/runtests.lpc` | The `runtests` wizard command |
 
 `STD_TEST` is defined in `mudlib.h` (auto-included via `global.h`); same for `STD_TEST_RUNNER`.
 

--- a/adm/etc/security/groups_base.lpml
+++ b/adm/etc/security/groups_base.lpml
@@ -6,7 +6,7 @@
       "runtests"
     ],
     members: [
-      "[cmd_wiz]",
+      "[cmd_dev]",
       "[cmd_file]",
       "[cmd_object]",
     ],

--- a/adm/etc/wizard_paths
+++ b/adm/etc/wizard_paths
@@ -1,4 +1,4 @@
-/cmds/wiz/
+/cmds/dev/
 /cmds/object/
 /cmds/file/
 /cmds/adm/

--- a/adm/obj/master.lpc
+++ b/adm/obj/master.lpc
@@ -357,7 +357,7 @@ string privs_file(string filename) {
   if(sscanf(filename, "/cmds/adm/%s", temp)) return "[cmd_adm]";
   if(sscanf(filename, "/cmds/file/%s", temp)) return "[cmd_file]";
   if(sscanf(filename, "/cmds/object/%s", temp)) return "[cmd_object]";
-  if(sscanf(filename, "/cmds/wiz/%s", temp))return "[cmd_wiz]";
+  if(sscanf(filename, "/cmds/dev/%s", temp))return "[cmd_dev]";
   if(sscanf(filename, "/home/%*s/%s/%*s", temp)) return "[home_" + temp + "]";
   if(sscanf(filename, "/open/%s", temp)) return "[open]";
   if(sscanf(filename, "/std/%s", temp)) return "[std_object]";

--- a/adm/simul_efun/existence.lpc
+++ b/adm/simul_efun/existence.lpc
@@ -51,8 +51,8 @@ int file_exists(string file) {
  * @param {string} file - Base path of LPC file, with or without extension
  * @returns {int} 1 if source file exists, 0 otherwise
  * @example
- * if(cfile_exists("/cmds/wiz/update")) {
- *     compile_object("/cmds/wiz/update");
+ * if(cfile_exists("/cmds/dev/update")) {
+ *     compile_object("/cmds/dev/update");
  * }
  */
 int cfile_exists(string file) {

--- a/cmds/action/go.lpc
+++ b/cmds/action/go.lpc
@@ -63,7 +63,7 @@ mixed main(
   MOVE_D->pre_walk_direction(tp, room, arg);
   MOVE_D->post_walk_direction(tp, dest, arg);
 
-  if(!wizardp(tp))
+  if(!devp(tp))
     tp->adjust_mp(-cost);
 
   return 1;

--- a/cmds/dev/alarm.lpc
+++ b/cmds/dev/alarm.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/alarm.lpc
+ * @file /cmds/dev/alarm.lpc
  *
  * Command to inspect, add, remove, and rehash alarms registered with
  * the central alarm daemon.

--- a/cmds/dev/back.lpc
+++ b/cmds/dev/back.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/back.lpc
+ * @file /cmds/dev/back.lpc
  * Return to your previous location.
  *
  * @created 2024-09-09 - Gesslar

--- a/cmds/dev/claude.lpc
+++ b/cmds/dev/claude.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/claude.lpc
+ * @file /cmds/dev/claude.lpc
  *
  * Activity-logging command for automated Claude agent sessions. Records
  * a timestamped, one-line description of what the agent is about to do

--- a/cmds/dev/dlevel.lpc
+++ b/cmds/dev/dlevel.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/dlevel.lpc
+ * @file /cmds/dev/dlevel.lpc
  * Manages debug levels
  *
  * @created 2024-07-20 - Gesslar

--- a/cmds/dev/do.lpc
+++ b/cmds/dev/do.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/do.lpc
+ * @file /cmds/dev/do.lpc
  * do command to execute a number of commands and/or repeatedly
  *
  * @created 2024-07-13 - Gesslar

--- a/cmds/dev/echo.lpc
+++ b/cmds/dev/echo.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/echo.lpc
+ * @file /cmds/dev/echo.lpc
  *
  * A command to echo a message to a room.
  *

--- a/cmds/dev/env.lpc
+++ b/cmds/dev/env.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/env.lpc
+ * @file /cmds/dev/env.lpc
  * Manage environment settings for a wizard.
  *
  * @created 2024-08-17 - Gesslar

--- a/cmds/dev/eval.lpc
+++ b/cmds/dev/eval.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/eval.lpc
+ * @file /cmds/dev/eval.lpc
  *
  * Evaluate a string by first writing it to a temp file and then compiling and
  * executing it.
@@ -31,7 +31,7 @@ mixed main(/** @type {STD_PLAYER} */ object caller, string arg) {
   _info(caller, "Evaluating: %s", arg);
 
   // Compile the snippet from a scratch file under /tmp, which the path-access
-  // table makes world-writable. The command's identity ([cmd_wiz]) can't
+  // table makes world-writable. The command's identity ([cmd_dev]) can't
   // write into a wizard's home, but it can write here. One file per caller so
   // concurrent evals don't collide.
   file = "/tmp/eval_" + caller->query_real_name() + ".lpc";

--- a/cmds/dev/exits.lpc
+++ b/cmds/dev/exits.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/exits.lpc
+ * @file /cmds/dev/exits.lpc
  * Shows all the exits in the current room and where they lead.
  *
  * @created 2024-02-04 - Gesslar

--- a/cmds/dev/force.lpc
+++ b/cmds/dev/force.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/force.lpc
+ * @file /cmds/dev/force.lpc
  *
  * Developer force command. Forces a living object to execute a command as
  * if they had typed it themselves.

--- a/cmds/dev/gauge.lpc
+++ b/cmds/dev/gauge.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/gauge.lpc
+ * @file /cmds/dev/gauge.lpc
  *
  * Executes a command and reports how much CPU time it consumed.
  *

--- a/cmds/dev/gimme.lpc
+++ b/cmds/dev/gimme.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/gimme.lpc
+ * @file /cmds/dev/gimme.lpc
  * Command to give coins to the wizard
  *
  * @created 2024-08-01 - Gesslar

--- a/cmds/dev/gr.lpc
+++ b/cmds/dev/gr.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/gr.lpc
+ * @file /cmds/dev/gr.lpc
  * Grapevine command
  *
  * @created 2024-07-18 - Gesslar

--- a/cmds/dev/halt.lpc
+++ b/cmds/dev/halt.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/halt.lpc
+ * @file /cmds/dev/halt.lpc
  *
  * Halts ongoing combat for one or more livings.
  *

--- a/cmds/dev/hb.lpc
+++ b/cmds/dev/hb.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/hb.lpc
+ * @file /cmds/dev/hb.lpc
  *
  * Reports heartbeat status for a specific object or for all livings.
  *

--- a/cmds/dev/healup.lpc
+++ b/cmds/dev/healup.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/healup.lpc
+ * @file /cmds/dev/healup.lpc
  * Command for wizards to heal themselves and others.
  *
  * @created 2024-07-31 - Gesslar

--- a/cmds/dev/killme.lpc
+++ b/cmds/dev/killme.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/killme.lpc
+ * @file /cmds/dev/killme.lpc
  * This command commands all NPCs in a room to attack you. It
  * does not change their current target if they are already
  * attacking someone else.

--- a/cmds/dev/mgenerate.lpc
+++ b/cmds/dev/mgenerate.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/mgenerate.lpc
+ * @file /cmds/dev/mgenerate.lpc
  * Generates an area map file.
  *
  * @created 2024-07-24 - Gesslar

--- a/cmds/dev/mudconfig.lpc
+++ b/cmds/dev/mudconfig.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/mudconfig.lpc
+ * @file /cmds/dev/mudconfig.lpc
  *
  * Lists all MUD configuration options available to the mud_config() sefun.
  *

--- a/cmds/dev/mudinfo.lpc
+++ b/cmds/dev/mudinfo.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/mudinfo.lpc
+ * @file /cmds/dev/mudinfo.lpc
  *
  * Displays runtime statistics about the running mud.
  *

--- a/cmds/dev/mupdate.lpc
+++ b/cmds/dev/mupdate.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/mupdate.lpc
+ * @file /cmds/dev/mupdate.lpc
  * This command will cause the caller to be moved around
  * all coordinates in order to generate a new Mudlet map.
  *

--- a/cmds/dev/reset.lpc
+++ b/cmds/dev/reset.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/reset.lpc
+ * @file /cmds/dev/reset.lpc
  * Resets a target object
  *
  * @created 2024-07-23 - Gesslar

--- a/cmds/dev/runtests.lpc
+++ b/cmds/dev/runtests.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/runtests.lpc
+ * @file /cmds/dev/runtests.lpc
  *
  * Run unit tests under /tests/. With no argument, walks /tests/
  * recursively and invokes every runner.lpc found. With an argument,

--- a/cmds/dev/sc.lpc
+++ b/cmds/dev/sc.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/sc.lpc
+ * @file /cmds/dev/sc.lpc
  * Deep scan
  *
  * @created 2024-07-28 - Gesslar

--- a/cmds/dev/ss.lpc
+++ b/cmds/dev/ss.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/ss.lpc
+ * @file /cmds/dev/ss.lpc
  * Shallow scan
  *
  * @created 2024-07-28 - Gesslar

--- a/cmds/dev/summon.lpc
+++ b/cmds/dev/summon.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/summon.lpc
+ * @file /cmds/dev/summon.lpc
  * Command to summon a player to your location.
  *
  * @created 2024-08-17 - Gesslar

--- a/cmds/dev/todo.lpc
+++ b/cmds/dev/todo.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/todo.lpc
+ * @file /cmds/dev/todo.lpc
  * Command for reporting todos
  *
  * @created 2024-07-13 - Gesslar

--- a/cmds/dev/touch.lpc
+++ b/cmds/dev/touch.lpc
@@ -1,5 +1,5 @@
 /**
- * @file /cmds/wiz/touch.lpc
+ * @file /cmds/dev/touch.lpc
  * This command allows a wizard to create a new empty file.
  *
  * @created 2024-08-10 - Gesslar

--- a/doc/sefun/cfile_exists.help
+++ b/doc/sefun/cfile_exists.help
@@ -29,6 +29,6 @@
 
 ### EXAMPLE
 
-    {{di1}}if(cfile_exists("/cmds/wiz/update")) {
-        compile_object("/cmds/wiz/update");
+    {{di1}}if(cfile_exists("/cmds/dev/update")) {
+        compile_object("/cmds/dev/update");
     }{{di0}}

--- a/doc/wiki/src/content/docs/systems/alarm.md
+++ b/doc/wiki/src/content/docs/systems/alarm.md
@@ -74,6 +74,6 @@ After editing alarm files, rebuild the live list with the `alarm` wizard command
 | File | Role |
 |---|---|
 | `adm/daemons/alarm.c` | `ALARM_D` -- parsing, scheduling, dispatch, persistence |
-| `cmds/wiz/alarm.c` | `alarm` wizard command -- list, add, and reload alarms |
+| `cmds/dev/alarm.c` | `alarm` wizard command -- list, add, and reload alarms |
 | `adm/etc/alarms/` | Default `ALARMS_PATH` -- alarm definition files |
 | `adm/etc/alarms/alarm.txt.example` | Annotated example alarm file |

--- a/doc/wiki/src/content/docs/systems/config.md
+++ b/doc/wiki/src/content/docs/systems/config.md
@@ -88,4 +88,4 @@ This system covers *library* configuration. Driver-level settings -- ports, stac
 | `adm/simul_efun/system.c` | `mud_config()` simul_efun |
 | `adm/etc/default.lpml` | Shipped default settings |
 | `adm/etc/config.lpml` | Local overrides (not tracked) |
-| `cmds/wiz/mudconfig.c` | `mudconfig` command -- dumps current config |
+| `cmds/dev/mudconfig.c` | `mudconfig` command -- dumps current config |

--- a/std/living/body.lpc
+++ b/std/living/body.lpc
@@ -52,7 +52,7 @@ void mudlib_setup() {
 
   enable_commands();
   add_standard_paths();
-  if(wizardp())
+  if(devp())
     add_wizard_path();
 
   if(!query_pref("prompt"))


### PR DESCRIPTION
Rename `cmds/wiz/` to `cmds/dev/` and update the associated privilege token from `[cmd_wiz]` to `[cmd_dev]` throughout the codebase.

All wizard/developer commands have been moved from `/cmds/wiz/` to `/cmds/dev/` to better reflect their purpose. The corresponding changes update `adm/etc/wizard_paths` to point to the new directory, the `privs_file` mapping in `adm/obj/master.lpc` to assign the `[cmd_dev]` privilege token, and the security group membership in `adm/etc/security/groups_base.lpml`. Documentation, skill guides, doc pages, and inline code comments referencing the old path or token have been updated to match.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR renames the developer command area and its privilege token. The main changes are:

- Moves commands from `cmds/wiz/` to `cmds/dev/`.
- Updates command path configuration and privilege mapping.
- Replaces `[cmd_wiz]` group membership with `[cmd_dev]`.
- Updates related source comments and documentation.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aadm%2Fetc%2Fwizard_paths%3A1%0A**Active%20Bodies%20Keep%20Old%20Paths**%0A%0A%60mudlib_setup%28%29%60%20reads%20this%20file%20only%20when%20%60BODY_D%60%20creates%20a%20body%20and%20stores%20the%20paths%20on%20that%20body.%20A%20developer%20already%20connected%20when%20this%20update%20is%20deployed%20keeps%20%60%2Fcmds%2Fwiz%2F%60%20in%20its%20command%20path%20after%20the%20directory%20is%20removed%2C%20so%20command%20lookup%20no%20longer%20finds%20developer%20commands%20until%20that%20body%20is%20recreated.%20Refresh%20existing%20developer%20bodies'%20wizard%20paths%20as%20part%20of%20this%20migration.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=327&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["moving wiz to dev"](https://github.com/gesslar/oxidus-mudlib/commit/14b68f797dbe663c366acf18f188464b57a10f71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44928398)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->