### PR TITLE
Add `look` support for objects, livings, and room items

### DIFF
--- a/cmds/action/look.lpc
+++ b/cmds/action/look.lpc
@@ -14,9 +14,12 @@ inherit STD_ACT;
 
 mixed identify_filename(object ob, int vm);
 mixed describe_environment(object tp);
+mixed describe_object(object tp, object ob);
+mixed describe_living(object tp, object ob);
+mixed describe_item(object tp, string item);
 
 mixed main(
-  /** @type {STD_PLAYER} */ object tp,
+  /** @type {STD_BODY} */ object tp,
   string arg
 ) {
   if(!environment(tp))
@@ -25,50 +28,33 @@ mixed main(
   if(falsy(arg))
     return describe_environment(tp);
 
+  /** @type {STD_ITEM | STD_BODY} */ object ob;
+  if(ob = find_target(tp, arg, tp))
+    return describe_object(tp, ob);
+
+  if(ob = find_target(tp, arg, environment(tp)))
+    return describe_object(tp, ob);
+
+  if(arg == "me")
+    return describe_living(tp, tp);
+
+  if(/** @type {STD_ROOM} */ (environment(tp))->has_item(arg))
+    return describe_item(tp, arg);
+
   return "You don't see that here.";
 }
 
-/**
- *
- * @param {STD_OBJECT} ob
- * @param vm
- */
-mixed identify_filename(object ob, int vm) {
-  vm = !!vm;
-
-  string fn = file_name(ob);
-
-  if(virtualp(ob)) {
-    if(vm == 0) {
-      if(ob->query_virtual_master())
-        return `${fn} [V]`;
-      else
-        return `${fn} [VM]`;
-    } else {
-      string virt = ob->query_virtual_master();
-
-      if(!virt)
-        return `${fn} [Virtual]`;
-      else
-        return `${fn} [${virt}]`;
-    }
-  } else {
-    return fn;
-  }
-}
-
 mixed describe_environment(
-  /** @type {STD_PLAYER} */ object tp
+  /** @type {STD_BODY} */ object tp
 ) {
   /** @type {STD_ROOM} */ object env = environment(tp);
   string result = "";
+  int fns = devp(tp) && tp->query_pref("look_filename") == "on";
 
-  if(devp(tp)) {
-    if(tp->query_pref("look_filename") == "on") {
-      string fn = `{{069}}${identify_filename(env, 1)}{{res}}`;
+  if(fns) {
+    string fn = `{{069}}${identify_filename(env, 1)}{{res}}`;
 
-      result += append(fn, "\n");
-    }
+    result += append(fn, "\n");
   }
 
   string short = ob_short(env);
@@ -97,7 +83,16 @@ mixed describe_environment(
   object *livs = filter(obs, (: living :));
   obs = non_livs + livs;
 
-  string *shorts = map(obs, (: ob_short :));
+  string *shorts = map(obs, function(object ob, int fns) {
+    string short = ob_short(ob);
+    if(!truthy(short))
+      return "";
+
+    if(fns)
+      return `${short} (${identify_filename(ob, 0)})`;
+    else
+      return short;
+  }, fns);
   shorts = filter(shorts, (: strlen :));
 
   if(sizeof(shorts)) {
@@ -110,4 +105,99 @@ mixed describe_environment(
   }
 
   return result;
+}
+
+mixed describe_object(
+  /** @type {STD_BODY} */ object tp,
+  /** @type {STD_ITEM | STD_BODY} */ object ob
+) {
+  if(living(ob))
+    return describe_living(tp, ob);
+
+  string result = "";
+  int fns = devp(tp) && tp->query_pref("look_filename") == "on";
+
+  if(fns) {
+    string fn = `{{069}}${identify_filename(ob, 1)}{{res}}`;
+
+    result += append(fn, "\n");
+  }
+
+  string short = ob_short(ob);
+  if(truthy(short)) {
+    result += append(short, "\n");
+  }
+
+  string long = ob_long(ob);
+  if(truthy(long))
+    result += append(long, "\n");
+
+  return result;
+}
+
+mixed describe_living(
+  /** @type {STD_BODY} */ object tp,
+  /** @type {STD_BODY} */ object ob
+) {
+  string result = "";
+  int fns = devp(tp) && tp->query_pref("look_filename") == "on";
+
+  if(fns) {
+    string fn = `{{069}}${identify_filename(ob, 1)}{{res}}`;
+
+    result += append(fn, "\n");
+  }
+
+  string short = ob_short(ob);
+  if(truthy(short)) {
+    result += append(short, "\n");
+  }
+
+  string long = ob_long(ob);
+  if(truthy(long))
+    result += append(long, "\n");
+
+  string race = ob->query_race();
+  string gender = ob->query_gender();
+  string sub = tp == ob ? "You" : capitalize(subjective(ob));
+  string verb = tp == ob ? "are" : "is";
+
+  if(truthy(race) && truthy(gender))
+    result += `${sub} ${verb} ${add_article(gender)} ${race}.\n`;
+  else if(truthy(race))
+    result += `${sub} ${verb} ${add_article(race)}.\n`;
+  else if(truthy(gender))
+    result += `${sub} ${verb} ${gender}.\n`;
+
+  return result;
+}
+
+mixed describe_item(object tp, string item) {
+  return /** @type {STD_ROOM} */ (environment(tp))->get_item(item);
+}
+
+/**
+ *
+ * @param {STD_OBJECT} ob
+ * @param vm
+ */
+mixed identify_filename(object ob, int vm) {
+  vm = !!vm;
+
+  string fn = file_name(ob);
+
+  if(virtualp(ob)) {
+    if(vm == 0) {
+      return `${fn} [V]`;
+    } else {
+      string virt = ob->query_virtual_master();
+
+      if(!virt)
+        return `${fn} [Virtual]`;
+      else
+        return `${fn} [${virt}]`;
+    }
+  } else {
+    return fn;
+  }
 }

--- a/std/room/items.lpc
+++ b/std/room/items.lpc
@@ -10,13 +10,14 @@
  * 2025-03-16 - GitHub Copilot - Added documentation
  */
 
-private nosave mapping _items = ([]);
+private nosave mapping __items = ([]);
 
 mapping set_items(mapping item_data);
 mapping remove_item(string id);
 mapping add_item(mixed id, string desc);
-mapping query_items();
-string query_item(string id);
+mapping get_items();
+string get_item(string id);
+int has_item(string id);
 
 /**
  * Sets up items that can be examined in the room.
@@ -41,9 +42,9 @@ mapping set_items(mapping item_data) {
     }
   }
 
-  _items = item;
+  __items = item;
 
-  return query_items();
+  return get_items();
 }
 
 /**
@@ -51,8 +52,18 @@ mapping set_items(mapping item_data) {
  *
  * @returns {mapping} A copy of the items mapping
  */
-mapping query_items() {
-  return copy(_items);
+mapping get_items() {
+  return copy(__items);
+}
+
+/**
+ * Returns 1 if an item is described in this room.
+ *
+ * @param {string} id - The id to check.
+ * @returns {int} 1 if the item is present, 0 if not.
+ */
+int has_item(string id) {
+  return includes(keys(__items), id);
 }
 
 /**
@@ -66,14 +77,14 @@ mapping query_items() {
  * @param {string} id - The item ID to look up
  * @returns {string} The item description, or 0 if not found
  */
-string query_item(string id) {
+string get_item(string id) {
   mixed item, value;
   string result;
 
   if(!nullp(item))
     return 0;
 
-  foreach(item, value in _items) {
+  foreach(item, value in __items) {
     if(pointerp(item)) {
       int i;
 
@@ -113,12 +124,12 @@ string query_item(string id) {
  * @returns {mapping} The updated items mapping (copy)
  */
 mapping remove_item(string id) {
-  if(!_items[id])
-    return query_items();
+  if(!__items[id])
+    return get_items();
 
-  map_delete(_items, id);
+  map_delete(__items, id);
 
-  return query_items();
+  return get_items();
 }
 
 /**
@@ -133,17 +144,17 @@ mapping add_item(mixed id, string desc) {
     int i;
 
     for(; i < sizeof(id); i++) {
-      if(_items[id[i]])
-        map_delete(_items, id);
+      if(__items[id[i]])
+        map_delete(__items, id);
 
-      _items += ([id[i] : desc]);
+      __items += ([id[i] : desc]);
     }
   } else {
-    if(_items[id])
-      map_delete(_items, id);
+    if(__items[id])
+      map_delete(__items, id);
 
-    _items += ([id : desc]);
+    __items += ([id : desc]);
   }
 
-  return query_items();
+  return get_items();
 }


### PR DESCRIPTION
## Expand `look` to Support Examining Objects, Livings, and Room Items

The `look` command now handles targeted look arguments rather than returning "You don't see that here." for everything. When a player looks at something, the command searches the player's inventory, then the environment, then checks for room-defined items, in that order.

### New look targets

- **Objects** — displays filename (if the dev preference is enabled), short description, and long description.
- **Livings** — same as objects, plus a line describing the target's race and gender using appropriate pronouns. Looking at yourself uses "You are" instead of third-person.
- **Room items** — delegates to the room's `get_item` method for inline-described scenery.
- `look me` — explicitly targets the player themselves.

### Room items API changes

- Renamed `query_items` → `get_items` and `query_item` → `get_item` to align with the broader codebase naming conventions.
- Added `has_item(string id)` to allow checking whether a room defines a given item without fetching its description.
- Renamed the internal `_items` variable to `__items`.

### `describe_environment` improvements

When the `look_filename` dev preference is on, filenames are now shown inline next to each object in the room's contents list, rather than only being shown for the room itself.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR expands the `look` command from a no-op stub into a full targeted-look implementation, and refactors the room items API to match codebase naming conventions.

- **`look` command** (`cmds/action/look.lpc`): Adds `describe_object`, `describe_living`, and `describe_item` helpers; searches the player's inventory, then the environment, then falls back to the explicit `me` shorthand and room-defined scenery items. Dev filename display is extended to room contents objects (previously only the room itself). The `identify_filename` function is silently simplified in its `vm=0` path (see inline comment).
- **Room items API** (`std/room/items.lpc`): `query_items` → `get_items`, `query_item` → `get_item`, `_items` → `__items`, and a new `has_item(string id)` predicate is added. All callers in the codebase have been updated — no lingering references to the old names were found.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acmds%2Faction%2Flook.lpc%3A189-192%0AThe%20%60vm%20%3D%3D%200%60%20branch%20previously%20distinguished%20virtual%20instances%20%28%60%5BV%5D%60%29%20from%20virtual%20masters%20%28%60%5BVM%5D%60%29%3A%20when%20%60query_virtual_master%28%29%60%20returned%20falsy%20the%20object%20had%20no%20master%20%E2%80%94%20it%20*was*%20the%20master%20%E2%80%94%20and%20showed%20%60%5BVM%5D%60.%20The%20new%20code%20always%20returns%20%60%5BV%5D%60%2C%20so%20a%20virtual%20master%20object%20sitting%20in%20a%20room's%20inventory%20will%20be%20mislabelled%20as%20a%20virtual%20instance%20in%20the%20dev%20filename%20view.%20This%20is%20only%20visible%20to%20devs%20with%20%60look_filename%60%20on%2C%20but%20the%20label%20distinction%20was%20genuinely%20informative.%0A%0A%60%60%60suggestion%0A%20%20if%28virtualp%28ob%29%29%20%7B%0A%20%20%20%20if%28vm%20%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20if%28ob-%3Equery_virtual_master%28%29%29%0A%20%20%20%20%20%20%20%20return%20%60%24%7Bfn%7D%20%5BV%5D%60%3B%0A%20%20%20%20%20%20else%0A%20%20%20%20%20%20%20%20return%20%60%24%7Bfn%7D%20%5BVM%5D%60%3B%0A%20%20%20%20%7D%20else%20%7B%0A%60%60%60%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=370&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["updating look"](https://github.com/gesslar/oxidus-mudlib/commit/129d563b68c3f94c2e806dd9401e1ae1adc171b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45465440)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->