### PR TITLE
Add `goto.lpc` dev command

### DIFF
--- a/cmds/dev/goto.lpc
+++ b/cmds/dev/goto.lpc
@@ -1,0 +1,51 @@
+/**
+ * @file /cmds/dev/goto.lpc
+ *
+ * Command to move to the location of an object.
+ *
+ * @created 2026-07-17 - Gesslar
+ * @last_modified 2026-07-17 - Gesslar
+ *
+ * @history
+ * 2026-07-17 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text = "goto <object>";
+  help_text =
+    "Moves you to the top-level environment of the object you name. The "
+    "object may be a room path, a player, an NPC, or anything else that "
+    "get_object() can resolve. If you name a room, you are taken to that "
+    "room; otherwise you are taken to wherever that object currently is.";
+}
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  if(!str)
+    return _usage(caller);
+
+  /** @type {STD_OBJECT} */ object ob = get_object(str, caller);
+
+  if(!ob)
+    return _error(caller, "Could not find: %s", str);
+
+  /** @type {STD_ROOM} */ object dest = top_environment(ob);
+
+  if(!dest)
+    return _error(caller, "Could not determine a destination for %s.", str);
+
+  int result = caller->move_living(dest);
+
+  if(result == MOVE_ALREADY_THERE)
+    return "You are already there.";
+
+  if(result)
+    return _error(caller, "Could not move there.\nReason: %s",
+      MOVE_REASON[result]);
+
+  return "You go to " + dest->query_short() + ".";
+}


### PR DESCRIPTION
Adds a `goto` developer command that teleports the caller to the top-level environment of a named object. The target can be a room path, player, NPC, or any object resolvable by `get_object()`. If the target is a room, the caller is moved there directly; otherwise they are moved to wherever that object currently resides. Handles edge cases including an unresolvable target, no valid destination environment, already being at the destination, and movement failures with a reason code.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a developer command for teleporting to an object's location. The main changes are:

- Adds `cmds/dev/goto.lpc`.
- Resolves room, player, NPC, and object targets.
- Reports unavailable targets and movement results.
</details>

<sub>Reviews (2): Last reviewed commit: ["goto command"](https://github.com/gesslar/oxidus-mudlib/commit/aab303bb7699b1a31d9efb93766cbbca42cb22ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45138052)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->