### PR TITLE
Add `shutdown`/`reboot` admin commands and shutdown daemon; fix exit codes and `valid_override`

### DIFF
--- a/adm/daemons/shutdown.lpc
+++ b/adm/daemons/shutdown.lpc
@@ -1,0 +1,296 @@
+/**
+ * @file /adm/daemons/shutdown.lpc
+ *
+ * Shutdown daemon. Owns the scheduling, countdown, broadcast, and
+ * cancellation of a pending game shutdown or reboot. The `shutdown` and
+ * `reboot` admin commands are thin wrappers that hand their argument line
+ * here; this daemon parses the grammar and drives everything else.
+ *
+ * A shutdown and a reboot differ only by the exit code handed to the
+ * driver: SYS_SHUTDOWN (0) exits cleanly and the run script stops;
+ * SYS_REBOOT (1) exits and the run script restarts the driver. Only one
+ * shutdown or reboot may be pending at a time.
+ *
+ * The actual driver call goes through the security-wrapped shutdown()
+ * override, which permits only master() and this daemon (SHUTDOWN_D) to
+ * invoke it, emits SIG_SYS_SHUTDOWN, and persists all objects first.
+ *
+ * @created 2026-07-18 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
+ *
+ * @history
+ * 2026-07-18 - Gesslar - Created
+ */
+
+#include <shutdown.h>
+#include <signal.h>
+#include <logs.h>
+
+inherit STD_DAEMON;
+
+public int request(int how, string arg);
+private int schedule(object who, int how, int minutes, string why);
+private int do_halt(object who);
+private int report_status(object who);
+private void warn();
+private void fire();
+private void announce(string msg);
+private void clear_calls();
+private string phrase(int secs);
+private string label(int how);
+
+private nosave int pending;         // 1 while a shutdown/reboot is scheduled
+private nosave int mode;            // SYS_SHUTDOWN or SYS_REBOOT
+private nosave int fire_time;       // time() at which it fires
+private nosave string reason;       // operator-supplied reason, or ""
+private nosave string actor;        // name of the operator who scheduled it
+private nosave int *calls = ({});   // outstanding call_out handles
+
+// Seconds-before-fire at which to broadcast a countdown warning. Only the
+// offsets shorter than the total delay are actually scheduled.
+private nosave int *warn_at = ({ 900, 600, 300, 120, 60, 30, 10 });
+
+void setup() {
+  set_no_clean(1);
+}
+
+/**
+ * Entry point for the `shutdown` and `reboot` commands. Parses the argument
+ * line and dispatches. The grammar (for either verb) is:
+ *
+ *   <verb>                  - report the current shutdown/reboot status
+ *   <verb> halt             - cancel a pending shutdown/reboot
+ *   <verb> now [reason]     - fire immediately
+ *   <verb> <minutes> [reason] - fire after <minutes> minutes
+ *   <verb> <reason>         - fire after the default delay
+ *
+ * @param {int} how - SYS_SHUTDOWN or SYS_REBOOT.
+ * @param {string} arg - The raw argument line from the command.
+ * @returns {int} A feedback result (always 1) sent to the invoking operator.
+ */
+public int request(int how, string arg) {
+  object who = this_body();
+  string first, rest, junk;
+  int minutes;
+
+  if(!objectp(who) || !adminp(who))
+    return _error(who, "You are not permitted to schedule a %s.", label(how));
+
+  arg = arg ? trim(arg) : "";
+
+  if(arg == "")
+    return report_status(who);
+
+  if(sscanf(arg, "%s %s", first, rest) != 2) {
+    first = arg;
+    rest = "";
+  }
+
+  if(lower_case(first) == "halt")
+    return do_halt(who);
+
+  if(pending)
+    return _error(who, "A %s is already scheduled. Use '%s halt' to cancel it "
+      "first.", label(mode), label(mode));
+
+  if(lower_case(first) == "now")
+    return schedule(who, how, 0, rest);
+
+  if(sscanf(first, "%d%s", minutes, junk) == 2 && junk == "") {
+    if(minutes < 0)
+      return _error(who, "The delay must not be negative.");
+
+    return schedule(who, how, minutes, rest);
+  }
+
+  return schedule(who, how, SHUTDOWN_DEFAULT_MINUTES, arg);
+}
+
+/**
+ * Schedules the shutdown/reboot: records state, broadcasts the opening
+ * announcement, and arms the countdown warnings plus the final fire. A zero
+ * delay fires at once.
+ *
+ * @param {object} who - The operator scheduling it.
+ * @param {int} how - SYS_SHUTDOWN or SYS_REBOOT.
+ * @param {int} minutes - Delay in minutes; 0 means immediately.
+ * @param {string} why - The reason, possibly empty.
+ * @returns {int} A feedback result for the operator.
+ */
+private int schedule(object who, int how, int minutes, string why) {
+  int total = minutes * 60;
+
+  why = why ? trim(why) : "";
+
+  pending = 1;
+  mode = how;
+  reason = why;
+  actor = who->query_name();
+  fire_time = time() + total;
+
+  clear_calls();
+
+  log_file(LOG_SHUTDOWN, sprintf("%s scheduled by %s in %s (%s) - %s\n",
+    label(how), actor, total <= 0 ? "0 seconds" : phrase(total),
+    why == "" ? "no reason given" : why, ldatetime()));
+
+  if(total <= 0) {
+    fire();
+
+    return _ok(who, "%s now.", how == SYS_REBOOT ? "Rebooting" : "Shutting down");
+  }
+
+  foreach(int th in warn_at)
+    if(th < total)
+      calls += ({ call_out((: warn :), total - th) });
+
+  calls += ({ call_out((: fire :), total) });
+
+  announce(sprintf("\n*** The game will %s in %s.%s ***\n",
+    how == SYS_REBOOT ? "reboot" : "shut down", phrase(total),
+    why == "" ? "" : " Reason: " + why));
+
+  return _ok(who, "%s scheduled in %s.%s", capitalize(label(how)),
+    phrase(total), why == "" ? "" : " Reason: " + why);
+}
+
+/**
+ * Cancels a pending shutdown/reboot, clears the armed call_outs, announces
+ * the cancellation, and emits the matching cancel signal.
+ *
+ * @param {object} who - The operator cancelling it.
+ * @returns {int} A feedback result for the operator.
+ */
+private int do_halt(object who) {
+  int how = mode;
+
+  if(!pending)
+    return _error(who, "There is no shutdown or reboot scheduled to cancel.");
+
+  clear_calls();
+  pending = 0;
+
+  announce(sprintf("\n*** The scheduled %s has been cancelled by %s. ***\n",
+    label(how), capitalize(who->query_name())));
+
+  emit(how == SYS_REBOOT ? SIG_SYS_REBOOT_CANCEL : SIG_SYS_SHUTDOWN_CANCEL);
+
+  log_file(LOG_SHUTDOWN, sprintf("%s cancelled by %s - %s\n",
+    label(how), who->query_name(), ldatetime()));
+
+  reason = actor = 0;
+
+  return _ok(who, "The scheduled %s has been cancelled.", label(how));
+}
+
+/**
+ * Reports the current shutdown/reboot status to the operator.
+ *
+ * @param {object} who - The operator asking.
+ * @returns {int} A feedback result for the operator.
+ */
+private int report_status(object who) {
+  int remaining;
+
+  if(!pending)
+    return _info(who, "No shutdown or reboot is currently scheduled.");
+
+  remaining = fire_time - time();
+  if(remaining < 0)
+    remaining = 0;
+
+  return _info(who, "%s scheduled by %s in %s.%s", capitalize(label(mode)),
+    capitalize(actor || "someone"), phrase(remaining),
+    reason == "" || nullp(reason) ? "" : " Reason: " + reason);
+}
+
+/**
+ * Countdown warning broadcast. Fired by call_out at each armed offset; it
+ * derives the remaining time from fire_time so the phrasing is always
+ * accurate.
+ */
+private void warn() {
+  int remaining;
+
+  if(!pending)
+    return;
+
+  remaining = fire_time - time();
+  if(remaining <= 0)
+    return;
+
+  announce(sprintf("\n*** The game will %s in %s.%s ***\n",
+    mode == SYS_REBOOT ? "reboot" : "shut down", phrase(remaining),
+    reason == "" || nullp(reason) ? "" : " Reason: " + reason));
+}
+
+/**
+ * Fires the shutdown/reboot: final broadcast, emits the pre-shutdown signal,
+ * then calls the security-wrapped shutdown() override with the exit code.
+ */
+private void fire() {
+  int how = mode;
+
+  clear_calls();
+  pending = 0;
+
+  announce(sprintf("\n*** The game is %s NOW. ***\n",
+    how == SYS_REBOOT ? "rebooting" : "shutting down"));
+
+  emit(how == SYS_REBOOT ? SIG_SYS_REBOOTING : SIG_SYS_SHUTTING_DOWN);
+
+  shutdown(how);
+}
+
+/**
+ * Broadcasts a message to every interactive user.
+ *
+ * @param {string} msg - The message to send.
+ */
+private void announce(string msg) {
+  foreach(object u in users())
+    if(objectp(u) && interactive(u))
+      tell(u, msg);
+}
+
+/**
+ * Removes and clears all outstanding countdown/fire call_outs.
+ */
+private void clear_calls() {
+  foreach(int id in calls)
+    remove_call_out(id);
+
+  calls = ({});
+}
+
+/**
+ * Formats a second count as a human-readable duration.
+ *
+ * @param {int} secs - The number of seconds.
+ * @returns {string} e.g. "15 minutes", "1 minute 30 seconds", "10 seconds".
+ */
+private string phrase(int secs) {
+  int m, s;
+
+  if(secs < 60)
+    return sprintf("%d second%s", secs, secs == 1 ? "" : "s");
+
+  m = secs / 60;
+  s = secs % 60;
+
+  if(s == 0)
+    return sprintf("%d minute%s", m, m == 1 ? "" : "s");
+
+  return sprintf("%d minute%s %d second%s", m, m == 1 ? "" : "s",
+    s, s == 1 ? "" : "s");
+}
+
+/**
+ * Returns the noun for an exit mode: "reboot" or "shutdown".
+ *
+ * @param {int} how - SYS_SHUTDOWN or SYS_REBOOT.
+ * @returns {string} The label.
+ */
+private string label(int how) {
+  return how == SYS_REBOOT ? "reboot" : "shutdown";
+}

