### PR TITLE
Add weighted forest spawn pool with new mobs and loot

### DIFF
--- a/d/forest/forest_base.lpc
+++ b/d/forest/forest_base.lpc
@@ -13,7 +13,6 @@ inherit STD_ROOM;
 
 void repopulate();
 
-private nosave string *mob_files = ({});
 /** @type {STD_NPC*} */ private nosave object *__mobs = ({});
 private nosave float spawn_chance = 10.0;
 
@@ -30,31 +29,32 @@ void virtual_setup(mixed _args...) {
   __DIR__ "forest_daemon"->setup_long(this_object());
 
   add_reset((: repopulate :));
-
-  mob_files = ({
-    "/mob/deer",
-    "/mob/doe",
-    "/mob/giant_red_squirrel",
-    "/mob/crimson_fox",
-    "/mob/monstrous_wasp",
-  });
 }
 
 void repopulate() {
   /** @type {STD_NPC} */ object mob;
-  string file;
 
   __mobs -= ({ 0 });
+
   foreach(mob in __mobs) {
     if(objectp(mob)) {
       mob->simple_action("$N $vscamper away into the forest.");
-      mob->remove();
+      mob->clean_remove();
     }
   }
 
   if(random_float(100.0) < spawn_chance) {
-    file = element_of(mob_files);
-    __mobs += ({ add_inventory(file) });
-    __mobs->simple_action("$N $vappear from the undergrowth.");
+    mapping mob_data = element_of_weighted(
+      __DIR__ "forest_daemon"->query_mob_files()
+    );
+    string file = mob_data["path"];
+    int level = random_clamp(mob_data["level"][0], mob_data["level"][1]);
+
+    mob = add_inventory(file);
+    mob->set_level(level);
+
+    __mobs += ({ mob });
+
+    mob->simple_action("$N $vemerge from the undergrowth.");
   }
 }

--- a/d/forest/forest_daemon.lpc
+++ b/d/forest/forest_daemon.lpc
@@ -20,6 +20,7 @@ inherit STD_VIRTUAL_MAP;
 // Forward declarations
 private void setup_forest_shorts();
 private void setup_forest_longs();
+private void load_mobs();
 
 private nosave string *forest_shorts;
 private nosave string *forest_longs;
@@ -28,10 +29,20 @@ private nosave string forest_map_file;
 
 private nosave int rot = 0;
 
+/**
+ * Weighted spawn pool for forest mobs, keyed by a mapping containing
+ * the mob path and level range, with the value being the relative
+ * spawn weight.
+ *
+ * @type {([ ([ string: mixed ]): int ])}
+ */
+private nosave mapping mob_files = ([]);
+
 void setup() {
   apply_map_file(__DIR__ "forest_map.txt");
   setup_forest_shorts();
   setup_forest_longs();
+  load_mobs();
 }
 
 /**
@@ -183,4 +194,35 @@ public void setup_exits(object room) {
   }
 
   room->set_exits(exits);
+}
+
+/**
+ * Loads the forest spawn pool from spawn.lpml into mob_files. Each
+ * entry is keyed by a mapping containing the mob's file path and
+ * level range, with the LPML weight as the value.
+ */
+private void load_mobs() {
+  mapping spawn = load_lpml(__DIR__ "spawn.lpml");
+
+  mob_files = ([]);
+
+  each(spawn, function(mapping mob) {
+    mapping mob_data = ([
+        "path": mob["path"],
+        "level": mob["level"]
+      ]);
+
+    mob_files[mob_data] = mob["weight"];
+  });
+}
+
+/**
+ * Returns the loaded spawn pool for forest rooms to use when
+ * deciding which mob to spawn.
+ *
+ * @returns {([ ([ string: mixed ]): int ])} The weighted spawn
+ *                                           pool mapping.
+ */
+public mapping query_mob_files() {
+  return mob_files;
 }

--- a/d/forest/spawn.lpml
+++ b/d/forest/spawn.lpml
@@ -1,0 +1,31 @@
+[
+  {
+    path: "mob/giant_red_squirrel",
+    level: [5, 7],
+    weight: 5,
+  },
+
+  {
+    path: "mob/crimson_fox",
+    level: [5, 8],
+    weight: 4,
+  },
+
+  {
+    path: "mob/monstrous_wasp",
+    level: [6, 8],
+    weight: 4,
+  },
+
+  {
+    path: "mob/forest_stag",
+    level: [7, 9],
+    weight: 3,
+  },
+
+  {
+    path: "mob/shadow_wolf",
+    level: [8, 10],
+    weight: 2,
+  },
+]

