### PR TITLE
Add healing extension and apply HP/SP/MP restoration on food consumption

### DIFF
--- a/cmds/action/eat.lpc
+++ b/cmds/action/eat.lpc
@@ -29,7 +29,6 @@ void setup() {
  */
 mixed main(object tp, string str) {
   /** @type {STD_FOOD} */ object ob;
-  int uses;
 
   if(!ob = find_target(tp, str, tp))
     return "You don't have that.";
@@ -37,13 +36,23 @@ mixed main(object tp, string str) {
   if(!ob->is_edible())
     return "You can't eat that.";
 
-  uses = ob->query_uses();
+  int uses = ob->query_uses();
+  int max_uses = ob->query_max_uses();
 
   if(uses < 1)
     return "There is nothing left to eat.";
 
-  if(!ob->eat_obj(tp))
+  mapping healing = ob->get_healing();
+  int eaten = ob->eat_obj(tp);
+
+  if(!eaten)
     return "You couldn't eat that.";
+
+  if(uses == max_uses && mapp(healing)) {
+    tp->adjust_hp(healing.hp);
+    tp->adjust_sp(healing.sp);
+    tp->adjust_mp(healing.mp);
+  }
 
   return 1;
 }

--- a/include/ext.h
+++ b/include/ext.h
@@ -10,6 +10,7 @@
 #define EXT_CURRENCY      DIR_STD_EXT "currency"
 #define EXT_EDIBLE        DIR_STD_EXT "edible"
 #define EXT_GMCP          DIR_STD_EXT "gmcp"
+#define EXT_HEALING       DIR_STD_EXT "healing"
 #define EXT_HTTP          DIR_STD_EXT "http"
 #define EXT_LOG           DIR_STD_EXT "log"
 #define EXT_LOOT          DIR_STD_EXT "loot"

--- a/obj/food/bat_meat.lpml
+++ b/obj/food/bat_meat.lpml
@@ -14,4 +14,5 @@
     food: true,
     raw: true,
   },
+  healing: 5,
 }

--- a/obj/food/cat_meat.lpml
+++ b/obj/food/cat_meat.lpml
@@ -14,4 +14,5 @@
     food: true,
     raw: true,
   },
+  healing: 6,
 }

--- a/obj/food/cheese.lpml
+++ b/obj/food/cheese.lpml
@@ -15,4 +15,5 @@
     autovalue: true,
     edible: true,
   },
+  healing: 3,
 }

--- a/obj/food/food.lpc
+++ b/obj/food/food.lpc
@@ -18,4 +18,8 @@ varargs void virtual_setup(mapping data) {
   data["mass"] && set_mass(data["mass"]);
   data["value"] && set_value(data["value"]);
   data["uses"] && set_uses(data["uses"]);
+  data["healing"] && set_healing(data["healing"]);
+  data["healing_hp"] && set_healing_hp(data["healing_hp"]);
+  data["healing_sp"] && set_healing_sp(data["healing_sp"]);
+  data["healing_mp"] && set_healing_mp(data["healing_mp"]);
 }

--- a/obj/food/mole_meat.lpml
+++ b/obj/food/mole_meat.lpml
@@ -14,4 +14,5 @@
     food: true,
     raw: true,
   },
+  healing: 3,
 }

--- a/obj/food/muffin.lpml
+++ b/obj/food/muffin.lpml
@@ -8,4 +8,5 @@
   mass: 5,
   value: 2,
   uses: 1,
+  healing: 3,
 }

--- a/obj/food/rabbit_meat.lpml
+++ b/obj/food/rabbit_meat.lpml
@@ -13,4 +13,5 @@
     autovalue: true,
     raw: true,
   },
+  healing: 6,
 }

--- a/obj/food/rat_meat.lpml
+++ b/obj/food/rat_meat.lpml
@@ -14,4 +14,5 @@
     food: true,
     raw: true,
   },
