### PR TITLE
Prevent repopulation while mobs are in combat

### DIFF
--- a/d/forest/forest_base.lpc
+++ b/d/forest/forest_base.lpc
@@ -36,6 +36,9 @@ void repopulate() {
 
   __mobs -= ({ 0 });
 
+  if(sizeof(filter(__mobs, (: $1->in_combat() :))))
+    return;
+
   foreach(mob in __mobs) {
     if(objectp(mob)) {
       mob->simple_action("$N $vscamper away into the forest.");

--- a/d/tunnels/tunnels_base.lpc
+++ b/d/tunnels/tunnels_base.lpc
@@ -39,6 +39,9 @@ public void repopulate() {
 
   __mobs -= ({ 0 });
 
+  if(sizeof(filter(__mobs, (: $1->in_combat() :))))
+    return;
+
   foreach(mob in __mobs) {
     if(objectp(mob)) {
       mob->simple_action("$N $vscurry away into the darkness.");

--- a/d/village/field/field_base.lpc
+++ b/d/village/field/field_base.lpc
@@ -36,6 +36,9 @@ public void repopulate() {
 
   __mobs -= ({ 0 });
 
+  if(sizeof(filter(__mobs, (: $1->in_combat() :))))
+    return;
+
   foreach(mob in __mobs) {
     if(objectp(mob)) {
       mob->simple_action("$N $vwander off through the grass.");

--- a/d/wastes/wastes_base.lpc
+++ b/d/wastes/wastes_base.lpc
@@ -39,6 +39,9 @@ public void repopulate() {
 
   __mobs -= ({ 0 });
 
+  if(sizeof(filter(__mobs, (: $1->in_combat() :))))
+    return;
+
   foreach(mob in __mobs) {
     if(objectp(mob)) {
       mob->simple_action("$N $vscurry away across the barren wasteland.");


### PR DESCRIPTION
Prevent mobs from being repopulated (and despawning) while any of them are in combat. This ensures that fights are not interrupted by the repopulation timer causing engaged mobs to disappear mid-encounter.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents reset-driven mob removal during combat. The main changes are:

- Adds combat checks before repopulating forest rooms.
- Adds matching checks for tunnels, fields, and wastes rooms.
</details>

<sub>Reviews (2): Last reviewed commit: ["rooms with monsters in combat don&#39;t repo..."](https://github.com/gesslar/oxidus-mudlib/commit/2a9c122b40e2b26771c0f2f622de28aa8681d0d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45543302)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->