--- a/d/mobs/crimson_fox.lpml
+++ b/d/mobs/crimson_fox.lpml
@@ -1,0 +1,39 @@
+// d/mobs/crimson_fox.lpml
+// A bold red predator that dens among the shadowed roots.
+
+{
+  type: "mammal",
+  name: "crimson fox",
+  short: "a crimson fox",
+  long: "A lean fox the deep red of old blood, low to the ground and moving"
+        "without a sound between the roots. Its ears are pricked and its"
+        "amber eyes hold yours with a cool, calculating patience. It is"
+        "bigger than a fox has any business being, and it has clearly"
+        "decided you are worth the trouble.",
+  id: [
+    "crimson fox",
+    "fox"
+  ],
+  adj: [
+    "crimson",
+    "red",
+    "lean"
+  ],
+  weapon name: "fangs",
+  weapon type: "piercing",
+  level: [5, 8],
+  gender: [
+    "male",
+    "female"
+  ],
+  race: "fox",
+  loot: [
+    ["/obj/loot/fox_pelt.loot", 55.0],
+    ["/obj/loot/fox_fang.loot", 40.0],
+  ],
+  loot chance: 60.0,
+  coins: {
+    copper: [3, 90.0],
+    silver: [1, 35.0],
+  },
+}

--- a/d/mobs/forest_stag.lpml
+++ b/d/mobs/forest_stag.lpml
@@ -1,0 +1,38 @@
+// d/mobs/forest_stag.lpml
+// A great territorial stag that will not yield the trail.
+
+{
+  type: "mammal",
+  name: "forest stag",
+  short: "a forest stag",
+  long: "A great stag stands square across the trail, dappled brown and"
+        "heavy through the shoulders, its breath steaming in the cool of"
+        "the shade. A broad rack of antlers crowns its head, worn pale at"
+        "the points from rubbing. It lowers that rack toward you and stamps"
+        "once, and it does not mean to give ground.",
+  id: [
+    "forest stag",
+    "stag",
+    "deer"
+  ],
+  adj: [
+    "forest",
+    "great",
+    "dappled"
+  ],
+  weapon name: "antlers",
+  weapon type: "piercing",
+  level: [7, 9],
+  gender: "male",
+  race: "deer",
+  loot: [
+    ["/obj/loot/stag_antler.loot", 50.0],
+    ["/obj/loot/deer_hide.loot", 60.0],
+    "/obj/food/venison.food",
+  ],
+  loot chance: 70.0,
+  coins: {
+    copper: [3, 100.0],
+    silver: [2, 50.0],
+  },
+}

--- a/d/mobs/giant_red_squirrel.lpml
+++ b/d/mobs/giant_red_squirrel.lpml
@@ -1,0 +1,40 @@
+// d/mobs/giant_red_squirrel.lpml
+// An oversized, ill-tempered tree-rat of the Shadowy Forest.
+
+{
+  type: "rodent",
+  name: "giant red squirrel",
+  short: "a giant red squirrel",
+  long: "A red squirrel grown far past any natural size, near as big as a"
+        "dog, clinging head-down to a trunk and watching you with beady"
+        "black eyes. Its russet fur is bristled up along its spine and its"
+        "chisel teeth are bared. It chatters at you, a harsh scolding"
+        "sound, and does not look inclined to flee.",
+  id: [
+    "giant red squirrel",
+    "red squirrel",
+    "squirrel"
+  ],
+  adj: [
+    "giant",
+    "red",
+    "oversized"
+  ],
+  weapon name: "teeth",
+  weapon type: "piercing",
+  level: [5, 7],
+  gender: [
+    "male",
+    "female"
+  ],
+  race: "squirrel",
+  loot: [
+    "/obj/loot/squirrel_tail.loot",
+    ["/obj/loot/squirrel_pelt.loot", 45.0],
+  ],
+  loot chance: 65.0,
+  coins: {
+    copper: [2, 90.0],
+    silver: [1, 25.0],
+  },
+}

--- a/d/mobs/monstrous_wasp.lpml
+++ b/d/mobs/monstrous_wasp.lpml
@@ -1,0 +1,39 @@
+// d/mobs/monstrous_wasp.lpml
+// A wasp swollen to nightmare size in the forest gloom.
+
+{
+  type: "insect",
+  name: "monstrous wasp",
+  short: "a monstrous wasp",
+  long: "A wasp the size of a cat hangs droning on the air, its striped"
+        "abdomen curling and uncurling around a barbed stinger that weeps a"
+        "bead of venom. Its wings are a blur and its faceted eyes catch"
+        "what little light filters down through the canopy. The drone of it"
+        "sets your teeth on edge.",
+  id: [
+    "monstrous wasp",
+    "wasp"
+  ],
+  adj: [
+    "monstrous",
+    "giant",
+    "striped"
+  ],
+  weapon name: "stinger",
+  weapon type: "piercing",
+  level: [6, 8],
+  gender: [
+    "male",
+    "female"
+  ],
+  race: "insect",
+  loot: [
+    ["/obj/loot/wasp_stinger.loot", 50.0],
+    "/obj/loot/insect_wing.loot",
+  ],
+  loot chance: 60.0,
+  coins: {
+    copper: [2, 85.0],
+    silver: [1, 30.0],
+  },
+}