+  healing: 3,
 }

--- a/obj/food/raw_pork.lpml
+++ b/obj/food/raw_pork.lpml
@@ -14,4 +14,5 @@
     food: true,
     raw: true,
   },
+  healing: 5,
 }

--- a/std/consume/food.lpc
+++ b/std/consume/food.lpc
@@ -14,6 +14,7 @@
 inherit STD_ITEM;
 
 inherit EXT_EDIBLE;
+inherit EXT_HEALING;
 
 string consume_message();
 
@@ -23,7 +24,13 @@ void mudlib_setup() {
   save_var(([
     "_uses": "set_uses",
     "_max_uses": "set_max_uses",
-    "_use_status_message": "set_use_status_message"
+    "_use_status_message": "set_use_status_message",
+    "__max_healing_hp": "set_max_healing_hp",
+    "__max_healing_sp": "set_max_healing_sp",
+    "__max_healing_mp": "set_max_healing_mp",
+    "__healing_hp": "set_healing_hp",
+    "__healing_sp": "set_healing_sp",
+    "__healing_mp": "set_healing_mp",
   ]));
 }
 

--- a/std/ext/healing.lpc
+++ b/std/ext/healing.lpc
@@ -1,0 +1,267 @@
+/**
+ * @file /std/ext/healing.lpc
+ *
+ * Provides healing and restoration functionality. Usually consumables, like
+ * food, drink, potions, etc.
+ *
+ * @created 2026-07-18 - Gesslar
+ * @last_modified 2026-07-18 - Gesslar
+ *
+ * @history
+ * 2026-07-18 - Gesslar - Created
+ */
+
+#include "include/healing.h"
+
+private nosave float __max_healing_hp = undefined, __healing_hp = undefined;
+private nosave float __max_healing_sp = undefined, __healing_sp = undefined;
+private nosave float __max_healing_mp = undefined, __healing_mp = undefined;
+
+/**
+ * Sets all three healing amounts (HP, SP, and MP) to the same value. When
+ * no maximum has been set yet, the maximums are seeded to the same value.
+ *
+ * @param {float} amt - The amount each pool is adjusted by when the
+ *                      healing is applied.
+ * @returns {float} The amount that was set.
+ * @errors If amt is null or not numeric.
+ */
+public float set_healing(float amt) {
+  assert_arg(!nullp(amt) && (intp(amt) || floatp(amt)), 1, "Amount must be a number.");
+
+  amt = to_float(amt);
+
+  set_healing_hp(amt);
+  set_healing_sp(amt);
+  set_healing_mp(amt);
+
+  return amt;
+}
+
+/**
+ * Sets all three maximum healing amounts (HP, SP, and MP) to the same
+ * value. When no current healing has been set yet, the current amounts are
+ * seeded to the same value.
+ *
+ * @param {float} amt - The maximum amount for each pool.
+ * @returns {float} The amount that was set.
+ * @errors If amt is null or not numeric.
+ */
+public float set_max_healing(float amt) {
+  assert_arg(!nullp(amt) && (intp(amt) || floatp(amt)), 1, "Amount must be a number.");
+
+  amt = to_float(amt);
+
+  set_max_healing_hp(amt);
+  set_max_healing_sp(amt);
+  set_max_healing_mp(amt);
+
+  return amt;
+}
+
+/**
+ * Sets the amount of HP restored when this object's healing is applied.
+ *
+ * @param {float} amt - The HP healing amount.
+ * @returns {float} The amount that was set.
+ * @errors If amt is null or not numeric.
+ */
+public float set_healing_hp(float amt) {
+  assert_arg(!nullp(amt) && (intp(amt) || floatp(amt)), 1, "Amount must be a number.");
+
+  amt = to_float(amt);
+
+  __healing_hp = amt;
+
+  if(nullp(__max_healing_hp))
+    set_max_healing_hp(amt);
+
+  return __healing_hp;
+}
+
+/**
+ * Sets the maximum HP healing amount. If the current HP healing has not
+ * been set, it is seeded to the same value.
+ *
+ * @param {float} amt - The maximum HP healing amount.
+ * @returns {float} The amount that was set.
+ * @errors If amt is null or not numeric.
+ */
+public float set_max_healing_hp(float amt) {
+  assert_arg(!nullp(amt) && (intp(amt) || floatp(amt)), 1, "Amount must be a number.");
+
+  amt = to_float(amt);
+
+  __max_healing_hp = amt;
+
+  if(nullp(__healing_hp))
+    set_healing_hp(amt);
+
+  return __max_healing_hp;
+}
+
+/**
+ * Sets the amount of SP restored when this object's healing is applied.
+ *
+ * @param {float} amt - The SP healing amount.
+ * @returns {float} The amount that was set.
+ * @errors If amt is null or not numeric.
+ */
+public float set_healing_sp(float amt) {
+  assert_arg(!nullp(amt) && (intp(amt) || floatp(amt)), 1, "Amount must be a number.");
+
+  amt = to_float(amt);
+
+  __healing_sp = amt;
+
+  if(nullp(__max_healing_sp))
+    set_max_healing_sp(amt);
+
+  return __healing_sp;
+}
+
+/**
+ * Sets the maximum SP healing amount. If the current SP healing has not
+ * been set, it is seeded to the same value.
+ *
+ * @param {float} amt - The maximum SP healing amount.
+ * @returns {float} The amount that was set.
+ * @errors If amt is null or not numeric.
+ */
+public float set_max_healing_sp(float amt) {
+  assert_arg(!nullp(amt) && (intp(amt) || floatp(amt)), 1, "Amount must be a number.");
+
+  amt = to_float(amt);
+
+  __max_healing_sp = amt;
+
+  if(nullp(__healing_sp))
+    set_healing_sp(amt);
+
+  return __max_healing_sp;
+}
+
+/**
+ * Sets the amount of MP restored when this object's healing is applied.
+ *
+ * @param {float} amt - The MP healing amount.
+ * @returns {float} The amount that was set.
+ * @errors If amt is null or not numeric.
+ */
+public float set_healing_mp(float amt) {
+  assert_arg(!nullp(amt) && (intp(amt) || floatp(amt)), 1, "Amount must be a number.");
+
+  amt = to_float(amt);
+
+  __healing_mp = amt;
+
+  if(nullp(__max_healing_mp))
+    set_max_healing_mp(amt);
+
+  return __healing_mp;
+}
+
+/**
+ * Sets the maximum MP healing amount. If the current MP healing has not
+ * been set, it is seeded to the same value.
+ *
+ * @param {float} amt - The maximum MP healing amount.
+ * @returns {float} The amount that was set.
+ * @errors If amt is null or not numeric.
+ */
+public float set_max_healing_mp(float amt) {
+  assert_arg(!nullp(amt) && (intp(amt) || floatp(amt)), 1, "Amount must be a number.");
+
+  amt = to_float(amt);
+
+  __max_healing_mp = amt;
+
+  if(nullp(__healing_mp))
+    set_healing_mp(amt);
+
+  return __max_healing_mp;
+}
+
+/**
+ * Returns the amount of HP restored when this object's healing is applied.
+ *
+ * @returns {float} The HP healing amount.
+ */
+public float get_healing_hp() {
+  return __healing_hp;
+}
+
+/**
+ * Returns the maximum HP healing amount.
+ *
+ * @returns {float} The maximum HP healing amount.
+ */
+public float get_max_healing_hp() {
+  return __max_healing_hp;
+}
+
+/**
+ * Returns the amount of SP restored when this object's healing is applied.
+ *
+ * @returns {float} The SP healing amount.
+ */
+public float get_healing_sp() {
+  return __healing_sp;
+}
+
+/**
+ * Returns the maximum SP healing amount.
+ *
+ * @returns {float} The maximum SP healing amount.
+ */
+public float get_max_healing_sp() {
+  return __max_healing_sp;
+}
+
+/**
+ * Returns the amount of MP restored when this object's healing is applied.
+ *
+ * @returns {float} The MP healing amount.
+ */
+public float get_healing_mp() {
+  return __healing_mp;
+}
+
+public float get_max_healing_mp() {
+  return __max_healing_mp;
+}
+
+public mapping get_healing() {
+  return ([
+    "hp":     __healing_hp,
+    "max_hp": __max_healing_hp,
+    "sp":     __healing_sp,
+    "max_sp": __max_healing_sp,
+    "mp":     __healing_mp,
+    "max_mp": __max_healing_mp,
+  ]);
+}
+
+/**
+ * Reports whether this object provides any healing.
+ *
+ * @param {int} [only_healing=0] - When truthy, only positive (restorative)
+ *                                 amounts qualify; otherwise any non-zero
+ *                                 amount, including negative (harmful) ones,
+ *                                 qualifies.
+ * @returns {int} 1 if the object qualifies as healing under the chosen
+ *                criterion, otherwise 0.
+ */
+public varargs int is_healing(int only_healing) {
+  if(only_healing)
+    return __healing_hp > 0.0
+        || __healing_sp > 0.0
+        || __healing_mp > 0.0;
+
+  return __healing_hp > 0.0
+      || __healing_hp < 0.0
+      || __healing_sp > 0.0
+      || __healing_sp < 0.0
+      || __healing_mp > 0.0
+      || __healing_mp < 0.0;
+}

