### PR TITLE
Replace JSON config files with LPML format in time daemon

### DIFF
--- a/adm/daemons/time.lpc
+++ b/adm/daemons/time.lpc
@@ -1,8 +1,9 @@
 /**
  * @file /adm/daemons/time.lpc
- * This is the game's time daemon. It is responsible for keeping
- * track of the game's time and date. It also provides functions for converting
- * the game's time to real time and vice versa.
+ *
+ * This is the game's time daemon. It is responsible for keeping track of the
+ * game's time and date. It also provides functions for converting the game's
+ * time to real time and vice versa.
  *
  * @created 2024-08-05 - Gesslar
  * @last_modified 2024-08-05 - Gesslar
@@ -24,9 +25,9 @@ private nosave int year_start, months_in_year, days_in_year, hour_length, hours_
 void setup() {
   int next_day;
 
-  config = json_decode(read_file("/adm/etc/time/time.json"));
-  months = json_decode(read_file("/adm/etc/time/months.json"));
-  seasons = json_decode(read_file("/adm/etc/time/seasons.json"));
+  config = load_lpml("/adm/etc/time/time.lpml");
+  months = load_lpml("/adm/etc/time/months.lpml");
+  seasons = load_lpml("/adm/etc/time/seasons.lpml");
 
   months_in_year = sizeof(months);
   days_in_year = sum(map(months, (: $1[1] :)));


### PR DESCRIPTION
Converts the time daemon's configuration files from JSON to LPML format, updating the loading of `time`, `months`, and `seasons` configuration files accordingly.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves the time daemon configuration from JSON files to LPML files.

- Loads time settings from `time.lpml`.
- Loads months from `months.lpml`.
- Loads seasons from `seasons.lpml`.
</details>

<sub>Reviews (2): Last reviewed commit: ["fixing time"](https://github.com/gesslar/oxidus-mudlib/commit/9e8b4864094d20dffe0da239b71eb5429e91b2be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45377550)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->