--- a/d/mobs/shadow_wolf.lpml
+++ b/d/mobs/shadow_wolf.lpml
@@ -1,0 +1,42 @@
+// d/mobs/shadow_wolf.lpml
+// The apex hunter of the Shadowy Forest -- rare, and never met alone by
+// choice.
+
+{
+  type: "mammal",
+  name: "shadow wolf",
+  short: "a shadow wolf",
+  long: "A wolf of unusual size, its coat so black that in the gloom it"
+        "reads as a wolf-shaped absence more than a beast. Only the pale"
+        "gleam of its eyes and the wet shine of its bared fangs give it"
+        "away. It pads forward on silent paws, hackles raised, and a low"
+        "growl rolls out of it that you feel in your chest before you hear"
+        "it.",
+  id: [
+    "shadow wolf",
+    "wolf"
+  ],
+  adj: [
+    "shadow",
+    "black",
+    "great"
+  ],
+  weapon name: "fangs",
+  weapon type: "piercing",
+  level: [8, 10],
+  gender: [
+    "male",
+    "female"
+  ],
+  race: "wolf",
+  loot: [
+    ["/obj/loot/shadow_pelt.loot", 45.0],
+    ["/obj/loot/wolf_fang.loot", 40.0],
+  ],
+  loot chance: 70.0,
+  coins: {
+    copper: [4, 100.0],
+    silver: [2, 60.0],
+    gold: [1, 20.0],
+  },
+}

--- a/obj/food/venison.lpml
+++ b/obj/food/venison.lpml
@@ -1,0 +1,18 @@
+{
+  id: ["venison"],
+  additional ids: ["meat","food"],
+  adj: ["deer","raw","red"],
+  name: "raw venison",
+  short: "a cut of raw venison",
+  long: "A dark red cut of venison carved from a forest stag. It is lean and"
+        "gamey, and wants a fire and a spit before it will make much of a"
+        "meal.",
+  mass: 25,
+  value: 35,
+  uses: 1,
+  properties: {
+    autovalue: true,
+    raw: true,
+  },
+  healing: 12,
+}

