### PR TITLE
Add NPC proc system with simple proc support and wild boar gore proc

### DIFF
--- a/d/mobs/wild_boar.lpml
+++ b/d/mobs/wild_boar.lpml
@@ -26,4 +26,14 @@
     copper: [1,100.0],
     silver: [1,50.0],
   },
+  simple procs: [
+    {
+      tag: "gore",
+      messages: [
+        "{{630}}$N $vgore $t with $p short tusks.{{res}}",
+      ],
+      damage_type: "piercing",
+      attack_type: "melee",
+    }
+  ]
 }

--- a/include/action.h
+++ b/include/action.h
@@ -7,6 +7,7 @@ varargs void simple_action(mixed msg, mixed *obs...);
 varargs void my_action(mixed msg, mixed *obs...);
 varargs void other_action(mixed msg, mixed *obs...);
 varargs void my_target_action(mixed msg, object target, mixed *obs...);
+varargs void other_target_action(mixed msg, object target, mixed *obs...);
 varargs void target_action(mixed msg, object target, mixed *obs...);
 varargs void targetted_action(mixed msg, object target, mixed *obs...);
 

--- a/include/mudlib.h
+++ b/include/mudlib.h
@@ -37,6 +37,7 @@
 #define STD_MODULE_BASE     DIR_STD "module_base"
 #define STD_LIVING          DIR_STD_LIVING "living"
 #define STD_NPC             DIR_STD_LIVING "npc"
+#define STD_NPC_PROC        DIR_STD_LIVING "proc"
 #define STD_OB_E            DIR_STD "object/ob_prop"
 #define STD_OBJECT          DIR_STD "object/object"
 #define STD_PLAYER          DIR_STD_LIVING "player"

