### PR TITLE
Add `give` command and coin-aware `get`/`drop` with `all` quantifier support

### DIFF
--- a/adm/daemons/action.lpc
+++ b/adm/daemons/action.lpc
@@ -651,6 +651,41 @@ varargs void other_action(mixed msg, mixed *obs...) {
 }
 
 /**
+ * Generates and sends a message to everyone except the actor and target.
+ *
+ * Like other_action, but the target is also excluded from the room broadcast.
+ * Pair it with my_target_action/target_action when the actor and target should
+ * see something the rest of the room does not (e.g. a precise coin count while
+ * bystanders see only a vague quantity).
+ *
+ * @param {string|string*} msg - Message template or array of templates
+ * @param {object} target - The target of the action
+ * @param {mixed*} obs - Variable number of objects involved
+ */
+varargs void other_target_action(mixed msg, object target, mixed *obs...) {
+  string others;
+  string str_msg;
+  object *who;
+
+  if(!sizeof(msg))
+    return;
+
+  who = ({ previous_object(), target });
+
+  if(pointerp(msg))
+    msg = element_of(msg);
+
+  str_msg = /** @type {string} */ (msg);
+  others = compose_message(0, str_msg, who, obs...);
+
+  tell_down(all_inventory(previous_object()), others);
+  tell_down(all_inventory(target), others);
+
+  if(environment(previous_object()))
+    tell_all(environment(previous_object()), others, null, who);
+}
+
+/**
  * Generates and sends messages for an action involving an actor and target.
  *
  * @param {string|string*} msg - Message template or array of templates

--- a/cmds/action/drop.lpc
+++ b/cmds/action/drop.lpc
@@ -4,13 +4,39 @@
  * The drop command.
  *
  * @created 2026-07-16 - Gesslar
- * @last_modified 2026-07-16 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
  *
  * @history
  * 2026-07-16 - Gesslar - Created
+ * 2026-07-18 - Gesslar - Added 'all' and 'all <type>' quantifiers
  */
 
 inherit STD_ACT;
