### PR TITLE
Reorder `clamp` arguments to `(val, min, max)`

### DIFF
--- a/adm/include/simul_efun.h
+++ b/adm/include/simul_efun.h
@@ -163,7 +163,7 @@ varargs void tell_them(string str, object *exclude, int message_type);
 // File: number.c
 float percent_of(float a, float b);
 float percent(float a, float b);
-float clamp(float min, float max, float val);
+float clamp(float val, float min, float max);
 int clamped(float val, float min, float max);
 int between(float val, float min, float max);
 varargs float remainder(mixed a, mixed b);

--- a/std/ext/loot.lpc
+++ b/std/ext/loot.lpc
@@ -25,7 +25,7 @@ varargs public void add_loot(mixed item, float chance) {
   if(!floatp(chance))
     return;
 
-  chance = clamp(0.0, 100.0, chance);
+  chance = clamp(chance, 0.0, 100.0);
 
   switch(typeof(item)) {
     case T_STRING :
@@ -62,7 +62,7 @@ varargs public void add_coin(string type, int num, float chance) {
   if(!floatp(chance))
     return;
 
-  chance = clamp(0.0, 100.0, chance);
+  chance = clamp(chance, 0.0, 100.0);
 
   _coin_table += ({ ({ type, num, chance }) });
 }

--- a/std/ext/unicode.lpc
+++ b/std/ext/unicode.lpc
@@ -100,7 +100,7 @@ int default_user_width() {
 private string use_colour(string *cols, int position, int width) {
   int col_index = floor(sizeof(cols) * ((0.0 + position) / (width || 1)));
 
-  col_index = clamp(0, sizeof(cols) - 1, col_index);
+  col_index = clamp(col_index, 0, sizeof(cols) - 1);
 
   return cols[col_index];
 }


### PR DESCRIPTION
The parameter order for `clamp` has been corrected to the more intuitive `(val, min, max)` instead of `(min, max, val)`. All call sites have been updated to match the new signature.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR standardizes `clamp` calls around the `(val, min, max)` order.

- Updates the public simul-efun declaration.
- Reorders loot and coin chance clamping.
- Reorders Unicode colour-index clamping.
</details>

<sub>Reviews (2): Last reviewed commit: ["fixing clamp call sites"](https://github.com/gesslar/oxidus-mudlib/commit/1d6aac6205b7d685a329069cc1271a0477bb47bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45543309)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
</details>

<!-- /greptile_comment -->