### PR TITLE
Skip appending newline for `question` feedback type

### DIFF
--- a/adm/simul_efun/system.lpc
+++ b/adm/simul_efun/system.lpc
@@ -303,10 +303,14 @@ private int _feedback(string type, mixed args...) {
   if(!result)
     return 0;
 
-  if(tp && interactive(tp))
-    tell(tp, append(result.message, "\n"));
-  else
+  if(tp && interactive(tp)) {
+    if(type == "question")
+      tell(tp, result.message);
+    else
+      tell(tp, append(result.message, "\n"));
+  } else {
     debug(result.message);
+  }
 
   return 1;
 }


### PR DESCRIPTION
When sending a `question` type feedback message to an interactive player, the trailing newline is omitted. This prevents a newline from appearing between the question prompt and the player's input cursor.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR keeps question prompts on the same line as player input.

- Skips the trailing newline for interactive `question` feedback.
- Keeps newline-delimited output for other feedback types.
</details>

<sub>Reviews (2): Last reviewed commit: ["on prompts, don&#39;t force new line"](https://github.com/gesslar/oxidus-mudlib/commit/bccbb3bd62767a5dba85ed3507fc2541d84c5d62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45346185)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))

<!-- /greptile_comment -->