### PR TITLE
Clean player inventory on exit to prevent item drops

### DIFF
--- a/std/living/player.lpc
+++ b/std/living/player.lpc
@@ -119,7 +119,12 @@ void exit_world() {
     `${query_ip_number()}\n`
   );
 
+  // Save our body's state. Additionally, saves our inventory.
   save_body();
+
+  // After saving inventory, we now clean our contents so that we don't drop
+  // things into the room.
+  clean_contents();
 
   remove();
 }


### PR DESCRIPTION
When a player exits the world, their inventory is now cleaned up after saving, preventing items from being dropped into the room upon disconnect.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR clears a player’s inventory after saving during world exit. The main changes are:

- Saves body and inventory state before cleanup.
- Removes inventory before the player removal path can drop it into the room.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Astd%2Fliving%2Fplayer.lpc%3A127%0A**Nested%20inventory%20is%20removed%20twice**%0A%0A%60clean_contents%28%29%60%20starts%20with%20%60deep_inventory%28%29%60%2C%20which%20includes%20a%20container%20and%20every%20object%20inside%20it%2C%20then%20recursively%20calls%20%60clean_contents%28%29%60%20on%20each%20container%20before%20vector-calling%20%60remove%28%29%60%20on%20that%20original%20full%20list.%20A%20player%20carrying%20a%20bag%20with%20contents%20therefore%20removes%20those%20contents%20during%20the%20bag%20recursion%20and%20again%20from%20the%20outer%20list%20while%20quitting%2C%20causing%20duplicate%20removal%20hooks%20or%20calls%20against%20already-destructed%20inventory%20objects.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["updating quitting with inventory"](https://github.com/gesslar/oxidus-mudlib/commit/bf3ce2d6d2155c71ef6e232c8d5a14756f4c805b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45389732)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->