### PR TITLE
Add item filtering and equipped status display to `inventory` command

### DIFF
--- a/cmds/std/inventory.lpc
+++ b/cmds/std/inventory.lpc
@@ -12,16 +12,22 @@
 
 inherit STD_CMD;
 
+private string *format_contents(object *obs, int fns);
+
 mixed main(
   /** @type {STD_BODY} */ object tp,
-  string _arg
+  string arg
 ) {
   object *obs = all_inventory(tp);
   obs = filter(obs, (: $(tp)->can_see($1) :));
 
-  string *shorts = map(obs, (: ob_short :));
-  shorts = filter(shorts, (: strlen :));
-  shorts = map(shorts, (: `  ${$1}` :));
+  if(arg)
+    obs = filter(obs, (: $1->id($(arg)) :));
+
+  string *shorts = format_contents(
+    obs,
+    devp(tp) && tp->query_pref("look_filename") == "on"
+  );
 
   string *result =
       ({ "You are carrying:", "" })
@@ -30,4 +36,23 @@ mixed main(
     ;
 
   return result;
+}
+
+private string *format_contents(object *obs, int fns) {
+  string *shorts = map(obs, function(object ob, int fns) {
+    int equipped = /** @type {STD_ARMOUR|STD_CLOTHING|STD_WEAPON} */ (ob)->equipped();
+    string short = ob_short(ob);
+
+    if(!truthy(short))
+      return "";
+
+    if(fns)
+      return `${equipped?"*":" "}${short} (${file_name(ob)})`;
+    else
+      return `${equipped?"*":" "}${short}`;
+  }, fns);
+
+  shorts = filter(shorts, (: strlen :));
+
+  return shorts;
 }


### PR DESCRIPTION
Adds optional filtering and formatting improvements to the `inventory` command.

An argument can now be passed to filter inventory items by id, e.g. `inventory sword` to list only items matching that id.

Item display now includes an equipped indicator (`*`) prefixed to each item's short description. For developers with the `look_filename` preference enabled, the object's file name is also shown alongside each item.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the `inventory` command with filtering and richer item output. The main changes are:

- Filters carried items by ID when an argument is provided.
- Marks equipped items with an asterisk.
- Shows object filenames for developers with the preference enabled.
</details>

<sub>Reviews (2): Last reviewed commit: ["upgrading inventory"](https://github.com/gesslar/oxidus-mudlib/commit/ed875221d88f7fde98ef12d7cb07268de0fd4c20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45786807)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->