### PR TITLE
Add attack speed support to LPML monster setup with crimson fox and monstrous wasp values

### DIFF
--- a/d/mobs/crimson_fox.lpml
+++ b/d/mobs/crimson_fox.lpml
@@ -21,6 +21,7 @@
   ],
   weapon name: "fangs",
   weapon type: "piercing",
+  plus attack speed: 0.25,
   level: [5, 8],
   gender: [
     "male",

--- a/d/mobs/monstrous_wasp.lpml
+++ b/d/mobs/monstrous_wasp.lpml
@@ -21,6 +21,7 @@
   ],
   weapon name: "stinger",
   weapon type: "piercing",
+  plus attack speed: 0.5,
   level: [6, 8],
   gender: [
     "male",

--- a/std/mobs/monster.lpc
+++ b/std/mobs/monster.lpc
@@ -53,6 +53,8 @@ void virtual_setup(mixed args...) {
     set_weapon_name(data["weapon name"]);
   if(!nullp(data["weapon type"]))
     set_weapon_type(data["weapon type"]);
+  data["attack speed"] && set_attack_speed(data["attack speed"]);
+  data["plus attack speed"] && add_attack_speed(data["plus attack speed"]);
 
   // Set race
   if(!nullp(data["race"]))


### PR DESCRIPTION
Adds support for configuring `attack speed` and `plus attack speed` in monster LPML definitions, allowing monsters to have their attack speed set or modified directly from data files. The crimson fox and monstrous wasp have been given increased attack speeds using this new functionality.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds LPML attack-speed configuration for virtual monsters. The main changes are:
- Adds direct and additive attack-speed fields during monster setup.
- Increases crimson fox attack speed.
- Increases monstrous wasp attack speed.
</details>

<sub>Reviews (2): Last reviewed commit: ["adding tech for virtual monsters and att..."](https://github.com/gesslar/oxidus-mudlib/commit/b137b178b483ff8d9046a9584642c7584782b7ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45543312)</sub>

<details><summary><h4>Context used (9)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Rule used - When guarding invocation of a closure/function poi... ([source](.greptile))
- Rule used - Do not add '#include <mudlib.h>'. mudlib.h is auto... ([source](.greptile))
- Rule used - In comments and documentation, refer to files by l... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->