### PR TITLE
Pass `file_name()` of virtual room object to `reload_it` in `update.lpc`

### DIFF
--- a/cmds/object/update.lpc
+++ b/cmds/object/update.lpc
@@ -155,7 +155,7 @@ private nomask mixed perform_update(object tp, mapping target) {
 
   if(target.virtual && objectp(target["object"])) {
     if(roomp(target["object"])) {
-      reload_it(target["object"]);
+      reload_it(file_name(target["object"]));
     }
   }
 


### PR DESCRIPTION
Fixes a bug in `perform_update` where `reload_it` was being called with the object reference directly instead of its file name when handling virtual rooms. This ensures the correct string argument is passed to `reload_it` during a virtual room update.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the virtual-room reload argument in the update command.

- Passes the room's file name to `reload_it`.
- Replaces the previous object-reference argument.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acmds%2Fobject%2Fupdate.lpc%3A158%0A**Clone%20Suffix%20Cannot%20Reload**%0A%0AVirtual%20rooms%20created%20as%20clones%20have%20a%20%60file_name%28%29%60%20ending%20in%20%60%23N%60.%20%60reload_it%28%29%60%20passes%20this%20same%20value%20to%20%60load_object%28%29%60%2C%20which%20requires%20the%20loadable%20master%20path%3A%20the%20room%20is%20removed%20and%20destructed%20after%20%60find_object%28%29%60%20succeeds%2C%20then%20fails%20to%20reload.%20Updating%20one%20of%20these%20rooms%20leaves%20its%20occupants%20without%20a%20recreated%20room.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=328&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix update command to know about virtual..."](https://github.com/gesslar/oxidus-mudlib/commit/49aee891786c5a172261f5c9c28da27b2de702c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44984580)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->