### PR TITLE
Ensure `query_xp` returns an integer

### DIFF
--- a/std/living/advancement.lpc
+++ b/std/living/advancement.lpc
@@ -32,7 +32,7 @@ private int __xp = 0;
  * @returns {int} The current XP total.
  */
 int query_xp() {
-  return __xp;
+  return to_int(__xp);
 }
 
 /**


### PR DESCRIPTION
Ensure `query_xp()` returns an integer by wrapping the internal XP value with `to_int()`, preventing potential type mismatches when the stored value is not already an integer.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ensures `query_xp()` returns an integer.

- Converts the stored XP value with `to_int()` before returning it.
</details>

<sub>Reviews (2): Last reviewed commit: ["ensuring return value as int"](https://github.com/gesslar/oxidus-mudlib/commit/61cc4d44e696f43b155298b9d1e274b7690e45c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45398573)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->