### PR TITLE
Add `date` command to display current server time

### DIFF
--- a/cmds/std/date.lpc
+++ b/cmds/std/date.lpc
@@ -1,0 +1,20 @@
+/**
+ * @file /cmds/std/date.lpc
+ *
+ * The current server date.
+ *
+ * @created 2026-07-18 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
+ *
+ * @history
+ * 2026-07-18 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+mixed main(
+  /** @type {STD_PLAYER} */ object _tp,
+  string _str
+) {
+  return `Server time: ${ldatetime()}`;
+}


### PR DESCRIPTION
Adds a `date` command that displays the current server time to the player using `ldatetime()`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a standard command for showing the current server time.

- Adds `/cmds/std/date.lpc`.
- Returns the value from `ldatetime()` through the standard command result path.
</details>

<sub>Reviews (4): Last reviewed commit: ["new date command"](https://github.com/gesslar/oxidus-mudlib/commit/5cb8b4eb73aae82efeba4ed631396fa69c72b450) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45377558)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->