### PR TITLE
Comment out unused `priv` variable in help daemon

### DIFF
--- a/adm/daemons/help.lpc
+++ b/adm/daemons/help.lpc
@@ -160,7 +160,7 @@ mapping *query_help(string topic, object who) {
 
     // Includes carry an explicit priv; plain directories fall back to the
     // directory name acting as its own priv.
-    string priv = helps["priv"] ?? cat;
+    // string priv = helps["priv"] ?? cat;
 
     // if(priv == "all" || !includes(groups, priv))
     //   push(ref result, ({ cat, helps[topic] }));


### PR DESCRIPTION
This diff comments out the `priv` variable assignment in the `query_help` function, which appears to be part of an in-progress or temporarily disabled privilege-checking mechanism for help topics. The surrounding code shows that the full privilege filtering logic (the `if` statement below) was already commented out, and this change brings the variable declaration in line with that dormant code to avoid an unused variable.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes an unused local assignment from the help daemon.

- Comments out the unused `priv` assignment in `query_help`.
- Keeps the surrounding disabled privilege-filter code unchanged.
</details>

<sub>Reviews (2): Last reviewed commit: ["commenting out code temporarily"](https://github.com/gesslar/oxidus-mudlib/commit/323dd994c463033a42fd27856b9367ac04284a32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45543292)</sub>

**Context used:**

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))

<!-- /greptile_comment -->