### PR TITLE
Add `get.lpc`, `drop.lpc`, and `inventory.lpc` action/std commands

### DIFF
--- a/cmds/action/drop.lpc
+++ b/cmds/action/drop.lpc
@@ -1,0 +1,37 @@
+/**
+ * @file /cmds/action/drop.lpc
+ *
+ * The drop command.
+ *
+ * @created 2026-07-16 - Gesslar
+ * @last_modified 2026-07-16 - Gesslar
+ *
+ * @history
+ * 2026-07-16 - Gesslar - Created
+ */
+
+inherit STD_ACT;
+
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string arg
+) {
+  if(!arg)
+    return "Drop what?";
+
+  /** @type {STD_ITEM} */ object ob = get_object(arg);
+  if(   !ob
+     || !present(ob, tp)
+     || !tp->can_see(ob))
+    return "You do not posses that.";
+
+  if(call_if(ob, "prevent_drop", tp))
+    return "You cannot drop that.";
+
+  if(ob->move(environment(tp)))
+    return "You could not drop that.";
+
+  tp->simple_action("$N $vdrop a $o.", ob);
+
+  return 1;
+}

--- a/cmds/action/get.lpc
+++ b/cmds/action/get.lpc
@@ -1,0 +1,63 @@
+/**
+ * @file /cmds/std/get.lpc
+ *
+ * The get command. Picks things up and out of containers.
+ *
+ * @created 2026-07-16 - Gesslar
+ * @last_modified 2026-07-16 - Gesslar
+ *
+ * @history
+ * 2026-07-16 - Gesslar - Created
+ */
+
+inherit STD_ACT;
+
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string arg
+) {
+  if(!arg)
+    return "Get what?";
+
+  /** @type {STD_ROOM|STD_CONTAINER} */ object env;
+  string ob_id, env_id;
+
+  if(sscanf(arg, "%s from %s", ob_id, env_id) == 2) {
+    env = get_object(env_id);
+    if(  !env
+      || (!present(env, tp) && !present(env, environment(tp)))
+      || !tp->can_see(env)
+    )
+      return `You do not possess ${env_id}.`;
+  } else {
+    ob_id = arg;
+    env = environment(tp);
+  }
+
+  if(!env->is_container())
+    return `${/** @type {STD_ITEM} */ (env)->query_short()} is not a container.`;
+
+  if(env->is_closed())
+    return `The ${/** @type {STD_ITEM} */ (env)->query_short()} is closed.`;
+
+  /** @type {STD_ITEM} */ object ob = present(ob_id, env);
+  if(    !ob
+      || !tp->can_see(ob)
+    ) {
+    return `You do not see ${ob_id}.`;
+  }
+
+  if(call_if(ob, "prevent_get", tp))
+    return 1;
+
+  if(ob->move(tp))
+    return `You could not get the ${ob->query_short()}.`;
+
+  if(env == environment(tp)) {
+    tp->simple_action("$N $vpick up a $o.", ob);
+  } else {
+    tp->simple_action("$N $vget a $o from a $o1.", ob, env);
+  }
+
+  return 1;
+}

--- a/cmds/std/inventory.lpc
+++ b/cmds/std/inventory.lpc
@@ -1,0 +1,33 @@
+/**
+ * @file /cmds/std/inventory.lpc
+ *
+ * Command to list your inventory.
+ *
+ * @created 2026-07-16 - Gesslar
+ * @last_modified 2026-07-16 - Gesslar
+ *
+ * @history
+ * 2026-07-16 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string _arg
+) {
+  object *obs = all_inventory(tp);
+  obs = filter(obs, (: $(tp)->can_see($1) :));
+
+  string *shorts = map(obs, (: ob_short :));
+  shorts = filter(shorts, (: strlen :));
+  shorts = map(shorts, (: `  ${$1}` :));
+
+  string *result =
+      ({ "You are carrying:", "" })
+    + shorts
+    + ({ "", `Capacity: ${tp->query_fill()}/${tp->query_capacity()}` })
+    ;
+
+  return result;
+}


### PR DESCRIPTION
Adds `get`, `drop`, and `inventory` commands to support basic item interaction.

- `get` allows picking up items from the environment or from a container using `get <item> from <container>` syntax, with checks for container state, visibility, and move prevention
- `drop` allows placing carried items into the current environment, with visibility and move prevention checks
- `inventory` lists carried items visible to the player along with current capacity usage

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds basic item interaction commands. The main changes are:

- Adds `get` for room and container items.
- Adds `drop` for carried items.
- Adds `inventory` with visible items and capacity.
</details>

<sub>Reviews (3): Last reviewed commit: ["new commands"](https://github.com/gesslar/oxidus-mudlib/commit/ecb06841b23641c40ae7734585512c58c6413f96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44984583)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))

<!-- /greptile_comment -->