### PR TITLE
Replace `OLD_ED` with modern `ed_start`/`ed_cmd` session; add `ed.lpc` command

### DIFF
--- a/adm/dist/local_options
+++ b/adm/dist/local_options
@@ -25,7 +25,7 @@
 #undef NO_ENVIRONMENT
 #undef NO_WIZARDS
 #define NO_LIGHT
-#define OLD_ED
+#undef OLD_ED
 #undef ED_INDENT_CASE
 #define ED_INDENT_SPACES 2
 #undef ED_USE_TABS

--- a/adm/etc/local_options.github
+++ b/adm/etc/local_options.github
@@ -25,7 +25,7 @@
 #undef NO_ENVIRONMENT
 #undef NO_WIZARDS
 #define NO_LIGHT
-#define OLD_ED
+#undef OLD_ED
 #undef ED_INDENT_CASE
 #define ED_INDENT_SPACES 4
 #undef ED_USE_TABS

--- a/cmds/file/ed.lpc
+++ b/cmds/file/ed.lpc
@@ -1,0 +1,55 @@
+/**
+ * @file /cmds/file/ed.lpc
+ *
+ * Command to edit a file with the driver's line editor. Opens an ed session
+ * on the given file; an existing file is loaded, a missing one starts an empty
+ * buffer you can write to create. Type 'h' inside the editor for help.
+ *
+ * @created 2026-07-17 - Gesslar
+ * @last_modified 2026-07-17 - Gesslar
+ *
+ * @history
+ * 2026-07-17 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text = "ed <file>";
+  help_text =
+    "This command opens a file in the line editor. An existing file is loaded "
+    "for editing; a file that does not yet exist starts an empty buffer, and "
+    "writing ('w') creates it.\n"
+    "\n"
+    "Once inside the editor, type 'h' for a list of editor commands. Use 'w' "
+    "to write, 'q' to quit, and 'x' to write and quit.\n"
+    "\n"
+    "You may use an absolute or relative path.\n"
+    "\n"
+    "See also: cat, more";
+}
+
+mixed main(
+  /** @type {STD_PLAYER} */ object caller,
+  string str
+) {
+  if(!str)
+    return _usage(caller);
+
+  if(caller->query_editing())
+    return _error(caller, "You are already editing something.");
+
+  string file = resolve_path(caller->query_env("cwd"), str);
+
+  if(directory_exists(file))
+    return _error(caller, "%s is a directory.", file);
+
+  if(!master()->valid_write(file, caller, "ed"))
+    return _error(caller, "Permission denied.");
+
+  if(file_size(file) > get_config(__MAX_READ_FILE_SIZE__))
+    return _error(caller, "%s is too large to edit.", file);
+
+  caller->ed_edit(file);
+  return 1;
+}

--- a/std/living/ed.lpc
+++ b/std/living/ed.lpc
@@ -1,24 +1,32 @@
 /**
- * @file /std/user/ed.lpc
+ * @file /std/living/ed.lpc
  *
- * Object to handle interacting with basic or advanced editor.
+ * Object to handle interacting with the basic composer or the driver's line
+ * editor. Two independent flows live here:
+ *
+ *   - start_edit() : a hand-rolled line collector (the "║ " prompt) that
+ *     gathers free text into a temp file and fires a callback. Used for
+ *     composing blobs of text (bug reports, descriptions) - it does not touch
+ *     the driver editor.
+ *   - ed_edit() : a session driver around the modern ed_start()/ed_cmd()
+ *     efuns. The mudlib owns the input loop; the driver owns the buffer. The
+ *     'w'/'x' commands write the real file directly through valid_write().
  *
  * @created 2024-07-20 - Gesslar
- * @last_modified 2024-07-20 - Gesslar
+ * @last_modified 2026-07-17 - Gesslar
  *
  * @history
  * 2024-07-20 - Gesslar - Created
+ * 2026-07-17 - Gesslar - Converted ed_edit() to the modern ed_start()/ed_cmd()
+ *                        paradigm; removed the OLD_ED ed() wrapper
  */
-
 
 #include <ed.h>
 
-int ed_write_callback(string file, int flag);
-void ed_exit_callback();
-void finish_exit_callback();
-void abort_edit();
+private void finish_exit_callback();
+private void abort_edit();
 
-string query_editing();
+public string query_editing();
 
 private nosave string edit_file, temp_file;
 private nosave mixed *post_edit;
@@ -26,153 +34,209 @@ private nosave mixed *post_edit;
 // When passing a callback to this function, you should have assembled it with
 // a string function instead of a function pointer. This is because the
 // function pointer may not be valid when the callback is called.
