### PR TITLE
Add `sockinfo.lpc` dev command

### DIFF
--- a/cmds/dev/sockinfo.lpc
+++ b/cmds/dev/sockinfo.lpc
@@ -1,0 +1,63 @@
+/**
+ * @file /cmds/dev/sockinfo.lpc
+ *
+ * Displays the status of the driver's LPC sockets.
+ *
+ * @created 2026-07-17 - Gesslar
+ * @last_modified 2026-07-17 - Gesslar
+ *
+ * @history
+ * 2026-07-17 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text =
+    "sockinfo\n"
+    "sockinfo <fd>";
+  help_text =
+    "Reports the status of the driver's LPC sockets. With no argument, every "
+    "socket is listed. Supply an <fd> to show only that socket.\n"
+    "\n"
+    "Each row reports the file descriptor, connection state, mode, the local "
+    "and remote addresses, and the object that owns the socket.";
+}
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  // socket_status() returns one array per socket:
+  //   [0] int fd, [1] string state, [2] string mode,
+  //   [3] string local addr, [4] string remote addr, [5] object owner
+  mixed *sockets = socket_status();
+
+  if(str) {
+    int fd;
+
+    if(sscanf(str, "%d", fd) != 1)
+      return _usage(caller);
+
+    sockets = filter(sockets, (: $1[0] == $(fd) :));
+
+    if(!sizeof(sockets))
+      return _error(caller, "No socket with fd %d.", fd);
+  }
+
+  if(!sizeof(sockets))
+    return _info(caller, "There are no active sockets.");
+
+  string out = sprintf("%-3s %-11s %-10s %-22s %-22s %s\n",
+    "Fd", "State", "Mode", "Local Address", "Remote Address", "Owner");
+
+  foreach(mixed sock in sockets) {
+    object owner = sock[5];
+
+    out += sprintf("%-3d %-11s %-10s %-22s %-22s %s\n",
+      sock[0], sock[1], sock[2], sock[3] || "-", sock[4] || "-",
+      objectp(owner) ? file_name(owner) : "-");
+  }
+
+  return out;
+}


### PR DESCRIPTION
Adds a new `sockinfo` developer command that displays the status of active LPC sockets reported by the driver. When called without arguments, all sockets are listed in a formatted table showing the file descriptor, connection state, mode, local address, remote address, and owning object. An optional `<fd>` argument filters the output to a single socket, returning an error if no matching socket is found.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a developer command for inspecting active LPC sockets.

- Adds `sockinfo` under developer commands.
- Supports optional filtering by file descriptor.
- Formats socket state, addresses, and owner details.
</details>

<sub>Reviews (2): Last reviewed commit: ["sockinfo command"](https://github.com/gesslar/oxidus-mudlib/commit/51d99129fc344df74e42bba6bd2a50c178a73fb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45138081)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->