--- a/std/ext/include/healing.h
+++ b/std/ext/include/healing.h
@@ -1,0 +1,21 @@
+#ifndef __HEALING_H__
+#define __HEALING_H__
+
+public float set_healing(float amt);
+public float set_max_healing(float amt);
+public float set_healing_hp(float amt);
+public float set_max_healing_hp(float amt);
+public float set_healing_sp(float amt);
+public float set_max_healing_sp(float amt);
+public float set_healing_mp(float amt);
+public float set_max_healing_mp(float amt);
+public float get_healing_hp();
+public float get_max_healing_hp();
+public float get_healing_sp();
+public float get_max_healing_sp();
+public float get_healing_mp();
+public float get_max_healing_mp();
+public mapping get_healing();
+public varargs int is_healing(int only_healing);
+
+#endif // __HEALING_H__


### PR DESCRIPTION
## Add healing extension for consumable food items

Introduces a new `EXT_HEALING` extension that allows consumable items (food, potions, drinks, etc.) to restore HP, SP, and MP when consumed. Healing amounts can be configured per-stat or set uniformly across all three pools, with both current and maximum values tracked independently.

The `eat` command now retrieves the healing mapping from the food object and applies the stat adjustments to the player on the first use (i.e., when uses equals max uses). This ensures healing only triggers on a fresh item rather than on subsequent bites of a partially consumed one.

Food items in `std/consume/food.lpc` now inherit `EXT_HEALING`, and the virtual setup handler in `obj/food/food.lpc` supports the `healing`, `healing_hp`, `healing_sp`, and `healing_mp` data keys. Existing food objects — bat meat, cat meat, cheese, mole meat, muffin, rabbit meat, rat meat, and raw pork — have been given healing values appropriate to their type.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds configurable healing to consumable food items. The main changes are:
- Adds the `EXT_HEALING` extension and its HP/SP/MP accessors.
- Saves food healing values with the existing persistence mapping.
- Applies configured restoration when a fresh food item is eaten.
- Adds healing values to the existing virtual food definitions.
</details>

<sub>Reviews (3): Last reviewed commit: ["adding healing and healing to food"](https://github.com/gesslar/oxidus-mudlib/commit/bde2352a7558a343c49a7b29152391dd70d99e56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45398576)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->