### PR TITLE
Add `home.lpc` dev command to teleport to workrooms

### DIFF
--- a/cmds/dev/home.lpc
+++ b/cmds/dev/home.lpc
@@ -1,0 +1,56 @@
+/**
+ * @file /cmds/dev/home.lpc
+ *
+ * Command to move to your own workroom, or another developer's workroom.
+ *
+ * @created 2026-07-17 - Gesslar
+ * @last_modified 2026-07-17 - Gesslar
+ *
+ * @history
+ * 2026-07-17 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text =
+    "home\n"
+    "home <user>";
+  help_text =
+    "With no argument, moves you to your own workroom. With a <user> "
+    "argument, moves you to that user's workroom instead.";
+}
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  string name;
+
+  if(str)
+    name = lower_case(str);
+  else
+    name = caller->query_real_name();
+
+  if(!user_exists(name))
+    return _error(caller, "No such user: %s", name);
+
+  string path = home_path(name) + "workroom";
+
+  /** @type {STD_ROOM} */ object room;
+  string err = catch(room = load_object(path));
+
+  if(err || !room)
+    return _error(caller, "Could not load %s's workroom.", capitalize(name));
+
+  int result = caller->move_living(room);
+
+  if(result == MOVE_ALREADY_THERE)
+    return "You are already there.";
+
+  if(result)
+    return _error(caller, "Could not move to %s's workroom.\nReason: %s",
+      capitalize(name), MOVE_REASON[result]);
+
+  return "You go to " + room->query_short() + ".";
+}


### PR DESCRIPTION
Adds a `home` command for developers that teleports them to their own workroom when used without arguments, or to another user's workroom when a username is provided. Includes validation for user existence and workroom availability, with appropriate error messages if the target user does not exist, the workroom cannot be loaded, or the move fails.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a developer `home` command for workroom travel. The main changes are:

- Resolve the caller's or a named user's workroom.
- Validate user and workroom availability.
- Report movement failures and successful travel.
</details>

<sub>Reviews (2): Last reviewed commit: ["home command"](https://github.com/gesslar/oxidus-mudlib/commit/d4a89ef712943c78bb7289ca126aa8a3eafe86a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45138059)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->