### PR TITLE
Add `clean` object command to destruct non-living inventory

### DIFF
--- a/cmds/object/clean.lpc
+++ b/cmds/object/clean.lpc
@@ -1,0 +1,54 @@
+/**
+ * @file /cmds/object/clean.lpc
+ *
+ * Clean the inventory of an object.
+ *
+ * @created 2026-07-18 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
+ *
+ * @history
+ * 2026-07-18 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+mixed main(
+  /** @type {STD_PLAYER} */ object _tp,
+  string str
+) {
+  str ||= "here";
+
+  object container = get_object(str);
+  if(!container)
+    return _info("Cannot find %s.", str);
+
+  if(!/** @type {STD_CONTAINER} */ (container)->is_container())
+    return _info("%O is not a container.", container);
+
+  /** @type {STD_OBJECT} */ object ob = first_inventory(container);
+  if(!ob)
+    return _info("Nothing to clean in %O.", container);
+
+  int num;
+  do {
+    object next = next_inventory(ob);
+
+    if(living(ob)) {
+      ob = next;
+    } else {
+      string destructed = ob_short(ob);
+      catch(ob->remove());
+      if(ob) {
+        catch(destruct(ob));
+      }
+      _info("Destructed %s", destructed);
+      ob = next;
+      num++;
+    }
+  } while(ob);
+
+  if(!num)
+    return _info("Nothing to clean in %O.", container);
+  else
+    return _info("Cleaned %d objects in %O.", num, container);
+}


### PR DESCRIPTION
Adds a new `clean` wizard command that removes all non-living objects from a target container's inventory. When given a container name (defaulting to `"here"`), it iterates through the inventory, skips living objects, and destructs everything else, reporting each destructed object and a final count of how many were removed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a wizard command for cleaning object inventories.

- Adds `cmds/object/clean.lpc`.
- Resolves a target container, defaulting to the current room.
- Removes non-living objects and reports the removal count.
</details>

<sub>Reviews (4): Last reviewed commit: ["new clean command"](https://github.com/gesslar/oxidus-mudlib/commit/fc2123774a22c7b298c77ebb0ceb74b577da1007) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45377557)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->