### PR TITLE
Add Greptile rules for undefined function calls and driver source citation requirements

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -30,6 +30,14 @@ positive evidence of a real defect.
 - **Numeric coercion preserves float values** through int-typed locals in
   FluffOS. `int x = <float expr>` does not necessarily truncate; verify before
   claiming a truncation bug.
+- **Calling an undefined function is not an error.** `ob->foo()` /
+  `call_other(ob, "foo")` where `ob` does not define `foo()` returns `0`; it
+  does **not** raise a missing-function runtime error (`apply_low()` in
+  `src/vm/internal/apply.cc` pops the arguments and returns 0). Duck-typed
+  calls across mixed inventories are a normal idiom here. Do not flag an
+  unguarded `->` call as a crash, and do not suggest a `function_exists()`
+  guard for one — the guard is only meaningful when the code must distinguish
+  "absent" from a legitimately returned `0`.
 - **Reserved type words** (`buffer`, `function`, `class`, `mapping`, `object`,
   `mixed`, …) may not be used as variable names — that one *is* worth flagging.
 - **Closures.** In `(: :)` closures, `$N` is the call-time positional argument
@@ -56,6 +64,22 @@ positive evidence of a real defect.
 
 You have the whole repository. Use it before you write a comment.
 
+- **Cite the driver source before you assert a failure mode.** Any finding that
+  says the driver will *do* something — raise a runtime error, fail to resolve
+  a call, crash, truncate, coerce, or reject a path — is a claim about
+  fluffos/fluffos, and you have that repository. Read the code that implements
+  it before the comment exists: the efun, the apply/call dispatch, the relevant
+  bytecode handler. This is a gate, not a suggestion. C or C++ intuition about
+  what "should" happen is not evidence, and neither is the absence of a
+  construct from general LPC knowledge; this driver has extensions. If the
+  source refutes the claim, drop the comment; if you cannot find the
+  implementing code, you have not confirmed the failure mode — also drop it.
+- **Suggesting a defensive guard is asserting a failure mode.** Proposing a
+  `function_exists()`, `objectp()`, `nullp()`, or similar check implies the
+  unguarded path breaks. That implication needs the same source-level proof as
+  any other finding. "Defensive anyway" is not a justification — if the driver
+  makes the unguarded call safe, the guard is noise and the comment should not
+  exist.
 - **State findings as facts, not conditionals.** "If `foo()` returns null then
   this dereferences null" is not a finding — it is unfinished homework. Go read
   `foo()` and its callers. Either it *can* return null on a real path (now it is


### PR DESCRIPTION
This PR strengthens the Greptile review rules around two related failure modes in LPC/FluffOS code review:

**Undefined function calls are safe by design.** Adds an explicit rule clarifying that `ob->foo()` or `call_other(ob, "foo")` where `foo` does not exist on the target object returns `0` rather than raising a runtime error — this is documented back to `apply_low()` in the FluffOS source. Reviewers should not flag unguarded `->` calls as crashes, and should not suggest `function_exists()` guards unless the code genuinely needs to distinguish "absent" from a legitimately returned `0`.

**Driver behavior claims require driver source citations.** Any finding asserting that FluffOS will raise an error, crash, truncate, coerce, or reject something is a claim about the FluffOS codebase and must be verified against it before the comment is written. C/C++ intuition and general LPC knowledge are not sufficient evidence. Proposing a defensive guard (`function_exists()`, `objectp()`, `nullp()`, etc.) is treated as implicitly asserting a failure mode and is held to the same standard — if the driver makes the unguarded path safe, the guard suggestion should not appear.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR strengthens the Greptile review guidance for LPC and FluffOS behavior. The main changes are:

- Documents that calls to undefined object functions return `0`.
- Requires driver source citations for claims about FluffOS behavior.
- Applies the same evidence requirement to defensive guard suggestions.
</details>

<sub>Reviews (2): Last reviewed commit: ["updating .greptile"](https://github.com/gesslar/oxidus-mudlib/commit/b888b75a7458f07e4b2a610fcc3d1368d5d9d8db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45792708)</sub>

<!-- /greptile_comment -->