### PR TITLE
Add `log.lpc` dev command

### DIFF
--- a/cmds/dev/log.lpc
+++ b/cmds/dev/log.lpc
@@ -1,0 +1,58 @@
+/**
+ * @file /cmds/dev/log.lpc
+ *
+ * Command to display the tail end of a log file.
+ *
+ * @created 2026-07-17 - Gesslar
+ * @last_modified 2026-07-17 - Gesslar
+ *
+ * @history
+ * 2026-07-17 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text = "log <file>";
+  help_text =
+    "This command shows the last few lines of a log file, like tail. The "
+    "number of lines shown is determined by your 'morelines' preference.\n"
+    "\n"
+    "If <file> does not begin with a slash, it is looked up relative to the "
+    "log directory (" + log_dir() + "). Otherwise it is treated as an "
+    "absolute path.\n"
+    "\n"
+    "See also: more, cat";
+}
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  if(!str)
+    return _usage(caller);
+
+  string file;
+
+  if(str[0] == '/')
+    file = resolve_path(caller->query_env("cwd"), str);
+  else
+    file = log_dir() + str;
+
+  if(!master()->valid_read(file, caller, "log"))
+    return _error(caller, "Permission denied.");
+
+  if(directory_exists(file))
+    return _error(caller, "%s is a directory.", file);
+
+  if(!file_exists(file))
+    return _error(caller, "No such file: %s", file);
+
+  int lines = to_int(caller->query_pref("morelines")) || mud_config("MORELINES");
+
+  string contents = tail(file, lines);
+  if(falsy(contents))
+    return _error(caller, "No data in file: %s", file);
+
+  return contents;
+}


### PR DESCRIPTION
Adds a new `log` command for developers that displays the tail end of a log file, similar to the Unix `tail` utility. The number of lines shown respects the user's `morelines` preference, falling back to the mud's configured default.

Files without a leading slash are resolved relative to the log directory, while absolute paths are used as-is. Standard permission checks, directory detection, and missing file handling are included.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a developer command for viewing the end of log files. The main changes are:

- Adds `cmds/dev/log.lpc` with `STD_CMD` integration.
- Resolves relative names from the log directory.
- Checks read access, directories, and missing files.
- Uses the `morelines` preference or configured default.
</details>

<sub>Reviews (2): Last reviewed commit: ["log command"](https://github.com/gesslar/oxidus-mudlib/commit/4b5e4afb0a7499cf89e590d6bf6a09035d954dc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45138065)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
</details>

<!-- /greptile_comment -->