--- a/std/living/combat.lpc
+++ b/std/living/combat.lpc
@@ -320,31 +320,11 @@ void strike_enemy(object enemy, object weapon) {
 
   mapping weapon_info = query_weapon_info(weapon);
 
-  string skill_name = sprintf(weapon_info["skill"]);
-  float skill = query_skill_level(skill_name);
-  float base = 5.0;
-  float subtracted = percent_of(25.0, base);
+  string skill_name = weapon_info.skill;
+  string wtype = weapon_info.type;
+  string wname = weapon_info.name;
 
-  base -= subtracted;
-  float variance = random_float(subtracted);
-  base += variance;
-
-  float wbase = weapon_info["base"];
-  string wname = weapon_info["name"];
-  string wtype = weapon_info["type"];
-
-  if(enemy->query_mp() < 0.0)
-      base += 4.0;
-
-  float dam =
-      base
-    + wbase
-    + query_effective_level()
-    + (skill + query_skill_level("combat") / 2.0)
-    - enemy->query_effective_level()
-    - enemy->query_defence_amount(wtype)
-    - enemy->query_skill_level("combat.defence")
-  ;
+  float dam = calculate_damage(enemy, weapon);
 
   use_skill(skill_name);
 
@@ -363,10 +343,25 @@ void strike_enemy(object enemy, object weapon) {
   add_threat(enemy, dam);
   add_seen_threat(enemy, dam);
 
+  if(!valid_enemy(enemy))
+    return;
+
   string proc;
   if(weapon && weapon->is_weapon()) {
     if(stringp(proc = call_if(weapon, "can_proc"))) {
       call_if(weapon, "proc", proc, this_object(), enemy);
+    }
+  }
+
+  if(!valid_enemy(enemy))
+    return;
+
+  if(npcp(this_object())) {
+    string tag = call_if(this_object(), "can_proc");
+    if(tag) {
+      catch {
+        /** @type {STD_NPC} */ (this_object())->proc_npc(tag);
+      };
     }
   }
 }

--- a/std/living/damage.lpc
+++ b/std/living/damage.lpc
@@ -17,7 +17,9 @@
  * 2026-05-10 - Gesslar - Documentation pass
  */
 
+#include <combat.h>
 #include <damage.h>
+#include <skills.h>
 #include <vitals.h>
 
 // Functions from other objects
@@ -41,7 +43,7 @@ object set_killed_by(object ob);
  *                  reductions, or 0 if the victim is missing or
  *                  the input damage was negative.
  */
-float deliver_damage(object victim, float damage, string type) {
+public float deliver_damage(object victim, float damage, string type) {
   if(!victim)
     return 0;
 
@@ -74,7 +76,7 @@ float deliver_damage(object victim, float damage, string type) {
  *                  attacker is missing, the input was negative, or
  *                  the body was already dead.
  */
-float receive_damage(object attacker, float damage, string type) {
+public float receive_damage(object attacker, float damage, string type) {
   float def, red, mod, level, alevel, level_difference, new_damage;
 
   if(!attacker)
@@ -125,4 +127,62 @@ float receive_damage(object attacker, float damage, string type) {
     set_killed_by(attacker);
 
   return damage;
+}
+
+/**
+ *
+ * @param {STD_BODY} enemy
+ * @param {object | string} weapon_or_skill
+ */
+public varargs float calculate_damage(object enemy, mixed weapon_or_skill) {
+  mapping weapon_info;
+
+  if(objectp(weapon_or_skill))
+    weapon_info = query_weapon_info(weapon_or_skill);
+  else
+    weapon_info = query_weapon_info(undefined);
+
+  string skill_name = stringp(weapon_or_skill) ? weapon_or_skill : weapon_info["skill"];
+  float skill = query_skill_level(skill_name);
+  float base = 5.0;
+  float subtracted = percent_of(25.0, base);
+
+  base -= subtracted;
+  float variance = random_float(subtracted);
+  base += variance;
+
+  float wbase = weapon_info["base"];
+
+  if(enemy->query_mp() < 0.0)
+    base += 4.0;
+
+  float dam =
+      base
+    + wbase
+    + query_effective_level()
+    + (skill + query_skill_level("combat") / 2.0)
+    - enemy->query_effective_level()
+    - enemy->query_skill_level("combat.defence")
+  ;
+
+  return dam;
+}
+
+public float adjust_damage_by_severity(float damage, string severity) {
+  switch(severity) {
+    case "weak":
+      return damage * 0.25;
+    case "moderate":
+      return damage * 0.75;
+    case "normal":
+      return damage;
+    case "heavy":
+      return damage * 1.50;
+    case "high":
+      return damage * 1.75;
+    case "brutal":
+      return damage * 2.0;
+    default:
+      error("Invalid damage severity.");
+  }
 }

--- a/std/living/include/damage.h
+++ b/std/living/include/damage.h
@@ -1,7 +1,9 @@
 #ifndef __DAMAGE_H__
 #define __DAMAGE_H__
 
-float deliver_damage(object victim, float damage, string type) ;
-float receive_damage(object attacker, float damage, string type) ;
+public float adjust_damage_by_severity(float damage, string severity);
+public varargs float calculate_damage(object enemy, mixed weapon_or_skill);
+public float deliver_damage(object victim, float damage, string type);
+public float receive_damage(object attacker, float damage, string type);
 
 #endif // __DAMAGE_H__

--- a/std/living/npc.lpc
+++ b/std/living/npc.lpc
@@ -11,6 +11,7 @@
 
 inherit STD_BODY;
 inherit EXT_LOOT;
+inherit STD_NPC_PROC;
 
 inherit __DIR__ "living";
 

--- a/std/living/proc.lpc
+++ b/std/living/proc.lpc
@@ -1,0 +1,166 @@
+/**
+ * @file /std/living/proc.lpc
+ *
+ * NPC procs.
+ *
+ * @created 2026-07-20 - Gesslar
+ * @last_modified 2026-07-20 - Gesslar
+ *
+ * @history
+ * 2026-07-20 - Gesslar - Created
+ */
+
+#include <action.h>
+#include <combat.h>
+#include <damage.h>
+
+// @this_object /std/living/npc.lpc
+
+private void perform_simple_proc(string tag, mapping proc);
+
+private nosave mapping __npc_procs = ([]);
+private nosave float __npc_proc_chance = 12.0;
+private nosave mapping __npc_proc_cooldowns = ([]);
+private nosave float __default_cooldown = 1;
+private nosave float __default_proc_weight = 1;
+
+public float set_proc_chance(float chance) {
+  assert_arg(nullp(chance) || (floatp(chance) && clamped(chance, 0.0, 100.0)), 1, "Chance must be null or a float clamped to 0.0 and 100.0.");
+
+  __npc_proc_chance = chance;
+
+  return __npc_proc_chance;
+}
+
+public float get_proc_chance() {
+  return __npc_proc_chance;
+}
+
+public varargs void add_simple_proc(
+  string  tag,
+  string *msgs,
+  string  damage_type,
+  string  attack_type,
+  int     weight,
+  int     cooldown,
+  string  severity) {
+  assert_arg(stringp(tag) && truthy(tag), 1, "Tag must be a non-empty string.");
+  assert_arg(pointerp(msgs) && uniformp(msgs, T_STRING), 2, "Invalid messages array.");
+  assert_arg(stringp(damage_type) && truthy(damage_type), 3, "Damage type must be a non-empty string.");
+  assert_arg(stringp(attack_type) && truthy(attack_type), 4, "Attack type must be a non-empty string.");
+  assert_arg(nullp(weight) || (intp(weight) && clamped(weight, 0, 100)), 5, "Weight must be null or an int clamped to 0 and 100.");
+  assert_arg(nullp(cooldown) || (intp(cooldown) && cooldown >= 0), 6, "Cooldown must be an int greater than or equal to 0.");
+  assert_arg(nullp(severity) || (stringp(severity) && truthy(severity)), 7, "Severity must be null or a non-empty string.");
+
+  assert(
+    sizeof(msgs) == 1 || sizeof(msgs) == 2,
+    "Messages must contain one or two strings."
+  );
+
+  severity ??= "normal";
+
+  mapping proc = ([
+    "messages": msgs,
+    "damage_type": damage_type,
+    "attack_type": attack_type,
+    "severity": severity,
+    "type": "simple",
+    "cooldown": cooldown,
+    "weight" : weight,
+  ]);
+
+  // If one already exists, just overwrite it.
+  __npc_procs[tag] = proc;
+}
+
+mapping get_procs() {
+  return copy(__npc_procs);
+}
+
+mapping get_proc(string tag) {
+  return copy(__npc_procs[tag]);
+}
+
+string can_proc() {
+  mapping procs = ([]);
+  int now = time();
+  string result;
+
+  // If there are no procs, return false
+  if(!sizeof(__npc_procs))
+    return false;
+
+  // If the proc chance is 0, return false
+  if(__npc_proc_chance <= 0.0)
+    return false;
+
+  float roll = random_float(100.0);
+
+  if(roll > __npc_proc_chance)
+    return false;
+
+  // Iterate through all procs and check if they can proc, if they have
+  // a cooldown.
+  foreach(string name, mapping proc in __npc_procs) {
+    if(proc.cooldown > 0) {
+      if(now - __npc_proc_cooldowns[name] > proc.cooldown) {
+        procs[name] = proc.weight ?? 100;
+      }
+    } else {
+      procs[name] = proc.weight ?? 100;
+    }
+  }
+
+  if(!sizeof(procs))
+    return false;
+
+  // Now let's check which proc can occur. This is based on the weight of
+  // the proc.
+  result = element_of_weighted(procs);
+
+  return result;
+}
+
+/**
+ * @brief Query a proc from an object.
+ * @param {string} tag - The name of the proc to query.
+ * @returns {mapping} The proc.
+ */
+public mapping query_proc(string tag) {
+  assert_arg(stringp(tag) && truthy(tag), 1, "Tag must be a string.");
+
+  return copy(__npc_procs[tag]);
+}
+
+/**
+ * @brief Call a proc.
+ * @param {string} tag - The name of the proc to call.
+ */
+public varargs void proc_npc(string tag) {
+  mapping proc = query_proc(tag);
+
+  if(!mapp(proc))
+    return;
+
+  if(proc.type == "simple") {
+    return perform_simple_proc(tag, proc);
+  }
+}
+
+private void perform_simple_proc(string tag, mapping proc) {
+  /** @type {STD_BODY} */ object enemy = highest_threat();
+
+  if(sizeof(proc.messages) == 1) {
+    target_action(proc.messages[0], enemy);
+  } else if(sizeof(proc.messages) == 2) {
+    target_action(proc.messages[0], enemy);
+    other_target_action(proc.messages[1], enemy);
+  }
+
+  float raw = calculate_damage(enemy, `combat.${proc.attack_type}.${proc.damage_type}`);
+  float damage = adjust_damage_by_severity(raw, proc.severity);
+
+  deliver_damage(enemy, damage, proc.damage_type);
+
+  __npc_proc_cooldowns[tag] = time();
+}

--- a/std/living/skills.lpc
+++ b/std/living/skills.lpc
@@ -198,7 +198,12 @@ float query_raw_skill(string skill) {
  * @returns {float} The level, or null if not found or invalid.
  */
 float query_skill(string skill) {
-  mapping node = find_skill_node(skill);
+  mapping node;
+
+  if(pcp(this_object()))
+    node = find_skill_node(skill);
+  else
+    node = ([ "level": query_effective_level() * 4.0 ]);
 
   if(!node)
     return null;
@@ -213,7 +218,12 @@ float query_skill(string skill) {
  * @returns {float} The level, or null if not found or invalid.
  */
 float query_skill_level(string skill) {
-  mapping node = find_skill_node(skill);
+  mapping node;
+
+  if(pcp(this_object()))
+    node = find_skill_node(skill);
+  else
+    node = ([ "level": query_effective_level() * 4.0 ]);
 
   if(!node)
     return null;

--- a/std/mobs/monster.lpc
+++ b/std/mobs/monster.lpc
@@ -55,6 +55,20 @@ void virtual_setup(mixed args...) {
     set_weapon_type(data["weapon type"]);
   data["attack speed"] && set_attack_speed(data["attack speed"]);
   data["plus attack speed"] && add_attack_speed(data["plus attack speed"]);
+  data["proc chance"] && set_proc_chance(data["proc chance"]);
+  if(pointerp(data["simple procs"])) {
+    foreach(mapping proc in data["simple procs"]) {
+      add_simple_proc(
+        proc.tag,
+        proc.messages,
+        proc.damage_type,
+        proc.attack_type ?? "melee",
+        proc.weight,
+        proc.cooldown,
+        proc.severity,
+      );
+    }
+  }
 
   // Set race
   if(!nullp(data["race"]))


### PR DESCRIPTION
## NPC Proc System

Introduces a proc system for NPCs, allowing them to trigger special attacks during combat with configurable chance, cooldown, weight, and severity.

### New `proc.lpc` Module

A new `STD_NPC_PROC` module (`std/living/proc.lpc`) is added and inherited by `npc.lpc`. It provides:

- **`set_proc_chance` / `get_proc_chance`** – Controls the percentage chance a proc fires on each strike.
- **`add_simple_proc`** – Registers a proc by tag with associated messages, damage type, attack type, weight, cooldown, and severity.
- **`can_proc`** – Rolls against the proc chance and returns the tag of an eligible proc selected by weighted random, respecting per-proc cooldowns.
- **`proc_npc`** – Dispatches the proc by tag, currently supporting `"simple"` type procs.
- **`perform_simple_proc`** – Sends combat messages via `target_action` / `other_target_action`, calculates damage using the proc's attack and damage type against the highest-threat enemy, applies a severity multiplier, and delivers the damage.

### Damage Refactoring

The damage calculation previously inlined in `strike_enemy` is extracted into `calculate_damage` in `damage.lpc`, accepting either a weapon object or a skill string. A new `adjust_damage_by_severity` function applies named multipliers (`weak`, `moderate`, `normal`, `heavy`, `high`, `brutal`) to a raw damage value.

### NPC Skill Handling

`query_skill` and `query_skill_level` now return a synthetic skill level of `effective_level * 4.0` for non-player characters instead of looking up a skill node, giving NPCs a consistent combat skill baseline.

### Monster Setup

`monster.lpc` reads `proc chance` and `simple procs` from mob definition data and calls the appropriate setup functions, wiring the proc system into the existing virtual setup flow.

### Wild Boar

The wild boar gains a `gore` proc, dealing piercing melee damage with a tusk attack message.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds configurable special attacks for NPC combat. The main changes are:

- Adds proc chance, weighting, cooldown, messaging, and severity handling.
- Integrates simple procs into NPCs and virtual monster setup.
- Extracts shared combat damage calculation and adds severity multipliers.
- Gives NPCs a synthetic combat skill baseline.
- Configures a gore proc for wild boars.
</details>

<sub>Reviews (2): Last reviewed commit: ["basic monster attack procs"](https://github.com/gesslar/oxidus-mudlib/commit/d3c7024e8b11b94561beb42a99f9904183950d99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45827263)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->