### PR TITLE
Replace `nullp` check with falsy check in `cmd_sell`

### DIFF
--- a/std/ext/shop.lpc
+++ b/std/ext/shop.lpc
@@ -353,7 +353,7 @@ mixed cmd_sell(object tp, string str) {
     int coins = sum(values(value));
     string mess, *list;
 
-    if(nullp(cost)) {
+    if(!cost) {
       tell(tp, "The shop refuses to buy your " + short + ".\n");
       continue;
     }


### PR DESCRIPTION
Changes the null check for `cost` from `nullp(cost)` to `!cost` when determining if a shop will buy an item, making the condition more idiomatic and also causing the shop to refuse purchase when `cost` is zero.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes how shops reject items with no sale value. The main change is:

- Treat both null and zero sale costs as reasons to refuse a purchase.
</details>

<sub>Reviews (2): Last reviewed commit: ["don&#39;t allow selling if actually 0"](https://github.com/gesslar/oxidus-mudlib/commit/6719777b826c3512ffd658aa1317fff098b12a15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45786799)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->