### PR TITLE
Fix colour selection prompt format for numeric input

### DIFF
--- a/adm/simul_efun/prompt.lpc
+++ b/adm/simul_efun/prompt.lpc
@@ -153,7 +153,7 @@ varargs void prompt_colour(object body, mixed *cb, string prompt) {
 
   mess += "\n\n";
 
-  mess += "Select one of (colour), (0-255), (c)olour list, (p)lain, or (q)uit.\n"
+  mess += "Select one of (colour), #(000-fff), (c)olour list, (p)lain, or (q)uit.\n"
           "Your choice: ";
 
   tell(body, mess);
@@ -190,7 +190,7 @@ private void _prompt_colour(string input, string prompt, object body, mixed *bas
     prompt += "\n";
     prompt += list;
     prompt += "\n";
-    prompt += "Select (0-255), (p)lain), or (q)uit.\n";
+    prompt += "Select #(000-fff), (p)lain, or (q)uit.\n";
     prompt += "Your choice: ";
 
     tell(body, prompt);


### PR DESCRIPTION
Updates the colour selection prompt text to use `#(0-255)` instead of `(0-255)`, making it clearer that numeric colour codes should be prefixed with `#`. Also fixes a stray closing parenthesis in the "plain" option of the secondary prompt.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR clarifies the colour selection prompts.

- Advertises `#RGB` colour input in both prompt paths.
- Fixes the extra parenthesis in the plain option.
</details>

<sub>Reviews (3): Last reviewed commit: ["fixing prompts"](https://github.com/gesslar/oxidus-mudlib/commit/5de36440036f73b39da16afafc1cbdd4d97d6a39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45493999)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->