### PR TITLE
Add `cat.lpc` file command

### DIFF
--- a/cmds/file/cat.lpc
+++ b/cmds/file/cat.lpc
@@ -1,0 +1,60 @@
+/**
+ * @file /cmds/file/cat.lpc
+ *
+ * Command to print the entire contents of a file.
+ *
+ * @created 2026-07-17 - Gesslar
+ * @last_modified 2026-07-17 - Gesslar
+ *
+ * @history
+ * 2026-07-17 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text = "cat <file>";
+  help_text =
+    "This command prints the entire contents of a specified file directly to "
+    "your screen, without paging.\n"
+    "\n"
+    "See also: more, tail";
+}
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  if(!str)
+    return _usage(caller);
+
+  string file = resolve_path(caller->query_env("cwd"), str);
+
+  if(!master()->valid_read(file, caller, "cat"))
+    return _error(caller, "Permission denied.");
+
+  if(directory_exists(file))
+    return _error(caller, "%s is a directory.", file);
+
+  if(!file_exists(file))
+    return _error(caller, "No such file: %s", file);
+
+  if(file_size(file) > get_config(__MAX_READ_FILE_SIZE__))
+    return _error(caller, "%s is too large to read.", file);
+
+  if(file_size(file) > get_config(__MAX_STRING_LENGTH__))
+    return _error(caller, "%s is too large to display.", file);
+
+  if(file_size(file) > __LARGEST_PRINTABLE_STRING__)
+    return _error(caller, "%s is too large to display; use more instead.", file);
+
+  string contents = read_file(file);
+  if(nullp(contents))
+    return _error(caller, "Could not read file: %s", file);
+
+
+  caller->set_env("cwf", file);
+
+  tell(caller, append(contents, "\n"));
+  return 1;
+}


### PR DESCRIPTION
Adds a `cat` command that prints the entire contents of a file directly to the caller's screen without paging. The command resolves the file path relative to the caller's current working directory and performs validation checks for directories, missing files, read permissions, and file size limits before outputting the contents. Upon success, it updates the caller's current working file environment variable.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `cat` command for printing file contents directly to the caller.

- Resolves paths from the caller's working directory.
- Validates read access, file type, existence, and size limits.
- Updates the caller's current working file after a successful read.
</details>

<sub>Reviews (2): Last reviewed commit: ["cat"](https://github.com/gesslar/oxidus-mudlib/commit/fbd6a157de69f80164d9f7347950b1f6567d7fd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45002853)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->