### PR TITLE
Increase arcane discipline skill gain rate from 0.15 to 0.5 across elemental spells

### DIFF
--- a/cmds/spell/embers.lpc
+++ b/cmds/spell/embers.lpc
@@ -58,7 +58,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
           "{{f73}}Glowing embers cling to $t!{{res}}",
           victim
         );
-        tp->use_skill("arcane.discipline.fire", 0.15);
+        tp->use_skill("arcane.discipline.fire", 0.5);
 
         // Recasting reapplies a fresh burn rather than stacking.
         mapping existing = victim->query_curse_object(

--- a/cmds/spell/motes.lpc
+++ b/cmds/spell/motes.lpc
@@ -56,7 +56,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
           victim
         );
         tp->deliver_damage(victim, damage, "light");
-        tp->use_skill("arcane.discipline.light", 0.15);
+        tp->use_skill("arcane.discipline.light", 0.5);
       } else {
         tp->simple_action(
           "The motes of light disperse harmlessly."

--- a/cmds/spell/shard.lpc
+++ b/cmds/spell/shard.lpc
@@ -60,7 +60,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
           victim
         );
         tp->deliver_damage(victim, initial, "cold");
-        tp->use_skill("arcane.discipline.frost", 0.15);
+        tp->use_skill("arcane.discipline.frost", 0.5);
 
         // Shards stack — each caster's shard shatters on its own
         // schedule, so group casts don't trample each other.

--- a/cmds/spell/shock.lpc
+++ b/cmds/spell/shock.lpc
@@ -53,7 +53,7 @@ mixed use(
       victim
     );
     tp->deliver_damage(victim, damage, "lightning");
-    tp->use_skill("arcane.discipline.lightning", 0.15);
+    tp->use_skill("arcane.discipline.lightning", 0.5);
   } else {
     tp->simple_action(
       "The bolt of lightning fizzles harmlessly."

--- a/cmds/spell/wither.lpc
+++ b/cmds/spell/wither.lpc
@@ -57,7 +57,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
           "{{83a}}$N $vreach out with a grasping shadow toward $t!{{res}}",
           victim
         );
-        tp->use_skill("arcane.discipline.shadow", 0.15);
+        tp->use_skill("arcane.discipline.shadow", 0.5);
 
         // Withers stack across casters — each contributes its own
         // -amount to the three defense skills.


### PR DESCRIPTION
Increases the skill advancement rate for elemental discipline spells (fire, light, frost, lightning, and shadow) from 0.15 to 0.5, allowing players to progress in these skills more quickly through normal spell use.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR increases elemental spell skill advancement rates.

- Updates fire, light, frost, lightning, and shadow discipline gains.
- Changes the progress modifier from `0.15` to `0.5` on successful spell use.
</details>

<sub>Reviews (2): Last reviewed commit: ["improving spell improvement chances"](https://github.com/gesslar/oxidus-mudlib/commit/ef92d35b05fac094f80287a59110bce0002fc2d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45543300)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->