### PR TITLE
Skip null values in `save_to_string` persist elements

### DIFF
--- a/std/object/persist.lpc
+++ b/std/object/persist.lpc
@@ -72,10 +72,14 @@ varargs string save_to_string(int recursep) {
     tmp = ([]);
 
     foreach(string element, string func in elements) {
-      tmp[element] = ([
-        "value": fetch_variable(element),
-        "func": func,
-      ]);
+      mixed value = fetch_variable(element);
+
+      if(!nullp(value)) {
+        tmp[element] = ([
+          "value": value,
+          "func": func,
+        ]);
+      }
     }
 
     if(sizeof(tmp))


### PR DESCRIPTION
When saving persistent data to a string, null values are now excluded from the output. Previously, all registered elements were saved regardless of their value, which could result in null entries being written to the save data. Now, an element is only included if its value is non-null, keeping the saved data clean and free of meaningless entries.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes null-valued persistence elements from `save_to_string()` output. The main changes are:

- Fetch each registered value once.
- Add only non-null values to the serialized `#vars#` mapping.
</details>

<sub>Reviews (1): Last reviewed commit: ["do not save undefined values"](https://github.com/gesslar/oxidus-mudlib/commit/4ddb837f0adec96f1bf2590f7e46c1bb6768c9d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45786793)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->