### PR TITLE
Replace string-based `input_to` callbacks with function references in `ed.lpc`

### DIFF
--- a/std/living/ed.lpc
+++ b/std/living/ed.lpc
@@ -23,6 +23,7 @@
 
 #include <ed.h>
 
+private void parse_input(string input);
 private void finish_exit_callback();
 protected void abort_edit();
 
@@ -83,7 +84,7 @@ public int start_edit(string file, mixed *cb) {
 
   tell(this_object(), text);
 
-  input_to("parse_input", 0);
+  input_to(parse_input, 0);
 }
 
 private void parse_input(string input) {
@@ -97,7 +98,7 @@ private void parse_input(string input) {
 
   tell(this_object(), "║ ");
 
-  input_to("parse_input", 0);
+  input_to(parse_input, 0);
 }
 
 private void finish_exit_callback() {
@@ -211,7 +212,7 @@ private void ed_line(string line) {
 private void ed_continue() {
   if(in_edit(this_object())) {
     tell(this_object(), ed_prompt());
-    input_to("ed_line", 0);
+    input_to(ed_line, 0);
   } else {
     mixed *cb = ed_post;
     string target = ed_target;


### PR DESCRIPTION
Convert `input_to` calls from string-based function references to direct function pointer references throughout the ed editing system. This also adds a missing forward declaration for `parse_input` to support the function pointer usage.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the editor's deferred input callbacks to use function references.

- Adds a forward declaration for `parse_input`.
- Converts `parse_input` callback registrations.
- Converts the `ed_line` callback registration.
</details>

<sub>Reviews (1): Last reviewed commit: ["fixing ed"](https://github.com/gesslar/oxidus-mudlib/commit/7f1ae70a9ab1d8b70e9ee9d167b6f0c7dcbbd30d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45377549)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->