+
+private mixed drop_all(object tp, string ob_id);
+private mixed drop_coins(object tp, string arg);
+private mixed drop_all_coins(object tp);
+private mixed drop_coin_pile(object tp, string currency, int amount);
+
+void setup() {
+  usage_text =
+    "drop <object>\n"
+    "drop all\n"
+    "drop all <object>\n"
+    "drop <number> <currency>\n"
+    "drop <currency>\n";
+  help_text =
+    "This command drops an object you are carrying onto the ground. Name a "
+    "single object to drop just that one, or use 'all' to drop everything (or "
+    "everything of a given type).\n"
+    "\n"
+    "Coins are carried as wealth rather than as items, so name a currency to "
+    "drop coins: 'drop 5 silver' drops five silver coins, while 'drop silver' "
+    "(or 'drop all silver') drops all of your silver. Bare 'drop all' leaves "
+    "your coins alone.\n"
+    "\n"
+    "See also: get, put\n";
+}
 
 mixed main(
   /** @type {STD_BODY} */ object tp,
@@ -18,6 +44,28 @@ mixed main(
 ) {
   if(!arg)
     return "Drop what?";
+
+  // Coins live in the wealth pool, not inventory. A request naming a currency
+  // ('drop 5 silver', 'drop silver', 'drop all gold') materialises coin
+  // objects on the ground instead of moving an inventory item.
+  mixed coins = drop_coins(tp, arg);
+  if(!nullp(coins))
+    return coins;
+
+  // Detect an "all" quantifier: bare "all" (everything) or "all <type>".
+  int all_flag = 0;
+  string rest;
+
+  if(arg == "all") {
+    all_flag = 1;
+    arg = 0;
+  } else if(sscanf(arg, "all %s", rest) == 1) {
+    all_flag = 1;
+    arg = rest;
+  }
+
+  if(all_flag)
+    return drop_all(tp, arg);
 
   /** @type {STD_ITEM} */ object ob = get_object(arg);
   if(   !ob
@@ -28,10 +76,161 @@ mixed main(
   if(call_if(ob, "prevent_drop", tp))
     return "You cannot drop that.";
 
+  // Capture the short before moving; some objects (coins) auto-destruct when
+  // they change inventory, leaving nothing to describe afterwards.
+  string sh = get_short(ob);
+
   if(ob->move(environment(tp)))
     return "You could not drop that.";
 
-  tp->simple_action("$N $vdrop a $o.", ob);
+  tp->simple_action("$N $vdrop a $o.", sh);
+
+  return 1;
+}
+
+private mixed drop_all(
+  /** @type {STD_BODY} */ object tp,
+  string ob_id
+) {
+  /** @type {STD_ROOM} */ object room = environment(tp);
+  object *obs = find_targets(tp, ob_id, tp);
+  int dropped = 0;
+
+  if(!sizeof(obs))
+    return ob_id
+      ? `You are not carrying any ${ob_id}.`
+      : "You are not carrying anything.";
+
+  foreach(/** @type {STD_ITEM} */ object ob in obs) {
+    if(call_if(ob, "prevent_drop", tp))
+      continue;
+
+    // Capture the short before moving; coins auto-destruct on changing
+    // inventory, leaving nothing to describe.
+    string sh = get_short(ob);
+
+    if(ob->move(room))
+      continue;
+
+    tp->simple_action("$N $vdrop a $o.", sh);
+    dropped++;
+  }
+
+  if(!dropped)
+    return "You could not drop anything.";
+
+  return 1;
+}
+
+// Routes a currency request to the wealth pool. Recognises "drop <n> <type>",
+// "drop all <type>", and "drop all coin(s)" (every currency). Bare "drop
+// <type>" is intentionally NOT handled here - an item may be described with a
+// currency word (e.g. a silver ingot), so a plain name must fall through to a
+// normal item drop. Returns undefined when the request is not about coins.
+private mixed drop_coins(
+  /** @type {STD_BODY} */ object tp,
+  string arg
+) {
+  string currency, base;
+  int amount = 0;
+  int all = 0;
+
+  if(sscanf(arg, "%d %s", amount, currency) == 2) {
+    // "drop 5 silver"
+  } else if(sscanf(arg, "all %s", currency) == 1) {
+    all = 1;                                    // "drop all silver" / "all coins"
+  } else {
+    return undefined;
+  }
+
+  // Accept "silver coin" / "silver coins" as "silver".
+  if(sscanf(currency, "%s coin", base) == 1 && strlen(base))
+    currency = base;
+
+  currency = lower_case(trim(currency));
+
+  // Bare "coin"/"coins", only with 'all', means every currency at once.
+  if(all && (currency == "coin" || currency == "coins"))
+    return drop_all_coins(tp);
+
+  if(!CURRENCY_D->valid_currency_type(currency))
+    return undefined;
+
+  int have = tp->query_wealth(currency);
+
+  if(have < 1)
+    return `You have no ${currency} coins.`;
+
+  if(all)
+    amount = have;
+
+  if(amount < 1)
+    return `Drop how many ${currency} coins?`;
+
+  if(amount > have)
+    return `You only have ${have} ${currency} ${have == 1 ? "coin" : "coins"}.`;
+
+  return drop_coin_pile(tp, currency, amount);
+}
+
+// Drops every currency the body holds. Bare "drop all" never reaches here;
+// this is only for the explicit "drop all coin(s)" form.
+private mixed drop_all_coins(/** @type {STD_BODY} */ object tp) {
+  mapping wealth = tp->query_all_wealth();
+  int dropped = 0;
+
+  if(!tp->query_total_coins())
+    return "You have no coins to drop.";
+
+  foreach(string currency, int amount in wealth) {
+    if(amount < 1)
+      continue;
+
+    if(drop_coin_pile(tp, currency, amount) == 1)
+      dropped++;
+  }
+
+  if(!dropped)
+    return "You could not drop your coins.";
+
+  return 1;
+}
+
+// Deducts <amount> of <currency> from the wealth pool and materialises a coin
+// object on the ground, refunding the pool if the drop fails.
+private mixed drop_coin_pile(
+  /** @type {STD_BODY} */ object tp,
+  string currency,
+  int amount
+) {
+  mixed res = tp->adjust_wealth(currency, -amount);
+  if(stringp(res))
+    return res;
+
+  /** @type {LIB_COIN} */ object coin = new(LIB_COIN);
+  coin->set_up(currency, amount);
+
+  if(coin->move(environment(tp))) {
+    if(coin)
+      coin->remove();
+
+    tp->adjust_wealth(currency, amount);       // refund the deduction
+
+    return `You could not drop the ${currency} coins.`;
+  }
+
+  // The actor sees the exact count; everyone else sees a vague quantity.
+  string self_phrase, other_phrase;
+
+  if(amount == 1) {
+    self_phrase = other_phrase = add_article(`${currency} coin`);
+  } else {
+    self_phrase = `${amount} ${currency} coins`;
+    other_phrase = `some ${currency} coins`;
+  }
+
+  tp->my_action("$N $vdrop $o.", self_phrase);
+  tp->other_action("$N $vdrop $o.", other_phrase);
 
   return 1;
 }

--- a/cmds/action/get.lpc
+++ b/cmds/action/get.lpc
@@ -1,16 +1,39 @@
 /**
- * @file /cmds/std/get.lpc
+ * @file /cmds/action/get.lpc
  *
  * The get command. Picks things up and out of containers.
  *
  * @created 2026-07-16 - Gesslar
- * @last_modified 2026-07-16 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
  *
  * @history
  * 2026-07-16 - Gesslar - Created
+ * 2026-07-18 - Gesslar - Added 'all' and 'all <type>' quantifiers, from the
+ *                        room or from a container
  */
 
 inherit STD_ACT;
+
+private mixed get_all(object tp, object env, string ob_id);
+private void announce_get(object tp, string *phrase, object env, int from_room);
+private string *get_phrase(object ob);
+
+void setup() {
+  usage_text =
+    "get <object>\n"
+    "get all\n"
+    "get all <object>\n"
+    "get <object> from <container>\n"
+    "get all from <container>\n"
+    "get all <object> from <container>\n";
+  help_text =
+    "This command picks things up off the ground or out of a container. Name a "
+    "single object to get just that one, or use 'all' to get everything (or "
+    "everything of a given type). With 'from <container>', it takes from the "
+    "named container instead of the room.\n"
+    "\n"
+    "See also: drop, put\n";
+}
 
 mixed main(
   /** @type {STD_BODY} */ object tp,
@@ -34,11 +57,31 @@ mixed main(
     env = environment(tp);
   }
 
+  // A living has an inventory (so is_container() is true), but you don't get
+  // things out of people - that would be theft, not a plain get.
+  if(living(env))
+    return `You cannot get anything from ${get_short(env)}.`;
+
   if(!env->is_container())
-    return `${/** @type {STD_ITEM} */ (env)->query_short()} is not a container.`;
+    return `${get_short(env)} is not a container.`;
 
   if(env->is_closed())
-    return `The ${/** @type {STD_ITEM} */ (env)->query_short()} is closed.`;
+    return `${get_short(env)} is closed.`;
+
+  // Detect an "all" quantifier: bare "all" (everything) or "all <type>".
+  int all_flag = 0;
+  string rest;
+
+  if(ob_id == "all") {
+    all_flag = 1;
+    ob_id = 0;
+  } else if(sscanf(ob_id, "all %s", rest) == 1) {
+    all_flag = 1;
+    ob_id = rest;
+  }
+
+  if(all_flag)
+    return get_all(tp, env, ob_id);
 
   /** @type {STD_ITEM} */ object ob = present(ob_id, env);
   if(    !ob
@@ -47,17 +90,103 @@ mixed main(
     return `You do not see ${ob_id}.`;
   }
 
+  if(living(ob))
+    return `You cannot get ${get_short(ob)}.`;
+
   if(call_if(ob, "prevent_get", tp))
     return 1;
 
-  if(ob->move(tp))
-    return `You could not get the ${ob->query_short()}.`;
+  // Build the description before moving; coins auto-destruct on entering
+  // inventory (or merging), leaving nothing to describe afterwards.
+  string sh = get_short(ob);
+  string *phrase = get_phrase(ob);
 
-  if(env == environment(tp)) {
-    tp->simple_action("$N $vpick up a $o.", ob);
-  } else {
-    tp->simple_action("$N $vget a $o from a $o1.", ob, env);
-  }
+  if(ob->move(tp))
+    return `You could not get the ${sh}.`;
+
+  announce_get(tp, phrase, env, env == environment(tp));
 
   return 1;
+}
+
+private mixed get_all(
+  /** @type {STD_BODY} */ object tp,
+  /** @type {STD_ROOM|STD_CONTAINER} */ object env,
+  string ob_id
+) {
+  int from_room = env == environment(tp);
+
+  // Livings are never picked up, and never the actor themselves.
+  object *obs = find_targets(tp, ob_id, env, (: !living($1) :));
+  int got = 0;
+
+  if(!sizeof(obs)) {
+    if(ob_id)
+      return `You do not see any ${ob_id}.`;
+
+    return from_room
+      ? "There is nothing here to get."
+      : `The ${get_short(env)} is empty.`;
+  }
+
+  foreach(/** @type {STD_ITEM} */ object ob in obs) {
+    if(call_if(ob, "prevent_get", tp))
+      continue;
+
+    // Build the description before moving; coins auto-destruct on entering
+    // inventory (or merging), leaving nothing to describe.
+    string *phrase = get_phrase(ob);
+
+    if(ob->move(tp))
+      continue;
+
+    announce_get(tp, phrase, env, from_room);
+    got++;
+  }
+
+  if(!got)
+    return "You could not get anything.";
+
+  return 1;
+}
+
+// Emits the pick-up / get-from-container message. <phrase> is ({ self, others })
+// so a coin pile can tell the actor the exact count while everyone else sees a
+// vague quantity.
+private void announce_get(
+  /** @type {STD_BODY} */ object tp,
+  string *phrase,
+  /** @type {STD_ROOM|STD_CONTAINER} */ object env,
+  int from_room
+) {
+  if(from_room) {
+    tp->my_action("$N $vpick up $o.", phrase[0]);
+    tp->other_action("$N $vpick up $o.", phrase[1]);
+  } else {
+    tp->my_action("$N $vget $o from a $o1.", phrase[0], env);
+    tp->other_action("$N $vget $o from a $o1.", phrase[1], env);
+  }
+}
+
+// Builds ({ self_phrase, others_phrase }) for a picked-up object. The actor sees
+// the exact coin count ("27 copper coins"); others see a vague quantity ("some
+// copper coins"). A single coin and any non-coin read the same for both. MUST be
+// called before the object moves, since a coin self-destructs on entering
+// inventory or merging into a ground pile.
+private string *get_phrase(/** @type {STD_ITEM} */ object ob) {
+  int cnum = call_if(ob, "query_coin_num");
+
+  if(cnum > 0) {
+    string ctype = call_if(ob, "query_coin_type");
+
+    if(cnum == 1) {
+      string one = add_article(`${ctype} coin`);
+      return ({ one, one });
+    }
+
+    return ({ `${cnum} ${ctype} coins`, `some ${ctype} coins` });
+  }
+
+  string s = add_article(get_short(ob));
+  return ({ s, s });
 }

--- a/cmds/action/give.lpc
+++ b/cmds/action/give.lpc
@@ -1,0 +1,254 @@
+/**
+ * @file /cmds/action/give.lpc
+ *
+ * The give command. Hands objects - or coins from the wealth pool - to
+ * another living.
+ *
+ * @created 2026-07-18 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
+ *
+ * @history
+ * 2026-07-18 - Gesslar - Created
+ */
+
+inherit STD_ACT;
+
+private mixed give_all(object tp, object target, string ob_id);
+private mixed give_coins(object tp, object target, string arg);
+private mixed give_all_coins(object tp, object target);
+private mixed give_coin_pile(object tp, object target, string currency, int amount);
+
+void setup() {
+  usage_text =
+    "give <object> to <living>\n"
+    "give all to <living>\n"
+    "give all <object> to <living>\n"
+    "give <number> <currency> to <living>\n"
+    "give <currency> to <living>\n";
+  help_text =
+    "This command hands something you are carrying to another living. Name a "
+    "single object to give just that one, or use 'all' to give everything (or "
+    "everything of a given type).\n"
+    "\n"
+    "Coins are carried as wealth rather than as items, so name a currency to "
+    "give coins: 'give 5 silver to bob' gives five silver coins, while 'give "
+    "all silver to bob' gives all of your silver. Bare 'give all' leaves "
+    "your coins alone.\n"
+    "\n"
+    "See also: get, drop, put\n";
+}
+
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string arg
+) {
+  string what, target_id;
+
+  if(!arg)
+    return "Give what to whom?";
+
+  if(sscanf(arg, "%s to %s", what, target_id) != 2)
+    return "Give what to whom?";
+
+  /** @type {STD_BODY} */ object target = find_target(tp, target_id, environment(tp));
+
+  if(!target)
+    return `You do not see ${target_id} here.`;
+
+  // You can only hand things to something alive - not to the floor, a chest,
+  // or a corpse.
+  if(!living(target))
+    return `You cannot give anything to ${get_short(target)}.`;
+
+  if(target == tp)
+    return "You cannot give things to yourself.";
+
+  // Coins live in the wealth pool, not inventory. A request naming a currency
+  // ('give 5 silver to bob', 'give silver to bob') transfers wealth instead of
+  // moving an inventory item.
+  mixed coins = give_coins(tp, target, what);
+  if(!nullp(coins))
+    return coins;
+
+  // Detect an "all" quantifier: bare "all" (everything) or "all <type>".
+  int all_flag = 0;
+  string rest;
+
+  if(what == "all") {
+    all_flag = 1;
+    what = 0;
+  } else if(sscanf(what, "all %s", rest) == 1) {
+    all_flag = 1;
+    what = rest;
+  }
+
+  if(all_flag)
+    return give_all(tp, target, what);
+
+  /** @type {STD_ITEM} */ object ob = find_target(tp, what, tp);
+  if(!ob || !tp->can_see(ob))
+    return `You do not have ${add_article(what)}.`;
+
+  if(call_if(ob, "prevent_drop", tp))
+    return `You cannot give ${get_short(ob)} away.`;
+
+  if(ob->move(target))
+    return `You could not give ${get_short(ob)} to ${get_short(target)}.`;
+
+  tp->targetted_action("$N $vgive a $o to $t.", target, ob);
+
+  return 1;
+}
+
+private mixed give_all(
+  /** @type {STD_BODY} */ object tp,
+  /** @type {STD_BODY} */ object target,
+  string ob_id
+) {
+  object *obs = find_targets(tp, ob_id, tp);
+  int given = 0;
+
+  if(!sizeof(obs))
+    return ob_id
+      ? `You are not carrying any ${ob_id}.`
+      : "You are not carrying anything.";
+
+  foreach(/** @type {STD_ITEM} */ object ob in obs) {
+    if(call_if(ob, "prevent_drop", tp))
+      continue;
+
+    if(ob->move(target))
+      continue;
+
+    tp->targetted_action("$N $vgive a $o to $t.", target, ob);
+    given++;
+  }
+
+  if(!given)
+    return "You could not give anything.";
+
+  return 1;
+}
+
+// Routes a currency request to the wealth pool. Recognises "give <n> <type> to
+// X", "give all <type> to X", and "give all coin(s) to X" (every currency).
+// Bare "give <type>" is intentionally NOT handled here - an item may be
+// described with a currency word (e.g. a silver ingot), so a plain name must
+// fall through to a normal item give. Returns undefined when the request is not
+// about coins.
+private mixed give_coins(
+  /** @type {STD_BODY} */ object tp,
+  /** @type {STD_BODY} */ object target,
+  string arg
+) {
+  string currency, base;
+  int amount = 0;
+  int all = 0;
+
+  if(sscanf(arg, "%d %s", amount, currency) == 2) {
+    // "give 5 silver to bob"
+  } else if(sscanf(arg, "all %s", currency) == 1) {
+    all = 1;                                    // "give all silver" / "all coins"
+  } else {
+    return undefined;
+  }
+
+  // Accept "silver coin" / "silver coins" as "silver".
+  if(sscanf(currency, "%s coin", base) == 1 && strlen(base))
+    currency = base;
+
+  currency = lower_case(trim(currency));
+
+  // Bare "coin"/"coins", only with 'all', means every currency at once.
+  if(all && (currency == "coin" || currency == "coins"))
+    return give_all_coins(tp, target);
+
+  if(!CURRENCY_D->valid_currency_type(currency))
+    return undefined;
+
+  int have = tp->query_wealth(currency);
+
+  if(have < 1)
+    return `You have no ${currency} coins.`;
+
+  if(all)
+    amount = have;
+
+  if(amount < 1)
+    return `Give how many ${currency} coins?`;
+
+  if(amount > have)
+    return `You only have ${have} ${currency} ${have == 1 ? "coin" : "coins"}.`;
+
+  return give_coin_pile(tp, target, currency, amount);
+}
+
+// Gives every currency the body holds. Bare "give all" never reaches here; this
+// is only for the explicit "give all coin(s) to X" form.
+private mixed give_all_coins(
+  /** @type {STD_BODY} */ object tp,
+  /** @type {STD_BODY} */ object target
+) {
+  mapping wealth = tp->query_all_wealth();
+  int given = 0;
+
+  if(!tp->query_total_coins())
+    return "You have no coins to give.";
+
+  foreach(string currency, int amount in wealth) {
+    if(amount < 1)
+      continue;
+
+    if(give_coin_pile(tp, target, currency, amount) == 1)
+      given++;
+  }
+
+  if(!given)
+    return "You could not give your coins.";
+
+  return 1;
+}
+
+// Deducts <amount> of <currency> from the actor's wealth pool and hands it to
+// the target via a coin object, which folds itself into the target's wealth on
+// arrival. Refunds the actor if the transfer fails. The actor and target see
+// the exact count; everyone else sees a vague quantity.
+private mixed give_coin_pile(
+  /** @type {STD_BODY} */ object tp,
+  /** @type {STD_BODY} */ object target,
+  string currency,
+  int amount
+) {
+  mixed res = tp->adjust_wealth(currency, -amount);
+  if(stringp(res))
+    return res;
+
+  /** @type {LIB_COIN} */ object coin = new(LIB_COIN);
+  coin->set_up(currency, amount);
+
+  if(coin->move(target)) {
+    if(coin)
+      coin->remove();
+
+    tp->adjust_wealth(currency, amount);       // refund the deduction
+
+    return `You could not give the ${currency} coins to ${get_short(target)}.`;
+  }
+
+  // The actor and target see the exact count; everyone else sees a vague
+  // quantity.
+  string precise, vague;
+
+  if(amount == 1) {
+    precise = vague = add_article(`${currency} coin`);
+  } else {
+    precise = `${amount} ${currency} coins`;
+    vague = `some ${currency} coins`;
+  }
+
+  tp->my_target_action("$N $vgive $o to $t.", target, precise);
+  tp->target_action("$N $vgive $o to $t.", target, precise);
+  tp->other_target_action("$N $vgive $o to $t.", target, vague);
+
+  return 1;
+}

--- a/cmds/action/put.lpc
+++ b/cmds/action/put.lpc
@@ -62,21 +62,27 @@ mixed main(
   }
 
   if(!container)
-    return "There is no container named '" + dest + "' here.";
+    return `There is no container named '${dest}' here.`;
+
+  // A living has an inventory (so is_container() is true), but you don't stuff
+  // things into people.
+  if(living(container))
+    return `You cannot put anything into ${get_short(container)}.`;
 
   if(!container->is_container())
-    return get_short(container) + " is not a container.";
+    return `${get_short(container)} is not a container.`;
 
   if(container->is_closed())
-    return get_short(container) + " is closed.";
+    return `${get_short(container)} is closed.`;
 
   // Handle 'put all' scenarios
   if(all_flag) {
-    object *obs = find_targets(tp, target, tp, (: !$1->is_container() :));
+    object *obs = find_targets(tp, target, tp,
+      (: !$1->is_container() && !living($1) :));
     int put_count = 0;
 
     if(sizeof(obs) < 1)
-      return "You do not have any " + target + ".";
+      return `You do not have any ${target}.`;
 
     foreach(object item in obs) {
       if(item == container)
@@ -94,7 +100,7 @@ mixed main(
         continue;
 
       if(item->move(container)) {
-        tell(tp, "You could not put " + get_short(item) + " in " + get_short(container) + ".\n");
+        tell(tp, `You could not put ${get_short(item)} in ${get_short(container)}.\n`);
         continue;
       }
 
@@ -103,17 +109,20 @@ mixed main(
     }
 
     if(put_count == 0)
-      return "You could not put any " + target + " in " + get_short(container) + ".";
+      return `You could not put any ${target} in ${get_short(container)}.`;
 
   } else {
     /** @type {STD_ITEM} */ object ob;
 
     // Handle 'put <object>' scenarios
     if(!(ob = find_target(tp, target, tp)))
-      return "You do not have " + add_article(target) + ".";
+      return `You do not have ${add_article(target)}.`;
+
+    if(living(ob))
+      return `You cannot put ${get_short(ob)} into ${get_short(container)}.`;
 
     if(ob == container)
-      return "You cannot put " + get_short(ob) + " in itself.";
+      return `You cannot put ${get_short(ob)} in itself.`;
 
     if(call_if(ob, "is_container"))
       return "You cannot put a container inside another container.";
@@ -123,14 +132,14 @@ mixed main(
       || call_if(ob, "prevent_put")
       || call_if(container, "prevent_put")
     ) {
-      return "You cannot put " + get_short(ob) + " in " + get_short(container) + ".";
+      return `You cannot put ${get_short(ob)} in ${get_short(container)}.`;
     }
 
     if(!container->can_hold_object(ob))
-      return get_short(container) + " cannot hold " + get_short(ob) + ".";
+      return `${get_short(container)} cannot hold ${get_short(ob)}.`;
 
     if(ob->move(container))
-      return "You could not put " + get_short(ob) + " in " + get_short(container) + ".";
+      return `You could not put ${get_short(ob)} in ${get_short(container)}.`;
 
     tp->simple_action("$N $vput a $o into a $o1.", ob, container);
   }

--- a/std/ext/action.lpc
+++ b/std/ext/action.lpc
@@ -12,6 +12,10 @@ varargs void other_action(mixed msg, mixed *obs...) {
   ACTION_D->other_action(msg, obs...);
 }
 
+varargs void other_target_action(mixed msg, object target, mixed *obs...) {
+  ACTION_D->other_target_action(msg, target, obs...);
+}
+
 varargs void my_target_action(mixed msg, object target, mixed *obs...) {
   ACTION_D->my_target_action(msg, target, obs...);
 }


### PR DESCRIPTION
Adds a `give` command and expands `drop` and `get` with `all`/`all <type>` quantifier support, coin-aware handling, and living-target guards.

**give command**

A new `give <object> to <living>` command lets players hand inventory items or coins directly to another living in the room. It supports the same quantifier forms as `drop` and `get`:

- `give all to <living>` — gives everything being carried
- `give all <type> to <living>` — gives all items matching a type
- `give <n> <currency> to <living>` — transfers an exact coin amount from the wealth pool
- `give <currency> to <living>` / `give all <currency> to <living>` — transfers all coins of that currency
- `give all coins to <living>` — transfers every currency at once

Coin transfers deduct from the actor's wealth pool, materialise a coin object, move it to the target (where it folds into their wealth), and refund the actor if the move fails. The actor and target see the precise count; bystanders see a vague quantity ("some silver coins").

**drop enhancements**

- `drop all` and `drop all <type>` now work, dropping matching inventory items one by one.
- `drop <n> <currency>`, `drop all <currency>`, and `drop all coins` materialise coin objects on the ground from the wealth pool, with the same precise/vague messaging split.
- The short description of each object is captured before moving it, since coin objects self-destruct when they change inventory.

**get enhancements**

- `get all` and `get all <type>` now work, picking up matching items from the room or a named container.
- Coin piles picked up from the ground report the exact count to the actor and a vague quantity to bystanders.
- Living objects are explicitly blocked as pick-up targets.
- Attempting to `get` from a living now returns an appropriate error rather than treating them as a container.

**other_target_action**

A new `other_target_action` function is added to the action daemon and its extension shim. It works like `other_action` but also excludes the target from the room broadcast, complementing `my_target_action`/`target_action` for cases where the actor and target should see a different message than bystanders.

**put cleanup**

Living objects are now blocked as `put` destinations and as items being put into containers. String concatenation in error messages is replaced with interpolated strings throughout.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds richer item and coin transfer commands. The main changes are:

- Adds `give` for items and wealth-pool coins.
- Adds `all` quantifiers to `get` and `drop`.
- Adds coin-aware action messages.
- Blocks living objects in `get` and `put` container paths.
- Adds a target-aware room broadcast helper.
</details>

<sub>Reviews (2): Last reviewed commit: ["updated get drop get and new give comman..."](https://github.com/gesslar/oxidus-mudlib/commit/b95c5299d2ddec7f6769ab152f6ec9fd3cfe826e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45386144)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
</details>

<!-- /greptile_comment -->