### PR TITLE
Add `who` command with role-sorted player listing

### DIFF
--- a/cmds/std/who.lpc
+++ b/cmds/std/who.lpc
@@ -1,0 +1,64 @@
+/**
+ * @file /cmds/std/who.lpc
+ *
+ * The who command.
+ *
+ * @created 2026-07-18 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
+ *
+ * @history
+ * 2026-07-18 - Gesslar - Created
+ */
+
+inherit STD_CMD;
+
+int sort_users(object a, object b);
+
+mixed main(
+  /** @type {STD_PLAYER} */ object _tp,
+  string _str
+) {
+  object *all = users();
+  all = filter(all, (: environment :));
+  all = sort_array(all, sort_users);
+
+  string *names = map(all, function(/** @type {STD_PLAYER} */ object user) {
+    if(ownerp(user))
+      return sprintf("[owner] %s", user->query_name());
+    if(adminp(user))
+      return sprintf("[admin] %s", user->query_name());
+    if(devp(user))
+      return sprintf("[ dev ] %s", user->query_name());
+
+    return sprintf("denizen %s", user->query_name());
+  });
+
+  return names;
+}
+
+/**
+ *
+ * @param {STD_PLAYER} a
+ * @param {STD_PLAYER} b
+ */
+int sort_users(object a, object b) {
+  if(ownerp(a)) {
+    if(ownerp(b))
+      return strcmp(a->query_name(), b->query_name());
+    return -1;
+  }
+
+  if(adminp(a)) {
+    if(adminp(b))
+      return strcmp(a->query_name(), b->query_name());
+    return -1;
+  }
+
+  if(devp(a)) {
+    if(devp(b))
+      return strcmp(a->query_name(), b->query_name());
+    return -1;
+  }
+
+  return strcmp(a->query_name(), b->query_name());
+}


### PR DESCRIPTION
Adds a `who` command that displays a list of currently connected players who are in an environment. Players are sorted and labeled by privilege level — owners, admins, and devs appear first (in that order), each with a corresponding tag, while regular players are listed as "denizen". Within each group, players are sorted alphabetically by name.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `who` command for listing connected players. The main changes are:

- Filters connected users that are present in an environment.
- Sorts players by owner, admin, developer, and denizen roles.
- Returns labeled player names through the standard command output path.
</details>

<sub>Reviews (4): Last reviewed commit: ["who"](https://github.com/gesslar/oxidus-mudlib/commit/086a723005140e32750c9bb8aad25c35907cc317) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45377561)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->