### PR TITLE
Guard against null result before querying virtual master

### DIFF
--- a/adm/daemons/virtual.lpc
+++ b/adm/daemons/virtual.lpc
@@ -94,6 +94,9 @@ public nomask object compile_object(string file) {
         return 0;
       }
 
+      if(!result)
+        return 0;
+
       if(!result->query_virtual_master()) {
         result->remove();
 


### PR DESCRIPTION
Adds a null check for `result` before attempting to call `query_virtual_master()` on it, preventing a potential null pointer dereference in `compile_object`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR guards the virtual-object compilation result before it is queried.

- Returns `0` when the module does not create an object.
- Avoids calling `query_virtual_master()` on a null result.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix for no virtual object"](https://github.com/gesslar/oxidus-mudlib/commit/0796693c2075da519e544d7ebb14f1d1342173d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45398572)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->