### PR TITLE
Use `??=` instead of `||=` in `resolve_path`

### DIFF
--- a/adm/simul_efun/file.lpc
+++ b/adm/simul_efun/file.lpc
@@ -684,8 +684,8 @@ string resolve_path(string base_dir, string path) {
   string *stack = ({ });
   int dir_marker = 0;
 
-  base_dir ||= "/";
-  path ||= "";
+  base_dir ??= "/";
+  path ??= "";
 
   // 'here' -> the source file of the caller's current environment.
   if(path == "here") {


### PR DESCRIPTION
Replaces the `||=` null coalescing assignment operators with `??=` in `resolve_path` to correctly handle cases where `base_dir` or `path` are explicitly passed as empty strings. The previous behavior would incorrectly override falsy values like `""`, while `??=` only assigns the default when the value is `null`/`undefined`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates path default handling in `resolve_path`.

- Uses nullish assignment for `base_dir`.
- Uses nullish assignment for `path`.
</details>

<sub>Reviews (3): Last reviewed commit: ["fixing to use undefinedish"](https://github.com/gesslar/oxidus-mudlib/commit/cd65f20c5bf2450e650eaf37014f8847f2b29b38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45183688)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->