### PR TITLE
Add `rm.lpc` file command

### DIFF
--- a/cmds/file/rm.lpc
+++ b/cmds/file/rm.lpc
@@ -1,0 +1,48 @@
+/**
+ * @file /cmds/file/rm.lpc
+ *
+ * Command to remove a file.
+ *
+ * @created 2026-07-17 - Gesslar
+ * @last_modified 2026-07-17 - Gesslar
+ *
+ * @history
+ * 2026-07-17 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text = "rm <file>";
+  help_text =
+    "This command permanently removes a specified file. It will not remove a "
+    "directory; use rmdir for that.\n"
+    "\n"
+    "You may use an absolute or relative path.";
+}
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  if(!str)
+    return _usage(caller);
+
+  string cwd = caller->query_env("cwd");
+  string path = resolve_path(cwd, str);
+
+  if(!master()->valid_write(path, caller, "rm"))
+    return _error(caller, "Permission denied.");
+
+  if(directory_exists(path))
+    return _error(caller, "%s is a directory.", path);
+
+  if(!file_exists(path))
+    return _error(caller, "No such file: %s", path);
+
+  int result = rm(path);
+  if(result)
+    return _ok(caller, "File removed: %s", path);
+  else
+    return _error(caller, "Could not remove file: %s", path);
+}


### PR DESCRIPTION
Adds a new `rm` command that allows players to remove files from the filesystem. The command resolves both absolute and relative paths, validates that the target exists and is not a directory (directing users to `rmdir` for that purpose), and checks write permissions before attempting removal. Returns appropriate success or error messages based on the outcome.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a wizard `rm` command for deleting files.

- Resolves absolute and relative file paths.
- Checks write access before removal.
- Rejects directories and missing files.
- Reports removal success or failure.
</details>

<sub>Reviews (4): Last reviewed commit: ["rm command"](https://github.com/gesslar/oxidus-mudlib/commit/f8ee7b36a5cec0085f2b933d50257d8c1fb919e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45002856)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->