### PR TITLE
Add `path.lpc` dev command

### DIFF
--- a/cmds/dev/path.lpc
+++ b/cmds/dev/path.lpc
@@ -1,0 +1,68 @@
+/**
+ * @file /cmds/dev/path.lpc
+ *
+ * Command to show or modify your command search path.
+ *
+ * @created 2026-07-17 - Gesslar
+ * @last_modified 2026-07-17 - Gesslar
+ *
+ * @history
+ * 2026-07-17 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text =
+    "path\n"
+    "path add <directory>\n"
+    "path remove <directory>";
+  help_text =
+    "Shows or modifies the list of directories the mud searches to resolve the "
+    "commands you type.\n"
+    "\n"
+    "With no argument, prints your current path. Use 'add <directory>' to "
+    "append a directory and 'remove <directory>' to drop one.\n"
+    "\n"
+    "Take care when removing directories: dropping an important one (such as "
+    "the directory holding this command) can leave you unable to run "
+    "commands.\n"
+    "\n"
+    "See also: which";
+}
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  string action, dir;
+
+  if(!str) {
+    string *path = caller->get_path();
+    return _info(caller, "Current path: %s",
+      implode(map(path, (: chop($1, "/") :)), ":"));
+  }
+
+  if(sscanf(str, "%s %s", action, dir) != 2)
+    return _usage(caller);
+
+  dir = append(dir, "/");
+
+  switch(action) {
+    case "add":
+      if(!directory_exists(dir))
+        return _error(caller, "No such directory: %s", chop(dir, "/"));
+      if(!caller->add_path(dir))
+        return _error(caller, "%s is already in your path.", chop(dir, "/"));
+      return _ok(caller, "Added %s to your path.", chop(dir, "/"));
+
+    case "remove":
+    case "rem":
+      if(!caller->rem_path(dir))
+        return _error(caller, "%s is not in your path.", chop(dir, "/"));
+      return _ok(caller, "Removed %s from your path.", chop(dir, "/"));
+
+    default:
+      return _usage(caller);
+  }
+}


### PR DESCRIPTION
Adds a new `path` dev command that allows players to view and manage their command search path. Running `path` with no arguments displays the current path as a colon-separated list. The `add` subcommand appends a directory to the path after verifying it exists and is not already present, while `remove` (or `rem`) drops a directory from the path. The command includes a warning in the help text about the risk of removing critical directories.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a developer command for inspecting and updating command search paths.

- Displays the current path as a colon-separated list.
- Adds validated directories to a player's command path.
- Removes directories from a player's command path.
</details>

<sub>Reviews (2): Last reviewed commit: ["path command"](https://github.com/gesslar/oxidus-mudlib/commit/26e25d69cd203470b9cfad63d8ba19149373d7ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45138077)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->