### PR TITLE
Fix double-space bug in LPML string concatenation across mobs, items, and skill docs

### DIFF
--- a/.claude/skills/lpml/SKILL.md
+++ b/.claude/skills/lpml/SKILL.md
@@ -97,6 +97,29 @@ Adjacent string values automatically concatenate. The joining rule depends on wh
 
 This works across quote styles (double and single quotes can be mixed).
 
+**Never pad a fragment with a space.** The separator is supplied by the parser, exactly as in YAML folding. A trailing space before the closing quote — or a leading space after the opening quote of the next fragment — produces a **double space** in the decoded string:
+
+```lpml
+{
+  // WRONG — trailing space before the closing quote
+  long: "A long, curved fang taken from the jaw of a shadow wolf, ivory "
+        "shading to a smoky grey at the root.",
+  // Result: "...ivory  shading to a smoky grey..."   <-- two spaces
+
+  // WRONG — leading space after the opening quote
+  long: "This heavy cloak is woven from thick, undyed wool in a natural"
+        " greyish-brown, its weave dense enough to turn a cold wind.",
+  // Result: "...natural  greyish-brown..."           <-- two spaces
+
+  // RIGHT — no padding at either edge; the parser joins with one space
+  long: "A long, curved fang taken from the jaw of a shadow wolf, ivory"
+        "shading to a smoky grey at the root.",
+  // Result: "...ivory shading to a smoky grey..."
+}
+```
+
+A trailing space on the *final* fragment is equally wrong — it leaves a stray space at the end of the value. The only fragment that may end in whitespace is one ending with an explicit `\n`, where the parser adds nothing.
+
 ```lpml
 {
   // These join with spaces (no trailing \n):
@@ -125,7 +148,15 @@ This works across quote styles (double and single quotes can be mixed).
 
 ### Multiline Strings (Source Line Folding)
 
-Actual newlines in the source (pressing Enter) are converted to spaces. Escape sequences like `\n` remain as literal newline characters. This means you write long strings naturally across source lines without worrying about embedded newlines.
+Actual newlines *inside* a single quoted string (pressing Enter without closing the quote) are folded. Escape sequences like `\n` survive folding and remain literal newline characters. This means you write long strings naturally across source lines without worrying about embedded newlines.
+
+Folding rules:
+
+- Each source line is trimmed, then joined to the previous with a single space.
+- A **blank source line** becomes a paragraph break — a literal `\n` — rather than a space.
+- The folded result is trimmed, so leading and trailing whitespace on the value is discarded.
+
+Note that folding applies within one quoted string; concatenation of *adjacent* quoted strings is the separate rule above, and only concatenation is affected by edge padding.
 
 ### File Includes
 
@@ -144,6 +175,7 @@ Rules:
 - File includes are processed recursively (included files may themselves contain includes).
 - If a file cannot be found, an implementation SHOULD keep the include string as its literal value.
 - To produce a literal `#` at the start of a string (preventing include processing), escape it: `\#`.
