### PR TITLE
Remove premature null check in `get_item`

### DIFF
--- a/std/room/items.lpc
+++ b/std/room/items.lpc
@@ -81,9 +81,6 @@ string get_item(string id) {
   mixed item, value;
   string result;
 
-  if(!nullp(item))
-    return 0;
-
   foreach(item, value in __items) {
     if(pointerp(item)) {
       int i;


### PR DESCRIPTION
Removes an incorrect early-return guard in `get_item` that checked `item` before it was assigned, causing the function to always return `0` and never retrieve any items.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the premature guard in room item lookup.

- Allows `get_item` to traverse the room item mapping.
- Preserves the existing item description handling.
</details>

<sub>Reviews (2): Last reviewed commit: ["removing dead code"](https://github.com/gesslar/oxidus-mudlib/commit/d3471a81f36a2202178026e3130b7802827bd90b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45543307)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->