### PR TITLE
Rename `query_attribute(s)` to `get_attribute(s)`, fix NPC defence/AC scaling, and bump NPC skill multiplier to 4.0

### DIFF
--- a/.claude/skills/buff-system/SKILL.md
+++ b/.claude/skills/buff-system/SKILL.md
@@ -95,7 +95,7 @@ int count = tp->remove_curse_by_name(
 
 | Class | Type Examples | Integrated In |
 |---|---|---|
-| `attribute` | `strength`, `dexterity`, `constitution`, `intelligence`, `wisdom`, `charisma` | `std/living/attributes.lpc` — `query_attribute()` adds `query_effective_boon("attribute", key)` |
+| `attribute` | `strength`, `dexterity`, `constitution`, `intelligence`, `wisdom`, `charisma` | `std/living/attributes.lpc` — `get_attribute()` adds `query_effective_boon("attribute", key)` |
 | `vital` | `max_hp`, `max_sp`, `max_mp` | `std/living/vitals.lpc` — `query_max_hp/sp/mp()` adds `query_effective_boon("vital", ...)` |
 | `skill` | Any skill name | `std/living/skills.lpc` — skill level queries add `query_effective_boon("skill", skill)` |
 

--- a/.claude/skills/equipment/SKILL.md
+++ b/.claude/skills/equipment/SKILL.md
@@ -232,7 +232,7 @@ void setup() {
 inherit STD_WEAPON;
 
 mixed equip_check(object tp) {
-  if(tp->query_attribute("strength") < 10)
+  if(tp->get_attribute("strength") < 10)
     return "You are not strong enough to wield this.";
   return 1;
 }

--- a/.claude/skills/skills-and-advancement/SKILL.md
+++ b/.claude/skills/skills-and-advancement/SKILL.md
@@ -258,9 +258,9 @@ Default attributes (from config): `"strength"`, `"dexterity"`, `"constitution"`,
 | Function | Signature | Description |
 |---|---|---|
 | `set_attribute` | `int (string key, int value)` | Set directly. Returns new value or null if invalid key |
-| `query_attribute` | `int (string key, int raw)` | Returns `value + query_effective_boon("attribute", key)`. If `raw=1`, raw only |
+| `get_attribute` | `int (string key, int raw)` | Returns `value + query_effective_boon("attribute", key)`. If `raw=1`, raw only |
 | `modify_attribute` | `int (string key, int value)` | Adjust by delta |
-| `query_attributes` | `mapping ()` | Returns copy of all attributes |
+| `get_attributes` | `mapping ()` | Returns copy of all attributes |
 | `init_attributes` | `void ()` | Loads from config, initializes missing to 5 |
 
 Like skills, attributes support boon/curse modifiers via `query_effective_boon("attribute", key)`.

--- a/cmds/std/attr.lpc
+++ b/cmds/std/attr.lpc
@@ -31,7 +31,7 @@ mixed main(/** @type {STD_BODY} */ object tp,
     foreach(attr in attrs) {
         out += sprintf("%-15s: %d\n",
             capitalize(attr),
-            tp->query_attribute(attr)
+            tp->get_attribute(attr)
         );
     }
 

--- a/std/living/attributes.lpc
+++ b/std/living/attributes.lpc
@@ -16,57 +16,57 @@ private nomask nosave string *__default_attributes = ({});
 private nomask mapping __attributes = ([]);
 
 void init_attributes() {
-    string key;
-    mixed data;
+  string key;
+  mixed data;
 
-    __default_attributes = mud_config("ATTRIBUTES");
+  __default_attributes = mud_config("ATTRIBUTES");
 
-    __attributes ??= ([]);
+  __attributes ??= ([]);
 
-    foreach(key in __default_attributes) {
-        if(!of(key, __attributes)) {
-            __attributes[key] = 5;
-        }
+  foreach(key in __default_attributes) {
+    if(!of(key, __attributes)) {
+      __attributes[key] = 5;
     }
+  }
 
-    foreach(key, data in __attributes) {
-        if(!of(key, __default_attributes)) {
-            map_delete(__attributes, key);
-        }
+  foreach(key, data in __attributes) {
+    if(!of(key, __default_attributes)) {
+      map_delete(__attributes, key);
     }
+  }
 }
 
 int set_attribute(string key, int value) {
-    if(!of(key, __attributes)) {
-        return null;
-    }
+  if(!of(key, __attributes)) {
+    return null;
+  }
 
-    __attributes[key] = value;
+  __attributes[key] = value;
 
-    return __attributes[key];
+  return __attributes[key];
 }
 
-varargs int query_attribute(string key, int raw) {
-    if(!of(key, __attributes)) {
-        return null;
-    }
+varargs int get_attribute(string key, int raw) {
+  if(!of(key, __attributes)) {
+    return null;
+  }
 
-    if(raw)
-        return __attributes[key];
+  if(raw)
+    return __attributes[key];
 
-    return __attributes[key] + query_effective_boon("attribute", key);
+  return __attributes[key] + query_effective_boon("attribute", key);
 }
 
 int modify_attribute(string key, int value) {
-    if(!of(key, __attributes)) {
-        return null;
-    }
+  if(!of(key, __attributes)) {
+    return null;
+  }
 
-    __attributes[key] += value;
+  __attributes[key] += value;
 
-    return __attributes[key];
+  return __attributes[key];
 }
 
-mapping query_attributes() {
-    return copy(__attributes);
+mapping get_attributes() {
+  return copy(__attributes);
 }

--- a/std/living/combat.lpc
+++ b/std/living/combat.lpc
@@ -81,15 +81,17 @@ void combat_round() {
 
   swing();
 
+  if(!valid_enemy(victim))
+    return;
+
   GMCP_D->send_gmcp(this_object(), GMCP_PKG_CHAR_STATUS, ([
     GMCP_LBL_CHAR_STATUS_CURRENT_ENEMY: victim->query_name(),
     GMCP_LBL_CHAR_STATUS_CURRENT_ENEMY_HEALTH: sprintf("%.2f", victim->hp_ratio()),
     GMCP_LBL_CHAR_STATUS_CURRENT_ENEMIES: keys(__current_enemies),
   ]));
 
-  if(find_call_out(__next_combat_round) == -1) {
+  if(find_call_out(__next_combat_round) == -1)
     next_round();
-  }
 }
 
 /**
@@ -345,7 +347,7 @@ void strike_enemy(object enemy, object weapon) {
   dam =
       base
     + query_effective_level()
-    + skill
+    + (skill + query_skill_level("combat") / 2.0)
     - enemy->query_effective_level()
     - enemy->query_defence_amount(wtype)
     - enemy->query_skill_level("combat.defence")
@@ -812,10 +814,14 @@ mapping query_defence() {
  * @returns {float} The defence value, or 0.0 if not configured.
  */
 float query_defence_amount(string type) {
-  if(!__defence)
-    return 0.0;
+  if(pcp(this_object())) {
+    if(!__defence)
+      return 0.0;
 
-  return __defence[type];
+    return __defence[type];
+  } else {
+    return query_level() * 0.5;
+  }
 }
 
 /**
@@ -852,7 +858,7 @@ mapping adjust_protection() {
       __ac += ob->query_ac();
   }
 
-  return __defence;
+  return copy(__defence);
 }
 
 /**
@@ -862,7 +868,10 @@ mapping adjust_protection() {
  * @returns {float} The current total AC.
  */
 float query_ac() {
-  return __ac;
+  if(pcp(this_object()))
+    return __ac;
+  else
+    return query_level() + (query_level() * 2.0);
 }
 
 /**

--- a/std/living/damage.lpc
+++ b/std/living/damage.lpc
@@ -48,9 +48,10 @@ float deliver_damage(object victim, float damage, string type) {
   if(damage < 0)
     return 0;
 
-  tell(this_object(), sprintf("delivering %O %O damage\n", damage, type));
+  float received = victim->receive_damage(this_object(), damage, type);
+  tell(this_object(), sprintf("delivering %O %O damage => %O\n", damage, type, received));
 
-  return victim->receive_damage(this_object(), damage, type);
+  return received;
 }
 
 /**
@@ -74,13 +75,20 @@ float deliver_damage(object victim, float damage, string type) {
  *                  the body was already dead.
  */
 float receive_damage(object attacker, float damage, string type) {
-  float def, red, mod, level, alevel, level_difference;
+  float def, red, mod, level, alevel, level_difference, new_damage;
 
   if(!attacker)
     return 0.0;
 
-  if(damage < 0.0)
+  if(query_hp() <= 0.0)
     return 0.0;
+
+  new_damage = damage;
+
+  if(damage < 0.0) {
+    tell(this_object(), sprintf("receiving %O %O damage => %O\n", damage, type, new_damage));
+    return 0.0;
+  }
 
   def = query_defence_amount(type);
   red = percent_of(def, damage);
@@ -100,13 +108,12 @@ float receive_damage(object attacker, float damage, string type) {
   red -= percent_of(mod, damage);
 
   // The damage is reduced by the level modifier
-  damage -= red;
+  new_damage -= red;
+
+  tell(this_object(), sprintf("receiving %O %O damage => %O\n", damage, type, new_damage));
 
   if(damage < 0.0)
     damage = 0.0;
-
-  if(query_hp() <= 0.0)
-    return 0.0;
 
   // Take the damage
   adjust_hp(-damage);

--- a/std/living/include/attributes.h
+++ b/std/living/include/attributes.h
@@ -1,10 +1,10 @@
 #ifndef __ATTRIBUTES_H__
 #define __ATTRIBUTES_H__
 
-void init_attributes() ;
-int set_attribute(string key, int value) ;
-varargs int query_attribute(string key, int raw) ;
-int modify_attribute(string key, int value) ;
-mapping query_attributes() ;
+void init_attributes();
+int set_attribute(string key, int value);
+varargs int get_attribute(string key, int raw);
+int modify_attribute(string key, int value);
+mapping get_attributes();
 
 #endif // __ATTRIBUTES_H__

--- a/std/living/skills.lpc
+++ b/std/living/skills.lpc
@@ -8,49 +8,19 @@
  * toward the next level) and a "subskills" submapping. Dot-paths
  * (e.g. "combat.melee.slashing") address nodes within the tree.
  *
- * Improvement is use-based: callers invoke use_skill() and, on a
- * 20% roll, improve_skill() picks a node from the skill's dot-path
- * via a weighted draw favouring leaves over roots, then applies a
- * single random_float against the supplied cap to that node.
- * Parent skills therefore grow organically alongside the children
- * that are used, but more slowly because they are picked less
- * often. Callers may pass mod_adjust to raise the upper bound on
- * the random draw — useful for low-frequency call sites (specific
- * spells, niche abilities) where the default 0.01 cap would feel
- * too slow. NPCs are seeded at setup with every skill set to
- * level * 3.0 so that query_skill_level() is honest in combat math
- * without any special-case branching.
+ * Improvement is use-based: callers invoke use_skill(), which rolls
+ * for a chance to hand progress to improve_skill().
  *
  * @created 2024-07-31 - Gesslar
- * @last_modified 2026-05-10 - Gesslar
+ * @last_modified 2026-07-19 - Gesslar
  *
  * @history
  * 2024-07-31 - Gesslar - Created
- * 2026-05-10 - Gesslar - Documentation pass; NPC skills seeded at
- *                        level*3 instead of zero so query_skill_level
- *                        reflects them; dropped NPC shortcut in
- *                        query_skill, then renamed query_skill to
- *                        query_raw_skill so the name advertises its
- *                        no-floor / no-boon semantics; use_skill
- *                        gained an optional mod_adjust that raises
- *                        the upper bound on per-call random progress,
- *                        and improve_skill's progress argument is
- *                        now mixed (float/int/closure) and is always
- *                        treated as the random_float cap, with the
- *                        weighted bubble-up running every call;
- *                        extracted find_skill_node() helper so the
- *                        nested-tree walk is no longer duplicated
- *                        across every read/leaf-mutate function;
- *                        added query_raw_skill_level (floored, no
- *                        boon) and has_skill (1/0 existence check);
- *                        improve_skill explored per-node depth-
- *                        tightening but settled on the simpler
- *                        shape: every node on the path shares the
- *                        same cap, with bubble-up balance living
- *                        entirely in the pick weights — easier to
- *                        tune and faithful to the call-site's
- *                        request regardless of which node is
- *                        chosen.
+ * 2026-05-10 - Gesslar - Renamed query_skill to query_raw_skill and
+ *                        added the floored/boon query grid; use_skill
+ *                        gained mod_adjust; extracted find_skill_node.
+ * 2026-07-19 - Gesslar - Doc pass: removed restated internals and
+ *                        corrected stale claims.
  */
 
 #include <skills.h>
@@ -207,12 +177,10 @@ private nomask mapping find_skill_node(string skill) {
 }
 
 /**
- * Get the raw float level of a skill — no flooring, no boon
- * modifier. Use query_skill_level() for combat math.
+ * Get a skill's level — unfloored, no boon modifier.
  *
  * @param {string} skill - The dot-path of the skill.
- * @returns {float} The raw float level, or null if the skill is not
- *                  found or input is invalid.
+ * @returns {float} The level, or null if not found or invalid.
  */
 float query_raw_skill(string skill) {
   mapping node = find_skill_node(skill);
@@ -224,15 +192,10 @@ float query_raw_skill(string skill) {
 }
 
 /**
- * Get the float level of a skill with boon modifiers applied — the
- * unfloored counterpart to query_skill_level(). Use this when the
- * fractional progress matters (proc rolls, scaling formulas); use
- * query_skill_level() when you want the integer level.
+ * Get a skill's level — unfloored, boon applied.
  *
  * @param {string} skill - The dot-path of the skill.
- * @returns {float} The raw float level plus the boon modifier, or
- *                  null if the skill is not found or input is
- *                  invalid.
+ * @returns {float} The level, or null if not found or invalid.
  */
 float query_skill(string skill) {
   mapping node = find_skill_node(skill);
@@ -244,15 +207,10 @@ float query_skill(string skill) {
 }
 
 /**
- * Get the floored level of a skill with boon modifiers applied.
- * Combat formulas use this function rather than query_raw_skill()
- * because the boon modifier is applied here. Use
- * query_raw_skill_level() to get the floored level without boons.
+ * Get a skill's level — floored, boon applied.
  *
  * @param {string} skill - The dot-path of the skill.
- * @returns {float} The floored level with the boon modifier applied,
- *                  or null if the skill is not found or input is
- *                  invalid.
+ * @returns {float} The level, or null if not found or invalid.
  */
 float query_skill_level(string skill) {
   mapping node = find_skill_node(skill);
@@ -264,13 +222,10 @@ float query_skill_level(string skill) {
 }
 
 /**
- * Get the floored level of a skill with no boon modifier applied.
- * Equivalent to query_skill_level(skill, 1) under a name that makes
- * the unbuffed intent obvious at the call site.
+ * Get a skill's level — floored, no boon modifier.
  *
  * @param {string} skill - The dot-path of the skill.
- * @returns {float} The floored level with no boon applied, or null
- *                  if the skill is not found or input is invalid.
+ * @returns {float} The level, or null if not found or invalid.
  */
 float query_raw_skill_level(string skill) {
   mapping node = find_skill_node(skill);
@@ -336,21 +291,14 @@ void set_skills(mapping s) {
 }
 
 /**
- * Invoke a skill, granting it a 20% chance to improve. On a
- * successful roll, improve_skill() is called with the named skill
- * and mod_adjust as the random_float cap; weighted bubble-up still
- * runs, so the node that actually gains progress may be a parent
- * on the dot-path rather than the named leaf. If the skill does
- * not yet exist, it is created at level 1.0 via assure_skill() and
- * no improvement is rolled this call.
+ * Invoke a skill, rolling for a chance to improve it. The chance
+ * scales with the skill's current level. An unknown skill is
+ * created instead, with no roll this call.
  *
  * @param {string} skill - The dot-path of the skill being used.
- * @param {mixed} [mod_adjust] - Upper bound for the per-call random
- *                               progress. Accepts a float, an int,
- *                               or a closure that evaluates to one
- *                               of those. Omit (or null) to fall
- *                               back to the 0.01 default in
- *                               improve_skill().
+ * @param {mixed} [mod_adjust] - Progress bound, passed through to
+ *                               improve_skill(). Omit for its
+ *                               default.
  * @returns {int | undefined} 1 if the roll fired this call, 0
  *                            otherwise, or null on invalid input.
  */
@@ -388,34 +336,20 @@ string *query_skill_path(string skill) {
  * Apply progress to a skill, with weighted bubble-up.
  *
  * A target node is chosen from the skill's dot-path via a weighted
- * draw favouring leaves over roots (weights are (depth+1)*3, so
- * for a 3-segment path the leaf is picked 50% of the time, the
- * middle 33%, the root 17%). A single random_float draw against
- * the supplied cap is then added to the chosen node's level.
- * Parent skills therefore grow organically alongside the children
- * that are used, but more slowly because they are picked less
- * often. The cap is the same for every node on the path — bubble-
- * up balance lives entirely in the pick weights.
- *
- * The progress argument is the upper bound for the random draw,
- * not the literal amount applied. It accepts:
- *
- *   - omitted / null — defaults to 0.01.
- *   - float — used as-is.
- *   - int — promoted to float.
- *   - closure — evaluated against this_object(), then coerced.
- *
- * If the integer level of the chosen node rises as a result, a
- * notification is sent to the living object.
+ * draw favouring leaves over roots, so parents grow alongside the
+ * children that are used, but more slowly. The node then gains a
+ * random amount of progress, bounded by potential_progress, and
+ * the living object is told if that crosses a level.
  *
  * @param {string} skill - The dot-path used to seed the weighted
  *                         walk.
  * @param {mixed} [potential_progress=0.01] - Upper bound for the
- *                            random roll. See description for
- *                            accepted forms.
- * @returns {float} The new raw level of the chosen node after
- *                  progress is applied, 0 if an intermediate is
- *                  missing, or null on invalid input.
+ *                            random roll, not the amount applied.
+ *                            A float, an int, or a closure
+ *                            evaluated against this_object().
+ * @returns {float} The chosen node's new level, 0 if an
+ *                  intermediate is missing, or null on invalid
+ *                  input.
  */
 varargs float improve_skill(string skill, mixed potential_progress: (: 0.01 :)) {
   if(!stringp(skill))
@@ -482,12 +416,9 @@ int query_skill_progress(string skill) {
 }
 
 /**
- * Set a skill's level to an integer value, replacing whatever was
- * stored.
- *
- * Unlike set_skill_level(), this accepts an int and does not
- * enforce a minimum level. Intermediate nodes must already exist —
- * this function will not create them.
+ * Set a skill's level to an integer value. Unlike
+ * set_skill_level(), takes an int and enforces no minimum.
+ * Intermediate nodes must already exist.
  *
  * @param {string} skill - The dot-path of the skill.
  * @param {int} level - The new level value.
@@ -509,12 +440,9 @@ int modify_skill_level(string skill, int level) {
 }
 
 /**
- * Seed every NPC skill to level * 3.0 so that query_skill_level()
- * is honest for combat math. Called from npc.c::set_level() after
- * the level is updated.
+ * Reseed every NPC skill from the NPC's current level.
  *
- * @param {float} level - The NPC's current level. Each skill is
- *                        stored as level * 3.0.
+ * @param {float} level - The NPC's current level.
  * @returns {int} 1 if the skill tree was traversed, 0 if there were
  *                no skills to adjust.
  */
@@ -528,7 +456,7 @@ public int adjust_skills_by_npc_level(float level) {
 }
 
 /**
- * Recursively set every skill's level to level * 3.0. NPC-only —
+ * Recursively set every skill's level to level * 4.0. NPC-only —
  * errors out if called on a user.
  *
  * @param {mapping} current_skills - The skills submapping at the
@@ -548,7 +476,7 @@ private nomask mapping adjust_skill_levels(mapping current_skills, float level) 
     if(mapp(skill_data) && mapp(skill_data["subskills"]))
       adjust_skill_levels(skill_data["subskills"], level);
 
-    current_skills[sk]["level"] = level * 3.0;
+    current_skills[sk]["level"] = level * 4.0;
   }
 
   return current_skills;


### PR DESCRIPTION
## Attribute & Combat System Refactor

### Attributes
- Renamed `query_attribute` to `get_attribute` and `query_attributes` to `get_attributes` for naming consistency
- Updated the header file declarations to match, removing extraneous whitespace before semicolons

### Combat
- Added an early return in `combat_round()` after `swing()` if the victim is no longer a valid enemy, preventing GMCP updates and round scheduling against a stale target
- Incorporated `combat` skill into strike damage calculation, adding half the attacker's `combat` skill level to the damage formula
- `query_defence_amount` and `query_ac` now return level-scaled fallback values for NPCs rather than relying on the `__defence` mapping, giving NPCs a baseline defence proportional to their level without requiring explicit defence configuration
- `adjust_protection` now returns a copy of `__defence` instead of the live mapping

### Damage
- `receive_damage` now exits early if the target is already at or below 0 HP, preventing damage application to dead targets
- Damage calculation now tracks the modified value in `new_damage` separately from the original `damage` argument, fixing a bug where `adjust_hp` was called with the unreduced original damage value
- Debug tell output now includes the received damage amount after reduction

### Skills
- NPC skill seeding multiplier raised from `3.0` to `4.0`
- Condensed verbose doc comments throughout to remove restated implementation details

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR renames attribute accessors and retunes NPC combat behavior.

- Renames `query_attribute(s)` to `get_attribute(s)`.
- Adds combat-round target validation and NPC defence/AC scaling.
- Updates damage logging and dead-target handling.
- Raises NPC skill seeding to four times level.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `std/living/damage.lpc`, line 110-127 ([link](https://github.com/gesslar/oxidus-mudlib/blob/510bed8487bbb6fd488f21609ba243bf30474529/std/living/damage.lpc#L110-L127)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mitigation result is never applied**

   This calculates the reduced value in `new_damage`, but the clamp, HP update, and return value still use the original `damage`. A defended victim hit for 100 therefore still loses and reports 100 HP even when defence and level scaling reduce `new_damage` to zero.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20std%2Fliving%2Fdamage.lpc%0ALine%3A%20110-127%0A%0AComment%3A%0A**Mitigation%20result%20is%20never%20applied**%0A%0AThis%20calculates%20the%20reduced%20value%20in%20%60new_damage%60%2C%20but%20the%20clamp%2C%20HP%20update%2C%20and%20return%20value%20still%20use%20the%20original%20%60damage%60.%20A%20defended%20victim%20hit%20for%20100%20therefore%20still%20loses%20and%20reports%20100%20HP%20even%20when%20defence%20and%20level%20scaling%20reduce%20%60new_damage%60%20to%20zero.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20The%20damage%20is%20reduced%20by%20the%20level%20modifier%0A%20%20new_damage%20-%3D%20red%3B%0A%0A%20%20tell%28this_object%28%29%2C%20sprintf%28%22receiving%20%25O%20%25O%20damage%20%3D%3E%20%25O%5Cn%22%2C%20damage%2C%20type%2C%20new_damage%29%29%3B%0A%0A%20%20if%28new_damage%20%3C%200.0%29%0A%20%20%20%20new_damage%20%3D%200.0%3B%0A%0A%20%20%2F%2F%20Take%20the%20damage%0A%20%20adjust_hp%28-new_damage%29%3B%0A%0A%20%20%2F%2F%20Set%20the%20last%20damaged%20by%20object%0A%20%20set_last_damaged_by%28attacker%29%3B%0A%0A%20%20if%28query_hp%28%29%20%3C%3D%200.0%29%0A%20%20%20%20set_killed_by%28attacker%29%3B%0A%0A%20%20return%20new_damage%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gesslar%2Foxidus-mudlib&pr=371&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

2. `std/living/damage.lpc`, line 111-127 ([link](https://github.com/gesslar/oxidus-mudlib/blob/3b5d214c484a1d330b264eee4ee1ea795324ab8a/std/living/damage.lpc#L111-L127)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Reduced damage is discarded**

   `new_damage` receives the defence and level reduction, but the HP update and return value still use the original `damage` argument. Every normal hit therefore bypasses the mitigation that was just calculated: a defended target loses the full incoming amount, and `deliver_damage()` reports that full amount instead of the amount actually applied.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20std%2Fliving%2Fdamage.lpc%0ALine%3A%20111-127%0A%0AComment%3A%0A**Reduced%20damage%20is%20discarded**%0A%0A%60new_damage%60%20receives%20the%20defence%20and%20level%20reduction%2C%20but%20the%20HP%20update%20and%20return%20value%20still%20use%20the%20original%20%60damage%60%20argument.%20Every%20normal%20hit%20therefore%20bypasses%20the%20mitigation%20that%20was%20just%20calculated%3A%20a%20defended%20target%20loses%20the%20full%20incoming%20amount%2C%20and%20%60deliver_damage%28%29%60%20reports%20that%20full%20amount%20instead%20of%20the%20amount%20actually%20applied.%0A%0A%60%60%60suggestion%0A%20%20new_damage%20-%3D%20red%3B%0A%0A%20%20tell%28this_object%28%29%2C%20sprintf%28%22receiving%20%25O%20%25O%20damage%20%3D%3E%20%25O%5Cn%22%2C%20damage%2C%20type%2C%20new_damage%29%29%3B%0A%0A%20%20if%28new_damage%20%3C%200.0%29%0A%20%20%20%20new_damage%20%3D%200.0%3B%0A%0A%20%20%2F%2F%20Take%20the%20damage%0A%20%20adjust_hp%28-new_damage%29%3B%0A%0A%20%20%2F%2F%20Set%20the%20last%20damaged%20by%20object%0A%20%20set_last_damaged_by%28attacker%29%3B%0A%0A%20%20if%28query_hp%28%29%20%3C%3D%200.0%29%0A%20%20%20%20set_killed_by%28attacker%29%3B%0A%0A%20%20return%20new_damage%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gesslar%2Foxidus-mudlib&pr=371&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Astd%2Fliving%2Fdamage.lpc%3A111-127%0A**Reduced%20damage%20is%20discarded**%0A%0A%60new_damage%60%20receives%20the%20defence%20and%20level%20reduction%2C%20but%20the%20HP%20update%20and%20return%20value%20still%20use%20the%20original%20%60damage%60%20argument.%20Every%20normal%20hit%20therefore%20bypasses%20the%20mitigation%20that%20was%20just%20calculated%3A%20a%20defended%20target%20loses%20the%20full%20incoming%20amount%2C%20and%20%60deliver_damage%28%29%60%20reports%20that%20full%20amount%20instead%20of%20the%20amount%20actually%20applied.%0A%0A%60%60%60suggestion%0A%20%20new_damage%20-%3D%20red%3B%0A%0A%20%20tell%28this_object%28%29%2C%20sprintf%28%22receiving%20%25O%20%25O%20damage%20%3D%3E%20%25O%5Cn%22%2C%20damage%2C%20type%2C%20new_damage%29%29%3B%0A%0A%20%20if%28new_damage%20%3C%200.0%29%0A%20%20%20%20new_damage%20%3D%200.0%3B%0A%0A%20%20%2F%2F%20Take%20the%20damage%0A%20%20adjust_hp%28-new_damage%29%3B%0A%0A%20%20%2F%2F%20Set%20the%20last%20damaged%20by%20object%0A%20%20set_last_damaged_by%28attacker%29%3B%0A%0A%20%20if%28query_hp%28%29%20%3C%3D%200.0%29%0A%20%20%20%20set_killed_by%28attacker%29%3B%0A%0A%20%20return%20new_damage%3B%0A%60%60%60%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=371&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["combat"](https://github.com/gesslar/oxidus-mudlib/commit/3b5d214c484a1d330b264eee4ee1ea795324ab8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45493995)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->