### PR TITLE
Add `preferences` help file documenting player, developer, and admin settings

### DIFF
--- a/doc/help/general/preferences.help
+++ b/doc/help/general/preferences.help
@@ -1,0 +1,127 @@
+---
+{
+  title: "Preferences"
+}
+---
+Preferences are per-character settings, managed with the {{ul1}}set{{ul0}} command
+and saved with your character.
+
+    set                        list your current preferences
+    set <preference> <value>   set a preference
+    set <preference>           clear a preference
+    set <name>_colour prompt   pick a colour interactively
+
+Any preference whose name ends in {{bl1}}_colour{{res}} accepts the value
+{{bl1}}prompt{{res}} to choose from the available colours instead of typing a code.
+
+See also: set, colour
+
+{{re1}}Player Preferences{{res}}
+
+Setting: colour
+Default: on (off for ghosts)
+ Effect: Sends colour to your terminal. Any value other than {{bl1}}on{{res}} strips
+         colour from everything you receive.
+
+Setting: prompt
+Default: >
+ Effect: The text written before each of your commands. A space is added after
+         it.
+
+Setting: morelines
+Default: 40
+ Effect: Number of lines shown per page before the pager pauses. Also governs
+         how many lines the {{bl1}}log{{res}} command tails.
+
+Setting: page_display
+Default: line
+ Effect: How the pager reports your position: {{bl1}}line{{res}} for line numbers,
+         anything else configured for a percentage readout.
+
+Setting: unicode
+Default: none (off)
+ Effect: Set to {{bl1}}on{{res}} to receive Unicode characters where available.
+         Always treated as off while a screenreader is active.
+
+Setting: screenreader
+Default: none (off)
+ Effect: Set to {{bl1}}on{{res}} for screenreader mode, which suppresses Unicode and
+         message decoration. Auto-detected clients get this without setting it.
+
+Setting: feedback
+Default: on
+ Effect: Whether system messages (ok, error, warn, info) carry their decoration
+         symbol. Set to {{bl1}}off{{res}} for plain text.
+
+Setting: gmcp
+Default: none (enabled)
+ Effect: GMCP data is sent to clients that negotiate it. Set to {{bl1}}off{{res}} to
+         stop sending it.
+
+Setting: keepalive
+Default: none (off)
+ Effect: Set to any value other than {{bl1}}off{{res}} to send periodic keepalive
+         packets once you have been idle for five minutes.
+
+Setting: combat_hit_colour
+Default: none
+ Effect: Colour applied to combat messages where you land a hit. Unset leaves
+         those messages uncoloured.
+
+Setting: combat_miss_colour
+Default: none
+ Effect: Colour applied to combat messages where you miss. Unset leaves those
+         messages uncoloured.
+
+{{re1}}Developer Preferences{{res}}
+
+These take effect only for characters holding the developer role.
+
+Setting: look_filename
+Default: none (off)
+ Effect: Set to {{bl1}}on{{res}} to show the source filename above the description
+         of rooms, objects, and livings when you look.
+
+Setting: error_output
+Default: none (enabled)
+ Effect: Compile and runtime errors attributed to you are echoed to your screen
+         as well as written to your home log. Set to {{bl1}}off{{res}} to silence them.
+
+Setting: log_level
+Default: 0
+ Effect: Verbosity of body event logging, {{bl1}}1{{res}} (least) to {{bl1}}4{{res}} (most). {{bl1}}0{{res}} or unset
+         disables it; higher levels are noisy.
+
+Setting: ls_directory
+Default: 5087b4
+ Effect: Colour used for directories in {{bl1}}ls{{res}} listings.
+
+Setting: ls_source
+Default: b0cabf
+ Effect: Colour used for unloaded source files in {{bl1}}ls{{res}} listings.
+
+Setting: ls_loaded
+Default: 04e5ad
+ Effect: Colour used for source files that are currently loaded.
+
+Setting: ls_header
+Default: a2c5b2
+ Effect: Colour used for header files.
+
+Setting: ls_save
+Default: c5baa5
+ Effect: Colour used for save files.
+
+Setting: ls_data
+Default: 9e93d4
+ Effect: Colour used for data files.
+
+Setting: ls_other
+Default: bbb
+ Effect: Colour used for anything not matching the categories above.
+
+{{re1}}Administrator Preferences{{res}}
+
+There are currently no preferences specific to the administrator role.
+Administrators use the player preferences above, plus the developer preferences
+if they also hold the developer role.


### PR DESCRIPTION
Adds a `preferences.help` file documenting all available per-character settings managed through the `set` command. The file covers:

- **Player preferences** — `colour`, `prompt`, `morelines`, `page_display`, `unicode`, `screenreader`, `feedback`, `gmcp`, `keepalive`, `combat_hit_colour`, and `combat_miss_colour`, including their defaults and effects.
- **Developer preferences** — `look_filename`, `error_output`, `log_level`, and the full set of `ls_*` colour settings used in directory listings.
- **Administrator preferences** — notes that no role-specific preferences exist beyond those inherited from the player and developer roles.

Also documents the `prompt` shorthand for interactively picking colours on any preference whose name ends in `_colour`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a help page for character preferences.

- Documents player, developer, and administrator settings.
- Covers defaults and effects for supported preferences.
- Documents interactive colour selection through `set`.
</details>

<sub>Reviews (5): Last reviewed commit: ["new help file for preferences"](https://github.com/gesslar/oxidus-mudlib/commit/5311d9d57e7eb295d3a84a7322484d7d4130e8c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45494005)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->