### PR TITLE
Skip destructed objects in command handler loop

### DIFF
--- a/std/object/command.lpc
+++ b/std/object/command.lpc
@@ -454,6 +454,12 @@ public int command_hook(string arg) {
   obs += ({ this_object() });
 
   foreach(ob in obs) {
+    // An earlier handler may have destructed a later candidate — lazy resets
+    // fire on the first call_other into a stale object, and reset functions
+    // are free to clean_remove() anything in this snapshot.
+    if(!objectp(ob))
+      continue;
+
     result = ob->evaluate_command(this_object(), verb, arg);
     result = evaluate_result(result);
 


### PR DESCRIPTION
Adds a guard in `command_hook` to skip any command handler candidates that have been destructed before they are evaluated. Since earlier handlers in the snapshot can trigger lazy resets or `clean_remove()` calls that destroy later candidates, iterating without this check would attempt to call into a stale object. The fix checks `objectp(ob)` before calling `evaluate_command`, continuing to the next candidate if the object is no longer valid.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents command dispatch from calling destructed handler objects.

- Validates each command candidate before evaluation.
- Skips candidates removed by an earlier handler in the same pass.
</details>

<sub>Reviews (3): Last reviewed commit: ["fixing command"](https://github.com/gesslar/oxidus-mudlib/commit/ce2f1e10d3ae5a65e75f086c288b8e565b9179f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45494004)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->