-int start_edit(string file, mixed *cb) {
-    string text;
-    string *lines;
-    int sz;
+public int start_edit(string file, mixed *cb) {
+  string text;
+  string *lines;
+  int sz;
 
-    if(in_edit() || !nullp(edit_file))
-        return _error(this_object(), "You are already editing a file.");
+  if(in_edit() || !nullp(edit_file))
+    return _error(this_object(), "You are already editing a file.");
 
-    if(nullp(cb))
-        return _error(this_object(), "Invalid callback.");
+  if(nullp(cb))
+    return _error(this_object(), "Invalid callback.");
 
-    post_edit = cb;
-    temp_file = temp_file(this_object());
+  post_edit = cb;
+  temp_file = temp_file(this_object());
 
-    text = "";
-    if(!nullp(file)) {
-        sz = file_size(file);
-        if(sz > -1) {
-            catch(cp(file, temp_file));
-            if(sz > 0) {
-                if(!master()->valid_read(file, this_object(), "ed"))
-                    return _error(this_object(), "Permission denied.");
-                if(file_size(file) > get_config(__MAX_READ_FILE_SIZE__)) {
-                    _error("File is too large to read");
-                    abort_edit();
-                }
-                text = read_file(file);
-            }
+  text = "";
+
+  if(!nullp(file)) {
+    sz = file_size(file);
+
+    if(sz > -1) {
+      catch(cp(file, temp_file));
+
+      if(sz > 0) {
+        if(!master()->valid_read(file, this_object(), "ed"))
+          return _error(this_object(), "Permission denied.");
+
+        if(file_size(file) > get_config(__MAX_READ_FILE_SIZE__)) {
+          _error("File is too large to read");
+          abort_edit();
         }
+
+        text = read_file(file);
+      }
     }
+  }
 
-    if(strlen(text))
-        text = append(text, "\n");
+  if(strlen(text))
+    text = append(text, "\n");
 
-    lines = map(explode(text, "\n"), (: "║ " + $1 :));
-    text = implode(lines, "\n") + "\n║ ";
+  lines = map(explode(text, "\n"), (: "║ " + $1 :));
+  text = implode(lines, "\n") + "\n║ ";
 
-    tell(this_object(),
+  tell(this_object(),
 "
     Enter text. When finished, enter '.' on a blank line, or '#' to abort.
   ═══════════════════════════════════════════════════════════════════════════\n");
 
-    tell(this_object(), text);
+  tell(this_object(), text);
 
-    input_to("parse_input", 0);
+  input_to("parse_input", 0);
 }
 
-void parse_input(string input) {
-    if(!input || input == "#")
-        return abort_edit();
+private void parse_input(string input) {
+  if(!input || input == "#")
+    return abort_edit();
 
-    if(input == ".")
-        return finish_exit_callback();
+  if(input == ".")
+    return finish_exit_callback();
 
-    write_file(temp_file, input + "\n");
+  write_file(temp_file, input + "\n");
 
-    tell(this_object(), "║ ");
+  tell(this_object(), "║ ");
 
-    input_to("parse_input", 0);
+  input_to("parse_input", 0);
 }
 
-// When passing a callback to this function, you should have assembled it with
-// a string function instead of a function pointer. This is because the
-// function pointer may not be valid when the callback is called.
-varargs int ed_edit(string file, mixed *cb) {
-    if(in_edit() || !nullp(edit_file))
-        return _error(this_object(), "You are already editing a file.");
+private void finish_exit_callback() {
+  string e;
+  int sz;
 
-    if(!stringp(file))
-        return _error(this_object(), "Invalid file name.");
+  defer((: rm, temp_file :));
 
-    edit_file = file;
-    temp_file = temp_file(this_object());
-    post_edit = cb;
+  if(!interactive(this_object())) {
+    catch(abort_edit());
 
-    if(file_size(file) > -1) {
-        cp(file, temp_file);
+    return;
+  }
+
+  // Now let's copy the temp file to the edit file.
+  e = catch {
+    sz = file_size(temp_file);
+
+    if(sz > 0) {
+      if(!nullp(edit_file)) {
+        if(!master()->valid_write(edit_file, this_object(), "ed"))
+          throw("Permission denied.");
+
+        cp(temp_file, edit_file);
+      }
+
+      if(!nullp(post_edit))
+        catch(call_back(post_edit, ED_STATUS_SUCCESS, edit_file, temp_file));
     } else {
-        touch(temp_file);
+      abort_edit();
     }
+  };
 
-    ed(temp_file, "ed_write_callback", "ed_exit_callback");
-    return 1;
+  if(e)
+    catch(abort_edit());
+
+  edit_file = post_edit = temp_file = null;
 }
 
-/**
- * When the editor writes to a file, the driver will callback the <write_fn>
- * function twice. The first time, the function is called before the write
- * takes place -- <flag> will be 0. If the function returns TRUE, the write
- * will continue, otherwise it will abort. The second time, the function
- * is called after the write has completed -- <flag> will be non-zero.
- */
-int ed_write_callback(string file, int flag) {
-    // I can't think of anything I want to do every time the editor writes to
-    // a file, so I'm just going to return TRUE.
-    return true;
-}
-
-void ed_exit_callback(mixed arg...) {
-    // Stupid hack to get around the fact that the driver doesn't call the
-    // link dead thingie properly.
-    call_out_walltime((: finish_exit_callback :), 0.01);
-}
-
-void finish_exit_callback() {
-    string e;
-    int sz;
-
+private void abort_edit() {
+  if(!nullp(temp_file))
     defer((: rm, temp_file :));
 
-    if(!interactive(this_object())) {
-        catch(abort_edit());
-        return;
-    }
+  if(!nullp(post_edit))
+    catch(call_back(post_edit, ED_STATUS_ABORTED, edit_file, temp_file));
 
-    // Now let's copy the temp file to the edit file.
-    e = catch {
-        sz = file_size(temp_file);
-        if(sz > 0) {
-            if(!nullp(edit_file)) {
-                if(!master()->valid_write(edit_file, this_object(), "ed"))
-                    throw("Permission denied.");
-                cp(temp_file, edit_file);
-            }
-            if(!nullp(post_edit))
-                catch(call_back(post_edit, ED_STATUS_SUCCESS, edit_file, temp_file));
-        } else {
-            abort_edit();
-        }
-    };
-
-    if(e)
-        catch(abort_edit());
-
-    edit_file = post_edit = temp_file = null;
+  edit_file = post_edit = temp_file = null;
 }
 
-void abort_edit() {
-    if(!nullp(temp_file))
-        defer((: rm, temp_file :));
+// ─── modern ed session (ed_start/ed_cmd) ────────────────────────────────────
 
-    if(!nullp(post_edit))
-        catch(call_back(post_edit, ED_STATUS_ABORTED, edit_file, temp_file));
+private void ed_line(string line);
+private void ed_continue();
+private string ed_prompt();
 
-    edit_file = post_edit = temp_file = null;
+private nosave mixed *ed_post;
+private nosave string ed_target;
+
+/**
+ * Starts a driver ed session on <file>. The mudlib drives the input loop; the
+ * driver holds the buffer. Writing ('w'/'x') goes straight to <file> through
+ * valid_write(), so no temp-file dance is needed. An optional callback, if
+ * given, is fired once when the session ends.
+ *
+ * @param {string} file - The file to edit; may be null to open an empty buffer.
+ * @param {mixed*} cb - Optional callback assembled with assemble_call_back(),
+ *                      invoked as (ED_STATUS_SUCCESS, file) when the session ends.
+ * @param {int} restricted - If set, disables commands that change which file is
+ *                           being edited.
+ * @returns {int} 1 on start, or an error result if already editing.
+ */
+public varargs int ed_edit(string file, mixed *cb, int restricted) {
+  string out;
+
+  if(in_edit(this_object()))
+    return _error(this_object(), "You are already editing something.");
+
+  if(!nullp(file) && !stringp(file))
+    return _error(this_object(), "Invalid file name.");
+
+  ed_post = cb;
+  ed_target = file;
+
+  out = ed_start(file, restricted, 0);   // loads the buffer; sets O_IN_EDIT
+
+  if(stringp(out) && strlen(out))
+    tell(this_object(), out);
+
+  ed_continue();
+
+  return 1;
 }
 
-string query_editing() {
-    return edit_file;
+// input_to target: feed one line to the session, echo the result, loop or finish.
+private void ed_line(string line) {
+  string out;
+
+  if(!in_edit(this_object()))
+    return;
+
+  out = ed_cmd(line);
+
+  if(stringp(out) && strlen(out))
+    tell(this_object(), out);
+
+  ed_continue();
+}
+
+// Re-arm the input loop while the session is live; fire the callback when it
+// ends (the file has already been written by the editor itself).
+private void ed_continue() {
+  if(in_edit(this_object())) {
+    tell(this_object(), ed_prompt());
+    input_to("ed_line", 0);
+  } else {
+    mixed *cb = ed_post;
+    string target = ed_target;
+
+    ed_post = ed_target = null;
+
+    if(!nullp(cb))
+      catch(call_back(cb, ED_STATUS_SUCCESS, target));
+  }
+}
+
+// query_ed_mode(): 0 = command mode, >0 = input/append mode (next line number),
+// -2 = pager. The pager prints its own prompt, so we emit nothing for it.
+private string ed_prompt() {
+  int mode = query_ed_mode();
+
+  if(mode == -2)
+    return "";
+
+  if(mode > 0)
+    return sprintf("%d\t", mode);
+
+  return ":";
+}
+
+public string query_editing() {
+  return in_edit(this_object());
 }

--- a/std/object/command.lpc
+++ b/std/object/command.lpc
@@ -17,7 +17,7 @@
 #include <command.h>
 
 private nosave mapping __command_handlers = ([]);
-private string *__command_paths = ({});
+private string* __command_paths = ({});
 private nosave string *__command_history = ({});
 
 /**
@@ -256,6 +256,8 @@ public int add_path(string path) {
   if(!adminp(previous_object()) && this_body() != this_object())
     return 0;
 
+  __command_paths ??= ({});
+
   if(includes(__command_paths, path))
     return 0;
 
@@ -264,7 +266,7 @@ public int add_path(string path) {
   if(!directory_exists(path))
     return 0;
 
-  push(ref __command_paths, path);
+  push(& __command_paths, path);
 
   return 1;
 }
@@ -277,6 +279,8 @@ public int add_path(string path) {
  *  paths
  */
 public void set_path(mixed path) {
+  __command_paths ??= ({});
+
   assert_arg(
     stringp(path) || pointerp(path) && uniformp(path, T_STRING),
     1,
@@ -309,6 +313,8 @@ public int rem_path(string path) {
 
   if(!adminp(previous_object()) && this_body() != this_object())
     return 0;
+
+  __command_paths ??= ({});
 
   if(!includes(__command_paths, path))
     return 0;


### PR DESCRIPTION
## Replace `OLD_ED` with modern `ed_start`/`ed_cmd` driver editor

The `OLD_ED` compile-time flag has been disabled in both `local_options` configs, and the `ed_edit()` function in `std/living/ed.lpc` has been rewritten to use the modern `ed_start()`/`ed_cmd()`/`query_ed_mode()` efuns instead of the legacy `ed()` wrapper.

### How the new `ed_edit()` works

The mudlib now owns the input loop entirely. `ed_start()` loads the file into the driver's buffer and sets the `O_IN_EDIT` flag. From there, `ed_continue()` arms an `input_to` on `ed_line()`, which feeds each line to `ed_cmd()`, echoes any output back to the player, and re-arms the loop. When `in_edit()` returns false (the user ran `w`/`q`/`x`), the loop exits and an optional callback is fired. Because the driver writes the file directly through `valid_write()`, no temp-file copy step is needed on exit.

`ed_prompt()` inspects `query_ed_mode()` to emit the right prompt: `:` in command mode, a line number and tab in append/insert mode, and nothing when the pager is active (it prints its own prompt).

The old `ed_write_callback` and `ed_exit_callback` functions, along with the workaround `call_out_walltime` hack, have been removed.

### New `ed` command

A new `cmds/file/ed.lpc` command exposes the editor to players. It resolves the target path against the caller's working directory, checks that it is not a directory, validates write permission, enforces the max read-file-size limit, and then calls `ed_edit()`.

### `start_edit()` / composer flow

The existing hand-rolled line collector (`start_edit` → `parse_input` → `║ ` prompt) is unchanged in behaviour. The diff reformats it to two-space indentation and tightens up the `finish_exit_callback` and `abort_edit` logic, but the semantics are the same.

### `std/object/command.lpc`

Added `??=` null-coalescing guards on `__command_paths` before each use in `add_path()`, `set_path()`, and `rem_path()` to prevent operating on a null array after object restoration.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves the mudlib from the legacy editor wrapper to the modern driver editor flow. The main changes are:

- Disables `OLD_ED` in both driver option files.
- Adds the `ed` file command with path and write checks.
- Reworks `ed_edit()` around `ed_start()` and `ed_cmd()`.
- Initializes command paths before path mutations.
</details>

<sub>Reviews (2): Last reviewed commit: ["converting to new ed"](https://github.com/gesslar/oxidus-mudlib/commit/f209aed851ab47f1586126b79a481533bd37fbf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45277240)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>


<!-- /greptile_comment -->