### PR TITLE
Change `error` symbol from black circle to bullet point

### DIFF
--- a/adm/simul_efun/system.lpc
+++ b/adm/simul_efun/system.lpc
@@ -187,7 +187,7 @@ varargs void debug(mixed str, mixed args...) {
 
 private nosave mapping _symbols = ([
   "ok"      : ({ ({ SYSTEM_OK,      "" }), ({ "\u2022 ", "o ", "" }) }), // • = bullet point
-  "error"   : ({ ({ SYSTEM_ERROR,   "" }), ({ "\u25CF ", "o ", "" }) }), // ● = black circle
+  "error"   : ({ ({ SYSTEM_ERROR,   "" }), ({ "\u2022 ", "o ", "" }) }), // • = bullet point
   "warn"    : ({ ({ SYSTEM_WARNING, "" }), ({ "\u25B2 ", "o ", "" }) }), // ▲ = black up-pointing triangle
   "info"    : ({ ({ SYSTEM_INFO,    "" }), ({ "\u25E6 ", "o ", "" }) }), // ◦ = white bullet
   "question": ({ ({ SYSTEM_QUERY,   "" }), ({ "\u25C6 ", "o ", "" }) }), // ◆ = black diamond


### PR DESCRIPTION
Changes the error symbol from a black circle (●) to a bullet point (•), making it consistent with the `ok` symbol.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the Unicode symbol used for error feedback.

- Changes the error glyph from `●` to `•`.
- Keeps the existing colour and fallback symbol mappings.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aadm%2Fsimul_efun%2Fsystem.lpc%3A190%0A**Colourless%20output%20loses%20error%20marker**%0A%0AUnicode-capable%20clients%20that%20disable%20or%20strip%20colour%20now%20receive%20the%20identical%20%60%E2%80%A2%20%60%20prefix%20for%20%60_ok%28%29%60%20and%20%60_error%28%29%60%20messages.%20Before%20this%20change%2C%20the%20error%20path%20retained%20a%20distinct%20%60%E2%97%8F%20%60%20marker%20in%20plain-text%20output%3B%20restoring%20a%20distinct%20error%20glyph%20preserves%20that%20semantic%20distinction%20when%20%60SYSTEM_ERROR%60%20colour%20is%20unavailable.%0A%0A%60%60%60suggestion%0A%20%20%22error%22%20%20%20%3A%20%28%7B%20%28%7B%20SYSTEM_ERROR%2C%20%20%20%22%22%20%7D%29%2C%20%28%7B%20%22%5Cu25CF%20%22%2C%20%22o%20%22%2C%20%22%22%20%7D%29%20%7D%29%2C%20%2F%2F%20%E2%97%8F%20%3D%20black%20circle%0A%60%60%60%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=363&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["making the bullet smaller for error"](https://github.com/gesslar/oxidus-mudlib/commit/5a45cd4f18f1b6b4a8018394b6ff2b661c953652) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45380303)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->