### PR TITLE
Add `wall` dev command to broadcast message to all users

### DIFF
--- a/adm/simul_efun/messaging.lpc
+++ b/adm/simul_efun/messaging.lpc
@@ -59,7 +59,7 @@ varargs void tell_direct(object ob, string str, int msg_type) {
  * @param {string} str - The message string to send (sent to previous_object()).
  *
  * @overload
- * @param {object} ob - The object to send the message to.
+ * @param {object | object*} ob - The object to send the message to.
  * @param {string} str - The message string to send.
  * @param {int} [msg_type] - The message type.
  *

--- a/cmds/dev/wall.lpc
+++ b/cmds/dev/wall.lpc
@@ -1,0 +1,30 @@
+/**
+ * @file /cmds/dev/wall.lpc
+ *
+ * Write to all.
+ *
+ * @created 2026-07-18 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
+ *
+ * @history
+ * 2026-07-18 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+void setup() {
+  usage_text = "wall <text>";
+}
+
+mixed main(
+  /** @type {STD_PLAYER} */ object tp,
+  string str
+) {
+  if(!str)
+    return _usage(tp);
+
+  object *users = filter(users(), (: environment :));
+  tell(users, `[${ldatetime()}] - ${tp->query_name()}\n\n${append(str, "\n")}`);
+
+  return 1;
+}


### PR DESCRIPTION
Adds a `wall` command for developers that broadcasts a message to all connected users who are in an environment. The message is prefixed with the current datetime and the sender's name.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a developer broadcast command. The main changes are:

- Adds `wall <text>` for connected users in environments.
- Formats broadcasts with the current datetime and sender name.
- Documents array targets for direct messaging.
</details>

<sub>Reviews (4): Last reviewed commit: ["new wall command"](https://github.com/gesslar/oxidus-mudlib/commit/5704dfb3c4d19043d04ad2feaf534c828b4799c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45377556)</sub>

<!-- /greptile_comment -->