+- A relative path resolves against the including file's directory. Traversal is single-direction only: `./sub/file.lpml` and `../../dir/file.lpml` are fine, but mixed traversal such as `./../what/no.lpml` is not resolved. Absolute paths (leading `/`) are used as-is.
 
 ```lpml
 {
@@ -194,12 +226,16 @@ Objects support nesting and trailing commas:
 
 ### Special Values
 
-#### Infinity and NaN
+#### null, undefined, Infinity and NaN
 
-`Infinity`, `-Infinity`, and `NaN` are valid values. In LPC, these map to `undefined` (equivalent to `([])[0]`) because LPC does not have native Infinity/NaN support.
+`null`, `undefined`, `Infinity`, `-Infinity`, and `NaN` are all valid values, and **all decode to LPC `undefined`** (equivalent to `([])[0]`) — LPC has no native null, Infinity, or NaN. `undefined` is an LPML keyword; JSON5 has no such literal.
+
+Because they collapse to the same value, a decoded key holding `null` is indistinguishable from an absent key. Test with `undefinedp()`, not `== 0` — `typeof()` in this lib returns `T_UNDEFINED` for these. On encode, `undefined` is written back out as `null`.
 
 ```lpml
 {
+  nothing: null,
+  also_nothing: undefined,
   inf: Infinity,
   neg_inf: -Infinity,
   nan: NaN,
@@ -252,11 +288,13 @@ Standard JSON escape sequences are supported in strings:
 | String concatenation | no | yes |
 | File includes | no | yes |
 | Multiline folding | no | yes |
+| `undefined` literal | no | yes |
 
 ## Formatting Guidelines
 
 - Keep lines within 80 columns. LPML files are MUD configuration data consumed in terminal contexts where 80 columns is the norm.
 - Break long string concatenation values across multiple lines to stay within the limit.
+- **Never pad a string fragment with a leading or trailing space.** The parser supplies the separator; padding yields a double space. Break at a word boundary and let the join do the work. This is the single most common defect in hand-written LPML.
 - Break long arrays across multiple lines if they would exceed 80 columns.
 
 ## Complete Example

--- a/.claude/skills/npc-creation/SKILL.md
+++ b/.claude/skills/npc-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: npc-creation
-description: Create and modify NPCs and monsters for Oxidus. Covers code-based NPCs (STD_NPC), data-driven monsters (virtual_setup, LPML), setLevel, race modules, body parts, heartbeat optimization, combat memory, loot/coin tables, utility-AI decisions, and the virtual compile flow.
+description: Create and modify NPCs and monsters for Oxidus. Covers code-based NPCs (STD_NPC), data-driven monsters (virtual_setup, LPML), set_level, race modules, body parts, heartbeat optimization, combat memory, loot/coin tables, utility-AI decisions, and the virtual compile flow.
 ---
 
 # NPC Creation Skill
@@ -10,7 +10,7 @@ You are helping create and modify NPCs/monsters for Oxidus. Follow the `lpc-codi
 ## Architecture Overview
 
 ```
-STD_NPC (std/living/npc.lpc)               — NPC base: heartbeat, setLevel, death detect
+STD_NPC (std/living/npc.lpc)               — NPC base: heartbeat, set_level, death detect
   └── STD_BODY                            — inherits skills, combat, vitals, wealth, etc.
 
 STD_MONSTER (std/mobs/monster.lpc)          — data-driven virtual_setup for LPML mobs
@@ -51,7 +51,7 @@ void setup() {
     set_id(({"guard", "town guard"}));
     set_gender("male");
     set_race("human");
-    setLevel(5.0);                          // BEFORE custom skills
+    set_level(5.0);                          // BEFORE custom skills
     set_damage(8.0);
     set_weapon_name("sword");
     set_weapon_type("slashing");
@@ -114,11 +114,11 @@ In `mudlib_setup()` (for clones):
 4. `add_hb("stop_heart_beat")` — checked each heartbeat to stop when room is empty.
 5. `add_module("mob/combat_memory")` — loads combat memory module.
 
-### `setLevel(float level)`
+### `set_level(float level)`
 
-**Overrides** the body's `setLevel`. After setting the level, calls `adjust_skills_by_npc_level(level)` which **resets all stored skill levels to near-zero** (`random_float(0.01)`).
+**Overrides** the body's `set_level`. After setting the level, calls `adjust_skills_by_npc_level(level)`, which **seeds every stored skill to a multiple of the NPC's level** so combat math reads honest values. The multiplier lives in `adjust_skill_levels()` in `/std/living/skills.lpc`.
 
-**Order matters:** If you add skills and then call `setLevel()`, the skills are wiped. Set level first, then add any custom skills if needed (though for NPCs, `query_skill()` uses the `level * 3` shortcut anyway).
+**Order matters:** If you add custom skills and then call `set_level()`, `adjust_skills_by_npc_level()` overwrites them all. Set level first, then add any custom skills if needed (though for NPCs every skill already resolves to the level-scaled value, so custom values rarely matter).
 
 ### NPC Weapon Properties
 
@@ -126,7 +126,7 @@ Used when the NPC has no wielded weapon object:
 
 | Function | Default | Description |
 |---|---|---|
-| `set_damage(float)` | `0.0` | Base damage. If `<= 0`, uses `random_float(queryLevel() * 2.0)` |
+| `set_damage(float)` | `0.0` | Base damage. If `<= 0`, the roll scales with level: `query_level() + random_float(query_level())` |
 | `set_weapon_name(string)` | `"fist"` | Display name for combat messages |
 | `set_weapon_type(string)` | `"bludgeoning"` | Damage type string |
 
@@ -446,9 +446,9 @@ Memory is populated from `combat.lpc::start_attack()` for NPC combatants. Resets
 
 NPCs interact with the skill system differently from players:
 
-1. **`query_skill()` returns `queryLevel() * 3.0`** for all skills — NPCs never use stored skill values for this function.
-2. **`setLevel()` wipes stored skills** via `adjust_skills_by_npc_level()`.
-3. **`query_skill_level()` reads stored values** (near-zero after `setLevel`) — no NPC shortcut.
+1. **Every NPC skill is scaled from the NPC's level**, not trained. `set_level()` seeds each stored skill node to a multiple of the level via `adjust_skills_by_npc_level()` — it does not wipe them to zero.
+2. **The query functions read those seeded values**, so `query_skill()` returns the scaled level (plus any boon) and `query_skill_level()` returns it floored. There is no NPC special-casing in the query path.
+3. The multiplier is defined in `adjust_skill_levels()` in `/std/living/skills.lpc` — check there rather than assuming a figure.
 4. See the `skills-and-advancement` skill for full details on the skill system.
 
 ## Signals
@@ -469,7 +469,7 @@ NPCs interact with the skill system differently from players:
 
 ## Gotchas
 
-1. **`setLevel()` on NPCs wipes stored skills.** Always call `setLevel()` before adding custom skills.
+1. **`set_level()` on NPCs overwrites stored skills** with the level-scaled value. Always call `set_level()` before adding custom skills.
 2. **`set_race()` silently falls back** if the race module file doesn't exist. The NPC will have no body parts, no equipment slots, and no regen rates. No error is raised.
 3. **NPCs stop ticking in empty rooms.** No heartbeat = no regen, no boon processing, no AI decisions, no death detection. An NPC at 1 HP in an empty room stays at 1 HP indefinitely.
 4. **`add_func()` matches by exact description string.** If the string doesn't match a registered decision, the function is never called.

--- a/d/mobs/bat.lpml
+++ b/d/mobs/bat.lpml
@@ -2,7 +2,7 @@
   type: "mammal",
   name: "cave bat",
   short: "cave bat",
-  long: "A leathery cave bat clings to the ceiling, its small black eyes "
+  long: "A leathery cave bat clings to the ceiling, its small black eyes"
         "watching for intruders. Its tiny fangs glisten in the gloom.",
   id: [
     "cave bat",

--- a/d/mobs/bramble_cur.lpml
+++ b/d/mobs/bramble_cur.lpml
@@ -6,11 +6,11 @@
   type: "mammal",
   name: "bramble cur",
   short: "bramble cur",
-  long: "Once it was a dog. The blight has made it something else: a lean, "
-        "scarred hound whose matted hide has gone half to bark, with thorns "
-        "grown through the skin along its spine and a green sickly light "
-        "behind its eyes. It pulls its lips back from yellow teeth and a low "
-        "wet snarl works in its throat. This is what guards the heart of "
+  long: "Once it was a dog. The blight has made it something else: a lean,"
+        "scarred hound whose matted hide has gone half to bark, with thorns"
+        "grown through the skin along its spine and a green sickly light"
+        "behind its eyes. It pulls its lips back from yellow teeth and a low"
+        "wet snarl works in its throat. This is what guards the heart of"
         "the thicket, and it has come home to find you in it.",
   id: [
     "bramble cur",

--- a/d/mobs/carrion_crow.lpml
+++ b/d/mobs/carrion_crow.lpml
@@ -5,9 +5,9 @@
   type: "monster",
   name: "carrion crow",
   short: "carrion crow",
-  long: "A big carrion crow, oily-black and bold, watches you with one "
-        "flat dark eye. It does not trouble to fly off. It has the look "
-        "of a bird that has grown used to easy pickings, and is wondering, "
+  long: "A big carrion crow, oily-black and bold, watches you with one"
+        "flat dark eye. It does not trouble to fly off. It has the look"
+        "of a bird that has grown used to easy pickings, and is wondering,"
         "without much hurry, whether you might become some.",
   id: [
     "carrion crow",

--- a/d/mobs/centipede.lpml
+++ b/d/mobs/centipede.lpml
@@ -2,7 +2,7 @@
   type: "insect",
   name: "giant centipede",
   short: "giant centipede",
-  long: "An enormous centipede ripples along the tunnel floor, its many legs "
+  long: "An enormous centipede ripples along the tunnel floor, its many legs"
         "clicking against the stone. Venom drips from its curved mandibles.",
   id: [
     "giant centipede",

--- a/d/mobs/mole.lpml
+++ b/d/mobs/mole.lpml
@@ -2,7 +2,7 @@
   type: "mammal",
   name: "tunnel mole",
   short: "tunnel mole",
-  long: "A burly tunnel mole digs at the dirt with its broad, shovel-like "
+  long: "A burly tunnel mole digs at the dirt with its broad, shovel-like"
         "claws. Its velvety dark fur is caked with earth.",
   id: [
     "tunnel mole",

--- a/d/mobs/rat.lpml
+++ b/d/mobs/rat.lpml
@@ -2,7 +2,7 @@
   type: "rodent",
   name: "cave rat",
   short: "cave rat",
-  long: "A grimy cave rat skitters through the gloom, its eyes reflecting the "
+  long: "A grimy cave rat skitters through the gloom, its eyes reflecting the"
         "faintest glimmer of light. Its long pink tail drags behind it.",
   id: [
     "cave rat",

--- a/d/mobs/waste_rat.lpml
+++ b/d/mobs/waste_rat.lpml
@@ -4,7 +4,7 @@
   type: "mammal",
   name: "waste rat",
   short: "waste rat",
-  long: "A scrappy waste rat scurries through the debris, searching for "
+  long: "A scrappy waste rat scurries through the debris, searching for"
         "scraps to eat.",
   id: [
     "waste rat",

--- a/d/mobs/wasterel.lpml
+++ b/d/mobs/wasterel.lpml
@@ -2,7 +2,7 @@
   type: "mammal",
   name: "wasterel",
   short: "wasterel",
-  long: "A cunning wasteland cat prowls the desolate terrain, its eyes "
+  long: "A cunning wasteland cat prowls the desolate terrain, its eyes"
         "glinting with hunger.",
   id: [
     "wasterel",

--- a/d/mobs/wild_boar.lpml
+++ b/d/mobs/wild_boar.lpml
@@ -2,7 +2,7 @@
   type: "mammal",
   name: "wild boar",
   short: "wild boar",
-  long: "A wild boar is here, snuffling around for food. Its tusks look sharp "
+  long: "A wild boar is here, snuffling around for food. Its tusks look sharp"
         "and dangerous.",
   id: [
     "wild boar",

--- a/etc/resource/stone.lpml
+++ b/etc/resource/stone.lpml
@@ -4,19 +4,19 @@
     adj: ["irregular", "rough", "fractured"],
     additional ids: ["chunk"],
     short: "a large, irregularly shaped rock",
-    long: "A rough chunk of rock the size of a man's chest, its sides "
-          "fractured along uneven planes where it broke from some "
-          "greater mass. The dull grey surface is streaked with paler "
-          "grit and would take more than a single swing to work loose "
+    long: "A rough chunk of rock the size of a man's chest, its sides"
+          "fractured along uneven planes where it broke from some"
+          "greater mass. The dull grey surface is streaked with paler"
+          "grit and would take more than a single swing to work loose"
           "of anything worth keeping."
   },
   ">=50.0AND<80.0": {
     size: "medium",
     adj: ["great", "pocked", "weather-pitted"],
     short: "a great, pocked stone",
-    long: "A heavy, weather-pitted stone, taller than it is wide, its "
-          "flanks dimpled by ages of patient erosion and threaded with "
-          "thin veins of pale mineral. It would take a good arm and a "
+    long: "A heavy, weather-pitted stone, taller than it is wide, its"
+          "flanks dimpled by ages of patient erosion and threaded with"
+          "thin veins of pale mineral. It would take a good arm and a"
           "better tool to split anything useful from it."
   },
   ">=80.0AND<100.0": {
@@ -24,10 +24,10 @@
     adj: ["colossal", "weather-worn", "hulking"],
     additional ids: ["boulder", "slab"],
     short: "a colossal, weather-worn slab",
-    long: "A hulking slab of stone, broad-shouldered and squat, half "
-          "settled into the earth as though it had always been here. "
-          "Its flanks bear the faint scars of countless seasons, and "
-          "the sheer bulk of it promises stubborn work for any hand "
+    long: "A hulking slab of stone, broad-shouldered and squat, half"
+          "settled into the earth as though it had always been here."
+          "Its flanks bear the faint scars of countless seasons, and"
+          "the sheer bulk of it promises stubborn work for any hand"
           "bold enough to try."
   }
 }

--- a/obj/armour/arms/leather_bracers.lpml
+++ b/obj/armour/arms/leather_bracers.lpml
@@ -6,10 +6,10 @@
   name: "sturdy leather bracers",
   short: "pair of sturdy leather bracers",
   long: "These matched bracers are cut from thick, supple leather and shaped"
-        " to guard the forearm from wrist to elbow. Dyed a rich, earthy brown"
-        " to match their jerkin, each is fastened by three adjustable straps"
-        " and reinforced with an extra layer of stitched leather along the"
-        " outer edge, where a blow is most likely to land.",
+        "to guard the forearm from wrist to elbow. Dyed a rich, earthy brown"
+        "to match their jerkin, each is fastened by three adjustable straps"
+        "and reinforced with an extra layer of stitched leather along the"
+        "outer edge, where a blow is most likely to land.",
   mass: 40,
   value: 15,
   slot: "arms",

--- a/obj/armour/back/wool_cloak.lpml
+++ b/obj/armour/back/wool_cloak.lpml
@@ -6,11 +6,11 @@
   name: "woollen cloak",
   short: "heavy woollen cloak",
   long: "This heavy cloak is woven from thick, undyed wool in a natural"
-        " greyish-brown, its weave dense enough to turn a cold wind or a"
-        " passing rain. It falls well past the knee and is gathered at the"
-        " throat by a simple bronze clasp. The wool is layered and quilted"
-        " across the shoulders, thick enough to soften a glancing blow, and a"
-        " deep hood can be drawn up against the weather.",
+        "greyish-brown, its weave dense enough to turn a cold wind or a"
+        "passing rain. It falls well past the knee and is gathered at the"
+        "throat by a simple bronze clasp. The wool is layered and quilted"
+        "across the shoulders, thick enough to soften a glancing blow, and a"
+        "deep hood can be drawn up against the weather.",
   mass: 70,
   value: 16,
   slot: "back",

--- a/obj/armour/feet/leather_boots.lpml
+++ b/obj/armour/feet/leather_boots.lpml
@@ -6,10 +6,10 @@
   name: "sturdy leather boots",
   short: "pair of sturdy leather boots",
   long: "These boots rise to mid-calf, built from thick, earthy-brown leather"
-        " that matches the rest of the set. The soles are heavy and stitched"
-        " twice over for the road, and a hardened leather guard shields the"
-        " shin and instep. Broad straps and a snug buckle at the top keep"
-        " them firmly in place.",
+        "that matches the rest of the set. The soles are heavy and stitched"
+        "twice over for the road, and a hardened leather guard shields the"
+        "shin and instep. Broad straps and a snug buckle at the top keep"
+        "them firmly in place.",
   mass: 55,
   value: 15,
   slot: "feet",

--- a/obj/armour/hands/leather_gloves.lpml
+++ b/obj/armour/hands/leather_gloves.lpml
@@ -6,10 +6,10 @@
   name: "sturdy leather gloves",
   short: "pair of sturdy leather gloves",
   long: "Crafted from the same supple, earthy-brown leather as their matching"
-        " set, these gloves fit close to the hand without hindering the"
-        " fingers. The backs are reinforced with an additional layer of"
-        " leather, and the palms are textured for a firm grip. Snug cuffs"
-        " buckle at the wrist to keep them from slipping.",
+        "set, these gloves fit close to the hand without hindering the"
+        "fingers. The backs are reinforced with an additional layer of"
+        "leather, and the palms are textured for a firm grip. Snug cuffs"
+        "buckle at the wrist to keep them from slipping.",
   mass: 15,
   value: 10,
   slot: "hands",

--- a/obj/armour/head/leather_cap.lpml
+++ b/obj/armour/head/leather_cap.lpml
@@ -6,11 +6,11 @@
   name: "sturdy leather cap",
   short: "sturdy leather cap",
   long: "This close-fitting cap is boiled from a single piece of sturdy"
-        " leather, moulded to hug the crown of the head. Dyed the same rich,"
-        " earthy brown as its matching jerkin, it is stitched along a central"
-        " ridge with reinforced thread and lined inside with a softer padding"
-        " for comfort. A thin chin strap keeps it seated snugly during"
-        " movement.",
+        "leather, moulded to hug the crown of the head. Dyed the same rich,"
+        "earthy brown as its matching jerkin, it is stitched along a central"
+        "ridge with reinforced thread and lined inside with a softer padding"
+        "for comfort. A thin chin strap keeps it seated snugly during"
+        "movement.",
   mass: 30,
   value: 12,
   slot: "head",

--- a/obj/armour/legs/leather_leggings.lpml
+++ b/obj/armour/legs/leather_leggings.lpml
@@ -6,10 +6,10 @@
   name: "sturdy leather leggings",
   short: "pair of sturdy leather leggings",
   long: "These leggings are layered from thick, treated leather and fitted to"
-        " protect the thigh and shin without restricting stride. Dyed a rich,"
-        " earthy brown to match their jerkin, the seams are double-stitched"
-        " and the leather is boiled harder over the knees and shins. A row of"
-        " side straps allows the fit to be drawn snug against the leg.",
+        "protect the thigh and shin without restricting stride. Dyed a rich,"
+        "earthy brown to match their jerkin, the seams are double-stitched"
+        "and the leather is boiled harder over the knees and shins. A row of"
+        "side straps allows the fit to be drawn snug against the leg.",
   mass: 80,
   value: 18,
   slot: "legs",

--- a/obj/armour/neck/leather_gorget.lpml
+++ b/obj/armour/neck/leather_gorget.lpml
@@ -6,10 +6,10 @@
   name: "sturdy leather gorget",
   short: "sturdy leather gorget",
   long: "This gorget is boiled from thick leather and shaped into a stiff"
-        " collar that guards the throat and the base of the neck. Dyed the"
-        " same rich, earthy brown as its matching set, it is cut in two"
-        " overlapping plates that buckle at the side, allowing the head to"
-        " turn freely while still warding off a thrust aimed at the throat.",
+        "collar that guards the throat and the base of the neck. Dyed the"
+        "same rich, earthy brown as its matching set, it is cut in two"
+        "overlapping plates that buckle at the side, allowing the head to"
+        "turn freely while still warding off a thrust aimed at the throat.",
   mass: 25,
   value: 13,
   slot: "neck",

--- a/obj/armour/torso/leather_jerkin.lpml
+++ b/obj/armour/torso/leather_jerkin.lpml
@@ -6,13 +6,13 @@
   name: "sturdy leather jerkin",
   short: "sturdy leather jerkin",
   long: "This sturdy leather jerkin is crafted from high-quality, supple"
-        " leather, designed to offer both protection and mobility. The"
-        " jerkin is dyed a rich, earthy brown, and the leather is treated to"
-        " provide resistance against wear and tear. Reinforced stitching"
-        " runs along the seams, ensuring durability, while the inside is"
-        " lined with a softer material for added comfort. The jerkin"
-        " features adjustable straps along the sides and shoulders, allowing"
-        " for a snug fit.",
+        "leather, designed to offer both protection and mobility. The"
+        "jerkin is dyed a rich, earthy brown, and the leather is treated to"
+        "provide resistance against wear and tear. Reinforced stitching"
+        "runs along the seams, ensuring durability, while the inside is"
+        "lined with a softer material for added comfort. The jerkin"
+        "features adjustable straps along the sides and shoulders, allowing"
+        "for a snug fit.",
   mass: 120,
   value: 25,
   slot: "torso",

--- a/obj/clothing/back/velvet_cape.lpml
+++ b/obj/clothing/back/velvet_cape.lpml
@@ -6,11 +6,11 @@
   name: "crimson velvet cape",
   short: "crimson velvet cape",
   long: "This short cape is cut from deep crimson velvet, its nap catching the"
-        " light with a soft sheen wherever it falls. It drapes just past the"
-        " shoulders and is lined with black silk, the two fabrics meeting in a"
-        " neat rolled hem. A pair of braided gold cords fasten it at the"
-        " throat, finished with small tasselled ends that rest against the"
-        " collarbone.",
+        "light with a soft sheen wherever it falls. It drapes just past the"
+        "shoulders and is lined with black silk, the two fabrics meeting in a"
+        "neat rolled hem. A pair of braided gold cords fasten it at the"
+        "throat, finished with small tasselled ends that rest against the"
+        "collarbone.",
   mass: 40,
   value: 45,
   slot: "back",

--- a/obj/clothing/feet/black_leather_shoes.lpml
+++ b/obj/clothing/feet/black_leather_shoes.lpml
@@ -6,12 +6,12 @@
   name: "black leather shoes",
   short: "black leather shoes",
   long: "These shoes are made from premium, black leather that has been"
-        " polished to a high shine. They are styled in a classic,"
-        " understated design with a rounded toe and a low heel. The shoes"
-        " fasten with thin, black laces that thread through small, silver"
-        " eyelets, providing a secure and adjustable fit. The soles are"
-        " thick and sturdy, suggesting durability and comfort for prolonged"
-        " wear.",
+        "polished to a high shine. They are styled in a classic,"
+        "understated design with a rounded toe and a low heel. The shoes"
+        "fasten with thin, black laces that thread through small, silver"
+        "eyelets, providing a secure and adjustable fit. The soles are"
+        "thick and sturdy, suggesting durability and comfort for prolonged"
+        "wear.",
   mass: 15,
   value: 16,
   slot: "feet",

--- a/obj/clothing/legs/tan_leather_breeches.lpml
+++ b/obj/clothing/legs/tan_leather_breeches.lpml
@@ -6,11 +6,11 @@
   name: "tan leather breeches",
   short: "tan leather breeches",
   long: "Crafted from supple, tan leather, these breeches fit snugly around"
-        " the legs, allowing for ease of movement. The leather has been"
-        " treated to a soft, almost buttery finish, and the seams are"
-        " reinforced with precise, durable stitching. The breeches feature"
-        " a high waist secured by a simple leather belt, and they taper"
-        " neatly to the ankle.",
+        "the legs, allowing for ease of movement. The leather has been"
+        "treated to a soft, almost buttery finish, and the seams are"
+        "reinforced with precise, durable stitching. The breeches feature"
+        "a high waist secured by a simple leather belt, and they taper"
+        "neatly to the ankle.",
   mass: 100,
   value: 20,
   slot: "legs",

--- a/obj/clothing/torso/cream-coloured_linen_tunic.lpml
+++ b/obj/clothing/torso/cream-coloured_linen_tunic.lpml
@@ -6,11 +6,11 @@
   name: "cream-coloured linen tunic",
   short: "cream-coloured linen tunic",
   long: "This tunic is made from a high-quality, cream-coloured linen that"
-        " hangs loosely over the torso, falling to mid-thigh. Its sleeves"
-        " are long and slightly billowy, cinching at the wrists. The"
-        " neckline is modest, with a simple slit down the front that is"
-        " fastened with small, wooden toggles. The fabric has a natural,"
-        " subtle texture, hinting at its fine weave.",
+        "hangs loosely over the torso, falling to mid-thigh. Its sleeves"
+        "are long and slightly billowy, cinching at the wrists. The"
+        "neckline is modest, with a simple slit down the front that is"
+        "fastened with small, wooden toggles. The fabric has a natural,"
+        "subtle texture, hinting at its fine weave.",
   mass: 50,
   value: 18,
   slot: "torso",

--- a/obj/food/bat_meat.lpml
+++ b/obj/food/bat_meat.lpml
@@ -4,7 +4,7 @@
   adj: ["bat","raw","stringy"],
   name: "bat meat",
   short: "a chunk of bat meat",
-  long: "This is a stringy chunk of meat carved from a cave bat. It needs to "
+  long: "This is a stringy chunk of meat carved from a cave bat. It needs to"
         "be cooked before eating.",
   mass: 10,
   value: 15,

--- a/obj/food/cat_meat.lpml
+++ b/obj/food/cat_meat.lpml
@@ -4,7 +4,7 @@
   adj: ["cat", "raw", "fresh"],
   name: "cat meat",
   short: "a chunk of cat meat",
-  long: "This is a fresh chunk of cat meat. It needs to be cooked before "
+  long: "This is a fresh chunk of cat meat. It needs to be cooked before"
         "eating.",
   mass: 25,
   value: 30,

--- a/obj/food/mole_meat.lpml
+++ b/obj/food/mole_meat.lpml
@@ -4,7 +4,7 @@
   adj: ["mole","raw","gamey"],
   name: "mole meat",
   short: "a chunk of mole meat",
-  long: "This is a gamey chunk of meat carved from a tunnel mole. It needs to "
+  long: "This is a gamey chunk of meat carved from a tunnel mole. It needs to"
         "be cooked before eating.",
   mass: 20,
   value: 25,

--- a/obj/food/raw_pork.lpml
+++ b/obj/food/raw_pork.lpml
@@ -4,7 +4,7 @@
   adj: ["raw", "fresh"],
   name: "raw pork",
   short: "a chunk of raw pork",
-  long: "This is a fresh chunk of raw pork from a wild boar. It needs to be "
+  long: "This is a fresh chunk of raw pork from a wild boar. It needs to be"
         "cooked before eating.",
   mass: 30,
   value: 40,

--- a/obj/loot/bat_fang.lpml
+++ b/obj/loot/bat_fang.lpml
@@ -4,7 +4,7 @@
   adj: ["bat","tiny","needle-like"],
   name: "bat fang",
   short: "a tiny bat fang",
-  long: "This is a needle-like fang plucked from the maw of a cave bat. It "
+  long: "This is a needle-like fang plucked from the maw of a cave bat. It"
         "could be useful for crafting small piercing instruments.",
   mass: 1,
   material: ["bone"],

--- a/obj/loot/bat_wing.lpml
+++ b/obj/loot/bat_wing.lpml
@@ -4,7 +4,7 @@
   adj: ["bat","leathery","membranous"],
   name: "bat wing",
   short: "a leathery bat wing",
-  long: "This is a thin, leathery wing torn from a cave bat. It is prized by "
+  long: "This is a thin, leathery wing torn from a cave bat. It is prized by"
         "alchemists for use in flight potions.",
   mass: 2,
   material: ["leather"],

--- a/obj/loot/blighted_hide.lpml
+++ b/obj/loot/blighted_hide.lpml
@@ -4,8 +4,8 @@
   adj: ["blighted","matted","mangy"],
   name: "blighted hide",
   short: "a matted, blighted hide",
-  long: "The hide of a bramble cur, matted and half gone to something like "
-        "bark. Thorns have grown clean through it in places. A tanner of "
+  long: "The hide of a bramble cur, matted and half gone to something like"
+        "bark. Thorns have grown clean through it in places. A tanner of"
         "strong stomach might still make something of it, blight and all.",
   mass: 40,
   material: ["leather"],

--- a/obj/loot/boar_skin.lpml
+++ b/obj/loot/boar_skin.lpml
@@ -4,7 +4,7 @@
   adj: ["boar","rough"],
   name: "boar skin",
   short: "a piece of boar skin",
-  long: "This is a rough piece of skin from a wild boar. It could be useful "
+  long: "This is a rough piece of skin from a wild boar. It could be useful"
         "for crafting.",
   mass: 50,
   material: ["leather"],

--- a/obj/loot/boar_tusk.lpml
+++ b/obj/loot/boar_tusk.lpml
@@ -4,7 +4,7 @@
   adj: ["boar","sharp"],
   name: "boar tusk",
   short: "a sharp boar tusk",
-  long: "This is a curved, sharp tusk from a wild boar. It could be used for "
+  long: "This is a curved, sharp tusk from a wild boar. It could be used for"
         "crafting or as a primitive weapon.",
   mass: 20,
   material: ["bone"],

--- a/obj/loot/cat_fur.lpml
+++ b/obj/loot/cat_fur.lpml
@@ -4,7 +4,7 @@
   adj: ["cat","soft"],
   name: "cat fur",
   short: "a piece of cat fur",
-  long: "This is a soft piece of fur from a wild cat. It could be useful for "
+  long: "This is a soft piece of fur from a wild cat. It could be useful for"
         "crafting.",
   mass: 20,
   material: [

--- a/obj/loot/centipede_chitin.lpml
+++ b/obj/loot/centipede_chitin.lpml
@@ -4,7 +4,7 @@
   adj: ["centipede","glossy","armoured"],
   name: "centipede chitin",
   short: "a segment of centipede chitin",
-  long: "This is a glossy, armoured segment of chitin pried from the carapace "
+  long: "This is a glossy, armoured segment of chitin pried from the carapace"
         "of a giant centipede. It would make a fine plating for crafting.",
   mass: 6,
   material: ["chitin"],

--- a/obj/loot/centipede_leg.lpml
+++ b/obj/loot/centipede_leg.lpml
@@ -4,7 +4,7 @@
   adj: ["centipede","spindly","jointed"],
   name: "centipede leg",
   short: "a spindly centipede leg",
-  long: "This is a long, spindly leg snapped off a giant centipede. Anglers "
+  long: "This is a long, spindly leg snapped off a giant centipede. Anglers"
         "swear by them as bait for cave fish.",
   mass: 1,
   material: ["chitin"],

--- a/obj/loot/centipede_mandible.lpml
+++ b/obj/loot/centipede_mandible.lpml
@@ -4,7 +4,7 @@
   adj: ["centipede","curved","venomous"],
   name: "centipede mandible",
   short: "a curved centipede mandible",
-  long: "This is a wickedly curved mandible plucked from a giant centipede. "
+  long: "This is a wickedly curved mandible plucked from a giant centipede."
         "Beads of dark venom still cling to its tip.",
   mass: 5,
   material: ["chitin"],

--- a/obj/loot/crow_feather.lpml
+++ b/obj/loot/crow_feather.lpml
@@ -4,8 +4,8 @@
   adj: ["crow","black","oily","ragged"],
   name: "crow feather",
   short: "an oily black crow feather",
-  long: "A long flight-feather from a carrion crow, black as wet slate and "
-        "faintly iridescent where the light catches it. The quill is sound "
+  long: "A long flight-feather from a carrion crow, black as wet slate and"
+        "faintly iridescent where the light catches it. The quill is sound"
         "and would take an ink well enough.",
   mass: 1,
   material: ["feather"],

--- a/obj/loot/cur_fang.lpml
+++ b/obj/loot/cur_fang.lpml
@@ -4,8 +4,8 @@
   adj: ["yellowed","curved","cur"],
   name: "cur fang",
   short: "a yellowed cur fang",
-  long: "A curved fang the length of a finger, prised from the jaw of a "
-        "bramble cur. It is yellowed and cracked, and a faint green stain "
+  long: "A curved fang the length of a finger, prised from the jaw of a"
+        "bramble cur. It is yellowed and cracked, and a faint green stain"
         "lingers in the root where the blight got into the bone.",
   mass: 3,
   material: ["bone"],

--- a/obj/loot/grasshopper_leg.lpml
+++ b/obj/loot/grasshopper_leg.lpml
@@ -4,7 +4,7 @@
   adj: ["grasshopper","spindly"],
   name: "grasshopper leg",
   short: "a grasshopper's leg",
-  long: "This is a long, spindly leg from a grasshopper. It might be useful "
+  long: "This is a long, spindly leg from a grasshopper. It might be useful"
         "as bait for fishing.",
   mass: 1,
   material: ["insect"],

--- a/obj/loot/insect_wing.lpml
+++ b/obj/loot/insect_wing.lpml
@@ -4,7 +4,7 @@
   adj: ["insect","delicate"],
   name: "insect wing",
   short: "a delicate insect wing",
-  long: "This is a thin, transparent wing from an insect. It's very fragile "
+  long: "This is a thin, transparent wing from an insect. It's very fragile"
         "but might be useful in certain alchemical recipes.",
   mass: 1,
   material: ["insect"],

--- a/obj/loot/mole_claw.lpml
+++ b/obj/loot/mole_claw.lpml
@@ -4,7 +4,7 @@
   adj: ["mole","broad","shovel-like"],
   name: "mole claw",
   short: "a broad mole claw",
-  long: "This is a thick, shovel-like claw torn from a tunnel mole. It is "
+  long: "This is a thick, shovel-like claw torn from a tunnel mole. It is"
         "tough enough to gouge through packed earth.",
   mass: 8,
   material: ["bone"],

--- a/obj/loot/mole_pelt.lpml
+++ b/obj/loot/mole_pelt.lpml
@@ -4,7 +4,7 @@
   adj: ["mole","velvety","dark"],
   name: "mole pelt",
   short: "a velvety mole pelt",
-  long: "This is a soft, velvety pelt taken from a tunnel mole. Its dark fur "
+  long: "This is a soft, velvety pelt taken from a tunnel mole. Its dark fur"
         "is highly prized for lining warm garments.",
   mass: 15,
   material: ["fur"],

--- a/obj/loot/rabbit_fur.lpml
+++ b/obj/loot/rabbit_fur.lpml
@@ -9,7 +9,7 @@
   name: "rabbit fur",
   short: "a patch of soft rabbit fur",
   long:
-    "This is a small patch of soft, fluffy fur from a rabbit. It could be "
+    "This is a small patch of soft, fluffy fur from a rabbit. It could be"
     "used for crafting warm clothing.",
   mass: 10,
   material: [

--- a/obj/loot/rat_fur.lpml
+++ b/obj/loot/rat_fur.lpml
@@ -4,7 +4,7 @@
   adj: ["waste","scrappy"],
   name: "rat fur",
   short: "a piece of rat fur",
-  long: "This is a scrappy piece of fur from a waste rat. It could be useful "
+  long: "This is a scrappy piece of fur from a waste rat. It could be useful"
         "for crafting.",
   mass: 10,
   material: ["fur"],

--- a/obj/loot/rat_tail.lpml
+++ b/obj/loot/rat_tail.lpml
@@ -4,7 +4,7 @@
   adj: ["rat","pink","slimy"],
   name: "rat tail",
   short: "a slimy rat tail",
-  long: "This is a long, pink, slimy tail severed from a cave rat. Some "
+  long: "This is a long, pink, slimy tail severed from a cave rat. Some"
         "alchemists pay a small bounty for them.",
   mass: 5,
   material: ["flesh"],

--- a/tests/adm/simul_efun/__fixtures/bat.lpml
+++ b/tests/adm/simul_efun/__fixtures/bat.lpml
@@ -2,7 +2,7 @@
   type: "mammal",
   name: "cave bat",
   short: "cave bat",
-  long: "A leathery cave bat clings to the ceiling, its small black eyes "
+  long: "A leathery cave bat clings to the ceiling, its small black eyes"
         "watching for intruders. Its tiny fangs glisten in the gloom.",
   id: [
     "cave bat",


### PR DESCRIPTION
Fixes double-space defect in LPML string concatenation across all mob, loot, armour, clothing, and food data files, and documents the rule that caused it.

The LPML parser supplies exactly one space when joining adjacent quoted string fragments. Any trailing space before a closing quote, or leading space after an opening quote, produces a double space in the decoded value. All affected `.lpml` files have been corrected by removing the padding character at fragment boundaries and letting the parser supply the separator.

The LPML skill document is updated to explain this behaviour explicitly, with before/after examples showing the wrong and right patterns. It also notes that a trailing space on the final fragment leaves a stray space at the end of the value, and calls this out as the single most common defect in hand-written LPML.

Additional documentation improvements in the same skill file:

- Folding rules for newlines *within* a single quoted string are now listed explicitly (trim, join with space, blank line becomes `\n`, result is trimmed).
- `null` and `undefined` are documented as valid LPML literals that both decode to LPC `undefined`, with a note to test with `undefinedp()` rather than `== 0`, and that `undefined` round-trips back out as `null` on encode.
- File include path resolution is clarified: relative paths resolve against the including file's directory, mixed traversal is not resolved, and absolute paths are used as-is.
- `undefined` is added to the JSON5 comparison table.

The NPC creation skill corrects `setLevel` to `set_level` throughout, and updates the description of what `adjust_skills_by_npc_level` actually does: it seeds stored skill values to a level-scaled multiple rather than wiping them to near-zero. The damage fallback formula and skill query behaviour are corrected to match the actual implementation.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects LPML string concatenation guidance and updates affected game data.

- Removes fragment-edge padding from mob, item, loot, food, armour, and clothing descriptions.
- Updates LPML documentation for concatenation, folding, literals, and includes.
- Corrects NPC creation documentation for `set_level`, skills, and unarmed damage.
</details>

<sub>Reviews (3): Last reviewed commit: ["fixing lpml"](https://github.com/gesslar/oxidus-mudlib/commit/df59921fa9fa648a86d4936685ee98eb1669a836) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45494002)</sub>

<!-- /greptile_comment -->