--- a/adm/dist/run
+++ b/adm/dist/run
@@ -41,7 +41,7 @@ case "$1" in
 
             echo "Exit status: $exit_status"
 
-            if [[ $exit_status -eq 0 ]]; then
+            if [[ $exit_status -eq 1 ]]; then
                 echo "Driver exited with reboot status code. Restarting."
                 sleep 1  # Optional: Add a small delay before restarting
             else

--- a/adm/obj/master.lpc
+++ b/adm/obj/master.lpc
@@ -82,7 +82,7 @@ void create() {
 
 void flag(string str) {
   if(str == "builddocs") {
-    call_out((: shutdown, 0 :), 10);
+    call_out((: shutdown, SYS_SHUTDOWN :), 10);
   } else {
     debug_message("Unknown flag: " + str);
   }

--- a/adm/obj/master/security.lpc
+++ b/adm/obj/master/security.lpc
@@ -1031,16 +1031,20 @@ private int valid_object(object _ob) {
 /**
  * Driver apply: decides whether a file may override an efun.
  *
- * @TODO Update later.
- *
  * @apply
  * @param {string} _file - The file attempting the override.
  * @param {string} _efun_name - The name of the efun being overridden.
- * @param {string} _mainfile - The file defining the override.
- * @returns {int} Always 1.
+ * @param {string} mainfile - The file defining the override.
+ * @returns {int} 1 if permitted, 0 if not.
  */
-private int valid_override(string _file, string _efun_name, string _mainfile) {
-  return 1;
+public int valid_override(string _file, string _efun_name, string mainfile) {
+  if(mainfile == `${ADM_OBJ_SIMUL_EFUN}.lpc`)
+    return 1;
+
+  if(starts_with(mainfile, DIR_ADM_SIMUL_EFUN))
+    return 1;
+
+  return 0;
 }
 
 /**

--- a/adm/simul_efun/override.lpc
+++ b/adm/simul_efun/override.lpc
@@ -46,7 +46,7 @@ void shutdown(int how) {
   object po = previous_object();
 
   if(po != master() && po != load_object(SHUTDOWN_D))
-      return;
+    return;
 
   emit(SIG_SYS_SHUTDOWN);
   PERSIST_D->persist_objects();

--- a/cmds/adm/reboot.lpc
+++ b/cmds/adm/reboot.lpc
@@ -1,0 +1,56 @@
+/**
+ * @file /cmds/adm/reboot.lpc
+ *
+ * Schedules, reports, or cancels a game reboot. A reboot exits the driver and
+ * the run script brings it straight back up. All the work is done by the
+ * shutdown daemon - this command just hands it the argument line.
+ *
+ * @created 2026-07-18 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
+ *
+ * @history
+ * 2026-07-18 - Gesslar - Created
+ */
+
+#include <shutdown.h>
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text =
+    "reboot\n"
+    "reboot <minutes> [reason]\n"
+    "reboot [reason]\n"
+    "reboot now [reason]\n"
+    "reboot halt";
+  help_text =
+    "Schedules a reboot of the game. When it fires, the driver exits and the "
+    "run script restarts it, so the game comes back up on its own.\n"
+    "\n"
+    "With no argument, reports whether a shutdown or reboot is currently "
+    "scheduled.\n"
+    "\n"
+    "A leading number sets the delay in minutes; anything after it is taken as "
+    "the reason. With no number, the whole argument is the reason and the "
+    "default delay of 15 minutes is used. 'now' fires immediately. 'halt' "
+    "cancels a pending shutdown or reboot.\n"
+    "\n"
+    "All connected players are warned as the countdown proceeds.\n"
+    "\n"
+    "  reboot                       report status\n"
+    "  reboot 30 server upgrade     in 30 minutes, with a reason\n"
+    "  reboot applying a hotfix     default delay, with a reason\n"
+    "  reboot now                   immediately\n"
+    "  reboot halt                  cancel a pending shutdown/reboot\n"
+    "\n"
+    "Only admins may use this command.\n"
+    "\n"
+    "See also: shutdown";
+}
+
+mixed main(/** @type {STD_PLAYER} */ object caller, string str) {
+  if(!adminp(caller))
+    return _error(caller, "Access denied.");
+
+  return SHUTDOWN_D->request(SYS_REBOOT, str);
+}

--- a/cmds/adm/shutdown.lpc
+++ b/cmds/adm/shutdown.lpc
@@ -1,0 +1,56 @@
+/**
+ * @file /cmds/adm/shutdown.lpc
+ *
+ * Schedules, reports, or cancels a clean game shutdown. A shutdown exits the
+ * driver cleanly; the run script does not restart it. All the work is done by
+ * the shutdown daemon - this command just hands it the argument line.
+ *
+ * @created 2026-07-18 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
+ *
+ * @history
+ * 2026-07-18 - Gesslar - Created
+ */
+
+#include <shutdown.h>
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text =
+    "shutdown\n"
+    "shutdown <minutes> [reason]\n"
+    "shutdown [reason]\n"
+    "shutdown now [reason]\n"
+    "shutdown halt";
+  help_text =
+    "Schedules a clean shutdown of the game. When it fires, the driver exits "
+    "and the run script stops - the game does not come back up on its own.\n"
+    "\n"
+    "With no argument, reports whether a shutdown or reboot is currently "
+    "scheduled.\n"
+    "\n"
+    "A leading number sets the delay in minutes; anything after it is taken as "
+    "the reason. With no number, the whole argument is the reason and the "
+    "default delay of 15 minutes is used. 'now' fires immediately. 'halt' "
+    "cancels a pending shutdown or reboot.\n"
+    "\n"
+    "All connected players are warned as the countdown proceeds.\n"
+    "\n"
+    "  shutdown                     report status\n"
+    "  shutdown 30 server upgrade   in 30 minutes, with a reason\n"
+    "  shutdown going down for maintenance   default delay, with a reason\n"
+    "  shutdown now                 immediately\n"
+    "  shutdown halt                cancel a pending shutdown/reboot\n"
+    "\n"
+    "Only admins may use this command.\n"
+    "\n"
+    "See also: reboot";
+}
+
+mixed main(/** @type {STD_PLAYER} */ object caller, string str) {
+  if(!adminp(caller))
+    return _error(caller, "Access denied.");
+
+  return SHUTDOWN_D->request(SYS_SHUTDOWN, str);
+}

--- a/include/dirs.h
+++ b/include/dirs.h
@@ -4,6 +4,7 @@
 #define DIR_ADM                 "/adm/"
 #define DIR_ADM_ETC             DIR_ADM "etc/"
 #define DIR_ADM_OBJ             DIR_ADM "obj/"
+#define DIR_ADM_SIMUL_EFUN      DIR_ADM "simul_efun/"
 #define DIR_CMDS                "/cmds/"
 #define DIR_CMDS_ACTION         DIR_CMDS "action/"
 #define DIR_CMDS_ADM            DIR_CMDS "adm/"

--- a/include/objects.h
+++ b/include/objects.h
@@ -3,6 +3,10 @@
 
 #include <dirs.h>
 
+// Admin objects
+#define ADM_OBJ_SIMUL_EFUN      DIR_ADM_OBJ "simul_efun"
+
+// Non-admin objects
 #define OBJ_LOOT                DIR_OBJ           "loot/loot"
 #define OBJ_NODE                DIR_OBJ_NODE      "node"
 

--- a/include/shutdown.h
+++ b/include/shutdown.h
@@ -1,7 +1,15 @@
 #ifndef __SHUTDOWN_H__
 #define __SHUTDOWN_H__
 
-#define SYS_SHUTDOWN  -1
-#define SYS_REBOOT     0
+// Exit codes handed to the driver's shutdown() efun. The run script keys off
+// the process exit status: SYS_REBOOT restarts the driver, SYS_SHUTDOWN stops
+// it. Driver boot failures exit with -1 (255), which the run script also
+// stops on, so a crash on boot never loops.
+#define SYS_SHUTDOWN               0   // clean exit; run script stops
+#define SYS_REBOOT                 1   // exit; run script restarts the driver
+
+// Default delay, in minutes, when an operator schedules a shutdown/reboot
+// without specifying a time.
+#define SHUTDOWN_DEFAULT_MINUTES  15
 
 #endif // __SHUTDOWN_H__

--- a/std/living/ed.lpc
+++ b/std/living/ed.lpc
@@ -24,7 +24,7 @@
 #include <ed.h>
 
 private void finish_exit_callback();
-private void abort_edit();
+protected void abort_edit();
 
 public string query_editing();
 
@@ -137,7 +137,7 @@ private void finish_exit_callback() {
   edit_file = post_edit = temp_file = null;
 }
 
-private void abort_edit() {
+protected void abort_edit() {
   if(!nullp(temp_file))
     defer((: rm, temp_file :));
 


### PR DESCRIPTION
Introduces a proper shutdown/reboot subsystem to replace the previous ad-hoc approach.

**Shutdown Daemon** (`adm/daemons/shutdown.lpc`) is the central authority for all shutdown and reboot operations. It handles scheduling with a configurable delay, countdown warnings broadcast to all connected players at 900, 600, 300, 120, 60, 30, and 10 seconds before firing, cancellation via `halt`, and status reporting. Only one shutdown or reboot may be pending at a time.

**Admin commands** (`cmds/adm/shutdown.lpc`, `cmds/adm/reboot.lpc`) are thin wrappers that forward their argument line to the daemon. Both support the same grammar: no argument reports status, `halt` cancels, `now` fires immediately, a leading number sets the delay in minutes, and any other text is treated as a reason with the default 15-minute delay.

**Exit code semantics** are corrected throughout. `SYS_SHUTDOWN` is now `0` (clean exit, run script stops) and `SYS_REBOOT` is `1` (exit, run script restarts). The run script's restart condition was inverted — it previously restarted on exit code `0` and stopped on `1`, which was backwards. The `flag("builddocs")` path in master is updated to use the named constant.

**`valid_override`** in the security module is tightened from unconditionally returning `1` to permitting efun overrides only from the simul_efun object and its directory, blocking any other file from silently overriding efuns.

**`abort_edit`** in `std/living/ed.lpc` is relaxed from `private` to `protected` so subclasses can call it.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds centralized admin shutdown and reboot handling. The main changes are:

- Adds shutdown and reboot command wrappers.
- Adds countdown scheduling, cancellation, and status reporting.
- Updates driver exit-code handling in the run script.
- Restricts efun overrides to simul_efun code.
- Exposes editor abort cleanup to subclasses.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aadm%2Fobj%2Fmaster%2Fsecurity.lpc%3A1041-1042%0A**Simul%20Efun%20Allowlist%20Never%20Matches**%0A%0AThe%20driver%20passes%20%60mainfile%60%20without%20its%20%60.lpc%60%20suffix.%20Compiling%20%60adm%2Fobj%2Fsimul_efun.lpc%60%20therefore%20supplies%20%60%2Fadm%2Fobj%2Fsimul_efun%60%2C%20but%20this%20branch%20compares%20it%20with%20%60%2Fadm%2Fobj%2Fsimul_efun.lpc%60%3B%20its%20included%20%60efun%3A%3A%60%20calls%20also%20cannot%20match%20the%20%60%2Fadm%2Fsimul_efun%2F%60%20fallback%20because%20their%20main%20file%20remains%20%60%2Fadm%2Fobj%2Fsimul_efun%60.%20The%20new%20default-deny%20policy%20rejects%20every%20required%20efun%20override%20and%20prevents%20the%20simul_efun%20object%20from%20compiling%20at%20boot.%0A%0A%60%60%60suggestion%0A%20%20if%28mainfile%20%3D%3D%20ADM_OBJ_SIMUL_EFUN%29%0A%20%20%20%20return%201%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aadm%2Fdaemons%2Fshutdown.lpc%3A147%0A**Scheduled%20Fire%20Loses%20Caller%20Identity**%0A%0AA%20delayed%20shutdown%20reaches%20%60fire%28%29%60%20through%20this%20%60call_out%60%2C%20where%20%60previous_object%28%29%60%20is%20the%20driver%20rather%20than%20%60SHUTDOWN_D%60.%20The%20shutdown%20simul_efun%20only%20permits%20%60master%28%29%60%20or%20%60load_object%28SHUTDOWN_D%29%60%2C%20so%20it%20returns%20without%20calling%20%60efun%3A%3Ashutdown%28%29%60.%20The%20daemon%20has%20already%20cleared%20%60pending%60%20and%20broadcast%20that%20the%20game%20is%20shutting%20down%2C%20leaving%20the%20driver%20running%20and%20status%20reporting%20no%20scheduled%20operation.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["shutdown and reboot"](https://github.com/gesslar/oxidus-mudlib/commit/161c0c2ca344e5ca48b5641b0334ee04fc431413) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45294740)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->