### PR TITLE
Add JSDoc type annotation to `ob` in `healup` command

### DIFF
--- a/cmds/dev/healup.lpc
+++ b/cmds/dev/healup.lpc
@@ -23,7 +23,7 @@ void setup() {
 }
 
 mixed main(object tp, string str) {
-    object ob;
+    /** @type {STD_BODY} */ object ob;
 
     if(!str)
         ob = tp;


### PR DESCRIPTION
Adds a type annotation to the `ob` variable in the `healup` command, specifying it as `STD_BODY` to improve code clarity and editor tooling support.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a type annotation to the `healup` command. The main change is:

- Documents the local target object as `STD_BODY`.
</details>

<sub>Reviews (2): Last reviewed commit: ["typing the food object"](https://github.com/gesslar/oxidus-mudlib/commit/85d5e780afacdee625f377064298197c08cbf5f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45398575)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->