### PR TITLE
Add `which.lpc` dev command to locate verb resolution sources

### DIFF
--- a/cmds/dev/which.lpc
+++ b/cmds/dev/which.lpc
@@ -1,0 +1,74 @@
+/**
+ * @file /cmds/dev/which.lpc
+ *
+ * Command to locate where a verb resolves: a command file on your path, an
+ * add_command() handler on a nearby object, or a room exit.
+ *
+ * @created 2026-07-17 - Gesslar
+ * @last_modified 2026-07-17 - Gesslar
+ *
+ * @history
+ * 2026-07-17 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text = "which <verb>";
+  help_text =
+    "Reports where a verb would resolve. It searches each directory on your "
+    "command path for a matching command file, checks the add_command() "
+    "handlers registered by objects in your inventory and room, and checks "
+    "the exits of your current room.\n"
+    "\n"
+    "Every match is reported, so a verb defined in more than one place shows "
+    "all of its locations.\n"
+    "\n"
+    "See also: path";
+}
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  if(!str)
+    return _usage(caller);
+
+  string verb = lower_case(str);
+  string *out = ({ });
+
+  // Command files on the search path.
+  foreach(string p in caller->get_path())
+    if(file_exists(p + verb + ".lpc"))
+      out += ({ "Command: " + p + verb });
+
+  // add_command() handlers on nearby objects, in command-resolution order.
+  object *obs = all_inventory(caller);
+  /** @type {STD_ROOM} */ object room = environment(caller);
+
+  if(room)
+    obs += ({ room }) + all_inventory(room);
+
+  obs += ({ caller });
+  obs = distinct_array(obs);
+
+  foreach(object ob in obs) {
+    mixed handler = ob->query_command(verb);
+
+    if(nullp(handler))
+      continue;
+
+    string desc = stringp(handler) ? handler + "()" : "<closure>";
+    out += ({ sprintf("Object:  %s -> %s", file_name(ob), desc) });
+  }
+
+  // Room exit (dispatched as 'go' by the command hook).
+  if(room && room->valid_exit(verb))
+    out += ({ "Exit:    " + room->query_exit(verb) });
+
+  if(!sizeof(out))
+    return _error(caller, "'%s' does not resolve to a command, handler, or "
+      "exit.", verb);
+
+  return out;
+}


### PR DESCRIPTION
Adds a `which` command for developers that locates where a given verb resolves. It searches the player's command path for matching command files, checks `add_command()` handlers registered on nearby objects (inventory and room), and checks the current room's exits. All matches are reported, so verbs defined in multiple places show every location.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a developer command for locating verb resolution sources. The main changes are:

- Searches command-path files for matching verbs.
- Lists nearby `add_command()` handlers.
- Reports matching room exits.
</details>

<sub>Reviews (2): Last reviewed commit: ["which command"](https://github.com/gesslar/oxidus-mudlib/commit/8690059ac48c6ae4f59325f779dcfcbed6ffede4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45138090)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->