### PR TITLE
Add JSDoc type cast to `player` in `get_object` simul_efun

### DIFF
--- a/adm/simul_efun/object.lpc
+++ b/adm/simul_efun/object.lpc
@@ -61,7 +61,7 @@ varargs object get_object(string str, object player) {
     return ob;
 
   if(objectp(player))
-    str = resolve_path(player->query_env("cwd"), str);
+    str = resolve_path(/** @type {STD_BODY} */ (player)->query_env("cwd"), str);
 
   if(ob = find_object(str))
     return ob;


### PR DESCRIPTION
Adds a JSDoc type cast to the `player` object in `get_object`, annotating it as `STD_BODY` before calling `query_env("cwd")`. This helps type checkers and tooling recognize the expected type of `player` at that call site.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a JSDoc cast for the `player` object in `get_object`.

- Annotates `player` as `STD_BODY` before reading its current directory.
</details>

<sub>Reviews (2): Last reviewed commit: ["fixing annotation"](https://github.com/gesslar/oxidus-mudlib/commit/0b2c74d46aced52c9cd121f28cdc8034da746a09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45543314)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))
- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Do not flag cross-kind cache contamination in this... ([source](https://app.greptile.com/gesslar/github/gesslar/oxidus-mudlib/-/custom-context?memory=7f1b23a3-84a2-42dc-aead-132350aed221))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->