--- a/obj/loot/deer_hide.lpml
+++ b/obj/loot/deer_hide.lpml
@@ -1,0 +1,16 @@
+{
+  id: ["hide"],
+  additional ids: ["skin","pelt"],
+  adj: ["deer","dappled","supple"],
+  name: "deer hide",
+  short: "a supple deer hide",
+  long: "The hide of a forest stag, dappled brown across the back and paling"
+        "to cream beneath. It is broad and supple, and a tanner would count"
+        "it a fine day's find, worth good leather once it has been worked.",
+  mass: 45,
+  material: ["leather"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/fox_fang.lpml
+++ b/obj/loot/fox_fang.lpml
@@ -1,0 +1,16 @@
+{
+  id: ["fang"],
+  additional ids: ["tooth","canine"],
+  adj: ["fox","slender","white"],
+  name: "fox fang",
+  short: "a slender fox fang",
+  long: "A slender white fang prised from the jaw of a crimson fox. It is"
+        "needle-sharp and no longer than a thumbnail, the kind of small"
+        "trophy a charm-maker might drill and string.",
+  mass: 1,
+  material: ["bone"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/fox_pelt.lpml
+++ b/obj/loot/fox_pelt.lpml
@@ -1,0 +1,17 @@
+{
+  id: ["pelt"],
+  additional ids: ["hide","skin","fur"],
+  adj: ["fox","crimson","russet"],
+  name: "crimson fox pelt",
+  short: "a crimson fox pelt",
+  long: "The pelt of a crimson fox, its fur a startling deep red that seems"
+        "to hold the last of the daylight even here beneath the shadowed"
+        "boughs. The white of the throat and belly is unmarked. A fine"
+        "prize, and worth good coin to the right tailor.",
+  mass: 12,
+  material: ["fur"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/shadow_pelt.lpml
+++ b/obj/loot/shadow_pelt.lpml
@@ -1,0 +1,17 @@
+{
+  id: ["pelt"],
+  additional ids: ["hide","skin","fur"],
+  adj: ["wolf","shadow","black"],
+  name: "shadow wolf pelt",
+  short: "a black shadow wolf pelt",
+  long: "The great pelt of a shadow wolf, its fur so deep a black that the"
+        "eye slides off it in poor light. It is thick and cold to the touch,"
+        "and heavier than its size would suggest. Rare, and a furrier would"
+        "pay dearly for the working of it.",
+  mass: 30,
+  material: ["fur"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/squirrel_pelt.lpml
+++ b/obj/loot/squirrel_pelt.lpml
@@ -1,0 +1,17 @@
+{
+  id: ["pelt"],
+  additional ids: ["hide","skin","fur"],
+  adj: ["squirrel","russet","soft"],
+  name: "squirrel pelt",
+  short: "a soft russet squirrel pelt",
+  long: "The pelt of a giant red squirrel, far larger than any common"
+        "tree-rat's and softer than it has any right to be. The russet fur"
+        "is dense and warm, the sort a furrier would gladly work into a"
+        "collar or a lining.",
+  mass: 8,
+  material: ["fur"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/squirrel_tail.lpml
+++ b/obj/loot/squirrel_tail.lpml
@@ -1,0 +1,16 @@
+{
+  id: ["tail"],
+  additional ids: ["brush","bushy tail"],
+  adj: ["squirrel","bushy","red"],
+  name: "squirrel tail",
+  short: "a bushy red squirrel tail",
+  long: "A long, bushy tail taken from a giant red squirrel, the fur a deep"
+        "russet that fades to smoke-grey at the tip. Fletchers prize such"
+        "brushes, and there is enough of it here to trim more than one thing.",
+  mass: 4,
+  material: ["fur"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/stag_antler.lpml
+++ b/obj/loot/stag_antler.lpml
@@ -1,0 +1,17 @@
+{
+  id: ["antler"],
+  additional ids: ["horn","rack"],
+  adj: ["stag","branching","heavy"],
+  name: "stag antler",
+  short: "a heavy branching antler",
+  long: "A heavy antler broken from the rack of a forest stag, pale as old"
+        "bone and branching into a spread of worn points. It has a good"
+        "weight to it, and a carver or a fletcher would find plenty of use"
+        "in so much sound horn.",
+  mass: 15,
+  material: ["bone"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/wasp_stinger.lpml
+++ b/obj/loot/wasp_stinger.lpml
@@ -1,0 +1,17 @@
+{
+  id: ["stinger"],
+  additional ids: ["sting","barb"],
+  adj: ["wasp","barbed","venomous"],
+  name: "wasp stinger",
+  short: "a barbed wasp stinger",
+  long: "A wickedly barbed stinger drawn from the abdomen of a monstrous"
+        "wasp, longer than a finger and still beaded at the tip with a bead"
+        "of drying venom. Handled carefully, an apothecary could render it"
+        "down for any number of unpleasant purposes.",
+  mass: 1,
+  material: ["chitin"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}

--- a/obj/loot/wolf_fang.lpml
+++ b/obj/loot/wolf_fang.lpml
@@ -1,0 +1,17 @@
+{
+  id: ["fang"],
+  additional ids: ["tooth","canine"],
+  adj: ["wolf","curved","long"],
+  name: "wolf fang",
+  short: "a long curved wolf fang",
+  long: "A long, curved fang taken from the jaw of a shadow wolf, ivory"
+        "shading to a smoky grey at the root. It is heavy and sharp, the"
+        "kind of trophy a charm-maker or a boastful hunter is glad to have"
+        "in hand.",
+  mass: 3,
+  material: ["bone"],
+  properties: {
+    autovalue: true,
+    crafting material: true,
+  },
+}


### PR DESCRIPTION
Forest mob spawning has been reworked to use a weighted spawn pool driven by an external `spawn.lpml` configuration file rather than a hardcoded list of mob paths. The forest daemon now loads this file at setup and exposes the pool via `query_mob_files()`, which forest rooms call during repopulation to select a mob using `element_of_weighted`. Spawned mobs now have their level set to a random value within the range defined in the spawn data.

Existing mobs are now removed with `clean_remove()` instead of `remove()`, and the appearance message has been changed from "appear from the undergrowth" to "emerge from the undergrowth."

Two new mobs have been added to the spawn pool — a `forest_stag` (levels 7–9) and a `shadow_wolf` (levels 8–10) — joining the existing squirrel, fox, and wasp. The deer and doe entries have been dropped from the pool. All five mobs have full LPML definitions with loot tables, coin drops, descriptions, and level ranges. Corresponding loot items have been added for each mob: pelts, fangs, a stinger, antlers, a squirrel tail, a deer hide, and a cut of raw venison.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the forest's fixed mob list with a weighted LPML spawn pool.

- Loads forest spawn data from `spawn.lpml`.
- Selects spawn levels from configured ranges.
- Adds forest stag and shadow wolf definitions.
- Adds loot and venison item definitions.
</details>

<sub>Reviews (3): Last reviewed commit: ["adding monsters to the forest"](https://github.com/gesslar/oxidus-mudlib/commit/9b064d2ecbd60cc70dc3debaa32bf3f91590dc91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45494007)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->