### PR TITLE
Replace `previous_object()` with `this_caller()` in `command.lpc` permission checks

### DIFF
--- a/std/object/command.lpc
+++ b/std/object/command.lpc
@@ -253,7 +253,7 @@ public int add_path(string path) {
     "Path must be a string."
   );
 
-  if(!adminp(previous_object()) && this_body() != this_object())
+  if(!adminp(this_caller()) && this_body() != this_object())
     return 0;
 
   __command_paths ??= ({});
@@ -311,7 +311,7 @@ public int rem_path(string path) {
     "Path must be a string."
   );
 
-  if(!adminp(previous_object()) && this_body() != this_object())
+  if(!adminp(this_caller()) && this_body() != this_object())
     return 0;
 
   __command_paths ??= ({});
@@ -388,7 +388,7 @@ public void add_ghost_paths() {
  */
 public nomask varargs string *query_command_history(int index, int range) {
   if(    this_body() != this_object()
-      && !adminp(previous_object())
+      && !adminp(this_caller())
     )
     return ({});
 


### PR DESCRIPTION
Replace `previous_object()` with `this_caller()` in permission checks for `add_path`, `rem_path`, and `query_command_history` to ensure admin privilege validation uses the correct caller context.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates command permission checks to use the initiating caller context.

- Updates `add_path()` authorization.
- Updates `rem_path()` authorization.
- Updates `query_command_history()` authorization.
</details>

<sub>Reviews (1): Last reviewed commit: ["fixing to this\_caller"](https://github.com/gesslar/oxidus-mudlib/commit/5827f8a728e4f2a87a7615caf476da893903db57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45346182)</sub>

<!-- /greptile_comment -->