### PR TITLE
Add `nuke` admin command for single-character wipe; clean up `awipe` formatting

### DIFF
--- a/cmds/adm/awipe.lpc
+++ b/cmds/adm/awipe.lpc
@@ -33,7 +33,7 @@ mixed main(/** @type {STD_PLAYER} */ object caller, string account) {
     return _error("Access denied.");
 
   if(!account)
-    return _info("Usage: awipe <account>");
+    return _usage(caller);
 
   account = lower_case(account);
 
@@ -42,8 +42,9 @@ mixed main(/** @type {STD_PLAYER} */ object caller, string account) {
 
   _question(
     caller,
-    "Are you sure you want to delete account " + account + " and all of its "
-    "characters? [y/n] ", MSG_PROMPT
+    "Are you sure you want to delete account %s and all of its "
+    "characters? [y/n] ",
+    account
   );
 
   input_to("confirm_awipe", 0, caller, account);
@@ -53,7 +54,7 @@ mixed main(/** @type {STD_PLAYER} */ object caller, string account) {
 
 void confirm_awipe(string str, object caller, string account) {
   if(str != "y" && str != "yes") {
-    _info(caller, "Abort [awipe]: Aborting account wipe.");
+    _info(caller, "Aborting account wipe.");
     return;
   }
 
@@ -68,13 +69,14 @@ void confirm_awipe(string str, object caller, string account) {
     master()->purge_roles(character);
 
     if(body = find_player(character)) {
-      _info(caller, "Disconnecting user '" + character + "'.");
+      _info(caller, "Disconnecting user '%s'.", character);
       _ok(body, "You watch as your body dematerializes.");
 
       if(environment(body)) {
         tell_down(
           environment(body),
-          "You watch as " + capitalize(character) + " dematerializes before your eyes.\n",
+          `You watch as ${capitalize(character)} dematerializes before your `
+          `eyes.\n`,
           0,
           ({ body })
         );
@@ -111,5 +113,7 @@ void confirm_awipe(string str, object caller, string account) {
   }
 
   _ok(caller, "Account '%s' has been wiped.", account);
-  log_file(LOG_AWIPE, capitalize(query_privs(caller)) + " awipes account " + account + " on " + ctime(time()) + "\n");
+  log_file(LOG_AWIPE,
+    `${capitalize(query_privs(caller))} awipes account ${account} on `
+    `${ldatetime()}\n`);
 }

--- a/cmds/adm/nuke.lpc
+++ b/cmds/adm/nuke.lpc
@@ -1,0 +1,110 @@
+/**
+ * @file /cmds/adm/nuke.lpc
+ *
+ * Character wipe command. Mirrors awipe, but operates on a single character,
+ * removing that character's pfile, bank account, and group memberships, and
+ * detaching it from its owning account. The account itself is left intact.
+ *
+ * @created 2026-07-18 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
+ *
+ * @history
+ * 2026-07-18 - Gesslar - Created
+ */
+
+#include <logs.h>
+
+inherit STD_CMD;
+
+void confirm_nuke(string str, object caller, string character);
+
+void setup() {
+  usage_text = "nuke <character>";
+  help_text =
+    "This command deletes the target character, removing its pfile, bank "
+    "account, and group memberships from " + mud_name() + ", and detaching it "
+    "from its owning account. The account and its other characters are left "
+    "intact. This is NON-REVERSIBLE, so use with discretion.\n"
+    "\n"
+    "See also: awipe";
+}
+
+mixed main(/** @type {STD_PLAYER} */ object caller, string character) {
+  if(!adminp(previous_object()))
+    return _error("Access denied.");
+
+  if(!character)
+    return _usage(caller);
+
+  character = lower_case(character);
+
+  if(!user_exists(character))
+    return _error("Character '%s' does not exist.", character);
+
+  _question(
+    caller,
+    "Are you sure you want to delete character %s? [y/n] ",
+    character
+  );
+
+  input_to("confirm_nuke", 0, caller, character);
+
+  return 1;
+}
+
+void confirm_nuke(string str, object caller, string character) {
+  if(str != "y" && str != "yes") {
+    _info(caller, "Aborting character wipe.");
+    return;
+  }
+
+  object body;
+
+  _info(caller, "Wiping character '%s'.", character);
+
+  master()->purge_roles(character);
+
+  if(body = find_player(character)) {
+    _info(caller, "Disconnecting user '%s'.", character);
+    _ok(body, "You watch as your body dematerializes.");
+
+    if(environment(body)) {
+      tell_down(
+        environment(body),
+        `You watch as ${capitalize(character)} dematerializes before your eyes.\n`,
+        0,
+        ({ body })
+      );
+    }
+
+    body->remove();
+  }
+
+  _info(caller, "Removing bank account for user '%s'.", capitalize(character));
+  BANK_D->remove_account(character, caller);
+
+  string user_dir = user_data_directory(character);
+  if(directory_exists(user_dir)) {
+    mixed err;
+
+    _info(caller, "Deleting user directory for user '%s'.", capitalize(character));
+    err = catch(recursive_delete(as_directory(user_dir), true));
+
+    if(err) {
+      _error(caller, "Error while deleting user directory: %s", err);
+      return;
+    }
+  }
+
+  string account = ACCOUNT_D->character_account(character);
+  if(account) {
+    _info(caller, "Detaching character from account '%s'.", account);
+    ACCOUNT_D->remove_character(account, character);
+  }
+
+  _ok(caller, "Character '%s' has been nuked.", character);
+  log_file(LOG_NUKE,
+    `${capitalize(query_privs(caller))} nukes character ${character} on `
+    `${ldatetime()}\n`
+  );
+}


### PR DESCRIPTION
Adds a new `nuke` admin command that wipes a single character without affecting the rest of its account. Unlike `awipe`, which removes an entire account and all associated characters, `nuke` targets one character specifically — deleting its pfile, bank account, and group memberships, and detaching it from its owning account while leaving the account and other characters intact.

Also cleans up `awipe` to use `_usage()` for the usage message, `ldatetime()` instead of `ctime(time())` for log timestamps, template literals for string interpolation, and a shorter abort message.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a single-character administrative wipe command and updates the account wipe command. The main changes are:

- Add `nuke` for character-specific cleanup.
- Remove the target’s bank, pfile, roles, and account association.
- Update `awipe` prompts and log formatting.
</details>

<sub>Reviews (3): Last reviewed commit: ["new nuke command"](https://github.com/gesslar/oxidus-mudlib/commit/70789cb14cc5eb5fce32f0c47c73661dd7dbf919) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45346186)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->