### PR TITLE
Add `more.lpc` file command

### DIFF
--- a/cmds/file/more.lpc
+++ b/cmds/file/more.lpc
@@ -1,0 +1,58 @@
+/**
+ * @file /cmds/file/more.lpc
+ *
+ * Command to page through the contents of a file.
+ *
+ * @created 2026-07-17 - Gesslar
+ * @last_modified 2026-07-17 - Gesslar
+ *
+ * @history
+ * 2026-07-17 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text = "more <file>";
+  help_text =
+    "This command displays the contents of a specified file one page at a "
+    "time, using the pager.\n"
+    "\n"
+    "See also: cat, tail";
+}
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  if(!str)
+    return _usage(caller);
+
+  string file = resolve_path(caller->query_env("cwd"), str);
+
+  if(!master()->valid_read(file, caller, "more"))
+    return _error(caller, "Permission denied.");
+
+  if(directory_exists(file))
+    return _error(caller, "%s is a directory.", file);
+
+  if(!file_exists(file))
+    return _error(caller, "No such file: %s", file);
+
+  if(file_size(file) > get_config(__MAX_READ_FILE_SIZE__))
+    return _error(caller, "%s is too large to read.", file);
+
+  if(file_size(file) > get_config(__MAX_STRING_LENGTH__))
+    return _error(caller, "%s is too large to read.", file);
+
+  string contents = read_file(file);
+  if(nullp(contents))
+    return _error(caller, "Could not read file: %s", file);
+
+  string *out = explode(contents, "\n");
+  out = ({ "=== " + file + " ===" }) + out;
+
+  caller->set_env("cwf", file);
+
+  return out;
+}


### PR DESCRIPTION
Adds a `more` command that allows users to page through the contents of a file using the pager. The command resolves the file path relative to the caller's current working directory, performs validation checks (directory, existence, read permissions, file size), and displays the file contents with a header showing the file path. It also sets the `cwf` environment variable to the viewed file upon success.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `more` command for paging file contents.

- Resolves paths from the caller's working directory.
- Checks read access before file metadata checks.
- Enforces file and string size limits before paging.
- Records the viewed file in `cwf`.
</details>

<sub>Reviews (3): Last reviewed commit: ["more command"](https://github.com/gesslar/oxidus-mudlib/commit/bdc018aa3158137dc8431f2ff1ec745843fff921) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45002859)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->