### PR TITLE
Extend `call.lpc` `coerce_arg` to resolve named objects and unquote strings

### DIFF
--- a/cmds/object/call.lpc
+++ b/cmds/object/call.lpc
@@ -15,7 +15,7 @@
 inherit STD_CMD;
 
 private object resolve_target(object caller, string spec);
-private mixed coerce_arg(string s);
+private mixed coerce_arg(object caller, string s);
 
 void setup() {
   usage_text = "call <object>;<function>[;<arg>...]";
@@ -53,7 +53,7 @@ mixed main(
   if(spec == "" || func == "")
     return _error(caller, "Syntax: call <object>;<function>[;<arg>...]");
 
-  mixed *args = map(parts[2..], (: coerce_arg :));
+  mixed *args = map(parts[2..], (: coerce_arg($(caller), $1) :));
 
   /** @type {STD_OBJECT} */ object ob = resolve_target(caller, spec);
   if(!ob)
@@ -63,8 +63,7 @@ mixed main(
   string err = catch(result = call_other(ob, ({ func }) + args));
 
   if(err)
-    return _error(caller, "%s->%s() raised: %s",
-      file_name(ob), func, trim(err));
+    return _error(caller, "%s->%s() raised: %s", file_name(ob), func, trim(err));
 
   return _info(caller, "%s->%s() = %s",
     file_name(ob), func, sprintf("%O", result));
@@ -114,22 +113,31 @@ private object resolve_target(object caller, string spec) {
 
 /**
  * Coerces a raw string argument to a typed value: an int or float when the
- * trimmed text is wholly numeric, otherwise the string itself.
+ * trimmed text is wholly numeric, otherwise the string itself. Also tries
+ * to resolve against an named object.
  *
  * @param {string} s - The raw argument text.
  * @returns {mixed} The coerced value.
  */
-private mixed coerce_arg(string s) {
+private mixed coerce_arg(object caller, string s) {
   int i;
   float f;
+  string unquoted;
 
   s = trim(s);
+
+  if(sscanf(s, "\"%s\"", unquoted) == 1)
+    return unquoted;
 
   if(sscanf(s, "%d", i) == 1 && s == sprintf("%d", i))
     return i;
 
   if(sscanf(s, "%f", f) == 1)
     return f;
+
+  object ob = resolve_target(caller, s);
+  if(objectp(ob))
+    return ob;
 
   return s;
 }


### PR DESCRIPTION
## Enhance `call` Command Argument Coercion with Object Resolution

Adds object resolution to `coerce_arg` so that arguments passed to `call` can reference in-game objects by name or spec, not just numeric or string literals. The `caller` context is threaded through to `coerce_arg` to enable this lookup, and the doc comment is updated to reflect the new behavior.

Additionally, quoted string literals (e.g. `"foo"`) are now explicitly handled by stripping the surrounding quotes before returning the inner value, ensuring string arguments are passed correctly when object resolution would otherwise be attempted.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends `call` argument coercion with caller-aware object lookup. The main changes are:

- Pass caller context into `coerce_arg`.
- Resolve unquoted object specifications as objects.
- Strip surrounding quotes from string literals.
</details>

<sub>Reviews (2): Last reviewed commit: ["updating args for call"](https://github.com/gesslar/oxidus-mudlib/commit/7499d848a601a70b0f2075e52a339d8d72e7b534) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45229738)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->