### PR TITLE
Refactor combat config into `COMBAT` block and fix damage, skill, and evade path bugs

### DIFF
--- a/adm/etc/default.lpml
+++ b/adm/etc/default.lpml
@@ -63,8 +63,14 @@
   DEFAULT_HEART_RATE: 10,
   OBJECT_DATA_DIR: "/data/obj/",
   DEFAULT_RACE: "human",
-  DAMAGE_LEVEL_MODIFIER: 25,
-  DEFAULT_HIT_CHANCE: 65,
+  // The damage level modifier is multiplied by the difference in levels
+  COMBAT: {
+    BASE_DAMAGE: 1.0,
+    DAMAGE_LEVEL_MODIFIER: 15.0,
+    DAMAGE_VARIANCE: 15.0,
+    DEFAULT_HIT_CHANCE: 65.0,
+    NPC_SKILL_MULTIPLIER: 2.0,
+  },
   PLAYER_AUTOLEVEL: true,
   BASE_TNL: 100,
   TNL_RATE: 1.25,

--- a/cmds/spell/embers.lpc
+++ b/cmds/spell/embers.lpc
@@ -58,7 +58,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
           "{{f73}}Glowing embers cling to $t!{{res}}",
           victim
         );
-        tp->use_skill("arcane.discipline.fire", 0.5);
+        tp->use_skill("arcane.discipline.fire", 1.15);
 
         // Recasting reapplies a fresh burn rather than stacking.
         mapping existing = victim->query_curse_object(
@@ -76,10 +76,9 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
         victim->curse_object(eff, 6);
         eff->start();
       } else {
-        tp->simple_action(
-          "The embers fizzle and fall away harmlessly."
-        );
-        victim->use_skill("arcane.combat.evade", 0.1);
+        tp->simple_action("The embers fizzle and fall away harmlessly.");
+        tp->use_skill("arcane.discipline.fire", 0.25);
+        victim->use_skill("combat.defence.evade", 0.1);
       }
 
       victim->start_attack(tp);

--- a/cmds/spell/motes.lpc
+++ b/cmds/spell/motes.lpc
@@ -56,12 +56,11 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
           victim
         );
         tp->deliver_damage(victim, damage, "light");
-        tp->use_skill("arcane.discipline.light", 0.5);
+        tp->use_skill("arcane.discipline.light", 1.15);
       } else {
-        tp->simple_action(
-          "The motes of light disperse harmlessly."
-        );
-        victim->use_skill("arcane.combat.evade", 0.1);
+        tp->simple_action("The motes of light disperse harmlessly.");
+        tp->use_skill("arcane.discipline.light", 0.25);
+        victim->use_skill("combat.defence.evade", 0.1);
       }
 
       victim->start_attack(tp);

--- a/cmds/spell/shard.lpc
+++ b/cmds/spell/shard.lpc
@@ -60,7 +60,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
           victim
         );
         tp->deliver_damage(victim, initial, "cold");
-        tp->use_skill("arcane.discipline.frost", 0.5);
+        tp->use_skill("arcane.discipline.frost", 1.15);
 
         // Shards stack — each caster's shard shatters on its own
         // schedule, so group casts don't trample each other.
@@ -71,10 +71,9 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
         eff->set_fixed(1);
         victim->curse_object(eff, 3);
       } else {
-        tp->simple_action(
-          "The shard of ice splinters harmlessly."
-        );
-        victim->use_skill("arcane.combat.evade", 0.1);
+        tp->simple_action("The shard of ice splinters harmlessly.");
+        tp->use_skill("arcane.discipline.frost", 0.25);
+        victim->use_skill("combat.defence.evade", 0.1);
       }
 
       victim->start_attack(tp);

--- a/cmds/spell/shock.lpc
+++ b/cmds/spell/shock.lpc
@@ -53,12 +53,11 @@ mixed use(
       victim
     );
     tp->deliver_damage(victim, damage, "lightning");
-    tp->use_skill("arcane.discipline.lightning", 0.5);
+    tp->use_skill("arcane.discipline.lightning", 1.15);
   } else {
-    tp->simple_action(
-      "The bolt of lightning fizzles harmlessly."
-    );
-    victim->use_skill("arcane.combat.evade", 0.1);
+    tp->simple_action("The bolt of lightning fizzles harmlessly.");
+    tp->use_skill("arcane.discipline.lightning", 0.25);
+    victim->use_skill("combat.defence.evade", 0.1);
   }
 
   apply_cost(tp, arg);

--- a/cmds/spell/wither.lpc
+++ b/cmds/spell/wither.lpc
@@ -57,7 +57,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
           "{{83a}}$N $vreach out with a grasping shadow toward $t!{{res}}",
           victim
         );
-        tp->use_skill("arcane.discipline.shadow", 0.5);
+        tp->use_skill("arcane.discipline.shadow", 1.15);
 
         // Withers stack across casters — each contributes its own
         // -amount to the three defense skills.
@@ -72,11 +72,9 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
 
         victim->simple_action("$N $vlook weakened.");
       } else {
-        tp->targetted_action(
-          "The grasping shadow recoils from $t.",
-          victim
-        );
-        victim->use_skill("arcane.combat.evade", 0.1);
+        tp->targetted_action("The grasping shadow recoils from $t.", victim);
+        tp->use_skill("arcane.discipline.shadow", 0.25);
+        victim->use_skill("combat.defence.evade", 0.1);
       }
 
       victim->start_attack(tp);

--- a/obj/effect/wither.lpc
+++ b/obj/effect/wither.lpc
@@ -66,7 +66,7 @@ void apply() {
     "wither", "skill", "combat.defence.dodge", __amount, dur
   );
   __tag_evade = victim->curse(
-    "wither", "skill", "arcane.combat.evade", __amount, dur
+    "wither", "skill", "combat.defence.evade", __amount, dur
   );
   __tag_defence = victim->curse(
     "wither", "skill", "combat.defence", __amount, dur
@@ -80,17 +80,13 @@ int expire_obj(int expired) {
     return 1;
 
   victim->remove_curse("skill", "combat.defence.dodge", __tag_dodge);
-  victim->remove_curse("skill", "arcane.combat.evade", __tag_evade);
+  victim->remove_curse("skill", "combat.defence.evade", __tag_evade);
   victim->remove_curse("skill", "combat.defence", __tag_defence);
 
   if(expired)
-    victim->simple_action(
-      "The withering shadow lifts from $n."
-    );
+    victim->simple_action("The withering shadow lifts from $n.");
   else
-    victim->simple_action(
-      "The withering shadow is dispelled from $n."
-    );
+    victim->simple_action("The withering shadow is dispelled from $n.");
 
   return 1;
 }

--- a/std/ext/proc.lpc
+++ b/std/ext/proc.lpc
@@ -68,11 +68,11 @@ void add_proc(string name, mixed proc) {
   if(stringp(proc) || valid_function(proc))
     proc = ([ "function": proc ]);
 
-  if(nullp(proc["cooldown"]))
-    proc["cooldown"] = __proc_cooldown;
+  if(nullp(proc.cooldown))
+    proc.cooldown = __proc_cooldown;
 
-  if(nullp(proc["weight"]))
-    proc["weight"] = __proc_weight;
+  if(nullp(proc.weight))
+    proc.weight = __proc_weight;
 
   __procs[name] = proc;
 }
@@ -163,9 +163,9 @@ string can_proc() {
   // Iterate through all procs and check if they can proc, if they have
   // a cooldown
   foreach(string name, mapping proc in __procs) {
-    if(proc["cooldown"] > 0) {
-      if(now - __cooldowns[name] > proc["cooldown"]) {
-        procs[name] = proc["chance"] || 100;
+    if(proc.cooldown > 0) {
+      if(now - __cooldowns[name] > proc.cooldown) {
+        procs[name] = proc.weight || 100;
       }
     }
   }

--- a/std/living/combat.lpc
+++ b/std/living/combat.lpc
@@ -228,7 +228,7 @@ int next_round() {
  */
 public int can_strike(object enemy, mixed weapon) {
   float ac;
-  float chance = mud_config("DEFAULT_HIT_CHANCE");
+  float chance = mud_config("COMBAT.DEFAULT_HIT_CHANCE");
   float lvl = query_effective_level();
   float vlvl = enemy->query_effective_level();
   float result;
@@ -246,7 +246,7 @@ public int can_strike(object enemy, mixed weapon) {
     skill_name = weapon;
     ac = enemy->query_spell_ac();
     if(strsrch(weapon, "arcane.") == 0)
-      defence_skill = "arcane.combat.evade";
+      defence_skill = "combat.defence.evade";
     else
       defence_skill = "combat.defence.dodge";
   } else

--- a/std/living/damage.lpc
+++ b/std/living/damage.lpc
@@ -77,36 +77,33 @@ public float deliver_damage(object victim, float damage, string type) {
  *                  the body was already dead.
  */
 public float receive_damage(object attacker, float damage, string type) {
-  float def, red, mod, level, alevel, level_difference, new_damage;
-
   if(!attacker)
     return 0.0;
 
   if(query_hp() <= 0.0)
     return 0.0;
 
-  new_damage = damage;
+  float new_damage = damage;
 
   if(damage < 0.0) {
     tell(this_object(), sprintf("receiving %O %O damage => %O\n", damage, type, new_damage));
     return 0.0;
   }
 
-  def = query_defence_amount(type);
-  red = percent_of(def, damage);
+  float def = query_defence_amount(type);
+  float red = percent_of(def, damage);
 
   // The global damage level modifier
-  mod = mud_config("DAMAGE_LEVEL_MODIFIER");
+  float mod = to_float(mud_config("COMBAT.DAMAGE_LEVEL_MODIFIER"));
 
   // The level of the attacker and the victim
-  level = query_effective_level();
-  alevel = attacker->query_effective_level();
+  float level = query_effective_level();
+  float alevel = attacker->query_effective_level();
 
   // The difference in levels between the attacker and the victim
-  level_difference = alevel - level;
+  float level_difference = alevel - level;
 
-  // The damage level modifier is multiplied by the difference in levels
-  mod = mod * level_difference;
+  mod *= level_difference;
   red -= percent_of(mod, damage);
 
   // The damage is reduced by the level modifier
@@ -114,11 +111,11 @@ public float receive_damage(object attacker, float damage, string type) {
 
   tell(this_object(), sprintf("receiving %O %O damage => %O\n", damage, type, new_damage));
 
-  if(damage < 0.0)
-    damage = 0.0;
+  if(new_damage < 0.0)
+    new_damage = 0.0;
 
   // Take the damage
-  adjust_hp(-damage);
+  adjust_hp(-new_damage);
 
   // Set the last damaged by object
   set_last_damaged_by(attacker);
@@ -126,7 +123,7 @@ public float receive_damage(object attacker, float damage, string type) {
   if(query_hp() <= 0.0)
     set_killed_by(attacker);
 
-  return damage;
+  return new_damage;
 }
 
 /**
@@ -144,8 +141,8 @@ public varargs float calculate_damage(object enemy, mixed weapon_or_skill) {
 
   string skill_name = stringp(weapon_or_skill) ? weapon_or_skill : weapon_info["skill"];
   float skill = query_skill_level(skill_name);
-  float base = 5.0;
-  float subtracted = percent_of(25.0, base);
+  float base = to_float(mud_config("COMBAT.BASE_DAMAGE"));
+  float subtracted = percent_of(to_float(mud_config("COMBAT.DAMAGE_VARIANCE")), base);
 
   base -= subtracted;
   float variance = random_float(subtracted);
@@ -156,13 +153,18 @@ public varargs float calculate_damage(object enemy, mixed weapon_or_skill) {
   if(enemy->query_mp() < 0.0)
     base += 4.0;
 
+  string defence_skill;
+  if(strsrch(skill_name, "arcane.") == 0) {
+    defence_skill = "combat.defence.evade";
+  } else {
+    defence_skill = "combat.defence.dodge";
+  }
+
   float dam =
       base
     + wbase
-    + query_effective_level()
     + (skill + query_skill_level("combat") / 2.0)
-    - enemy->query_effective_level()
-    - enemy->query_skill_level("combat.defence")
+    - enemy->query_skill_level(defence_skill)
   ;
 
   return dam;

--- a/std/living/proc.lpc
+++ b/std/living/proc.lpc
@@ -150,6 +150,11 @@ public varargs void proc_npc(string tag) {
 private void perform_simple_proc(string tag, mapping proc) {
   /** @type {STD_BODY} */ object enemy = highest_threat();
 
+  string skill_name = `combat.${proc.attack_type}.${proc.damage_type}`;
+
+  if(!can_strike(enemy, skill_name))
+    return;
+
   if(sizeof(proc.messages) == 1) {
     target_action(proc.messages[0], enemy);
   } else if(sizeof(proc.messages) == 2) {
@@ -157,7 +162,7 @@ private void perform_simple_proc(string tag, mapping proc) {
     other_target_action(proc.messages[1], enemy);
   }
 
-  float raw = calculate_damage(enemy, `combat.${proc.attack_type}.${proc.damage_type}`);
+  float raw = calculate_damage(enemy, skill_name);
   float damage = adjust_damage_by_severity(raw, proc.severity);
 
   deliver_damage(enemy, damage, proc.damage_type);

--- a/std/living/skills.lpc
+++ b/std/living/skills.lpc
@@ -203,7 +203,10 @@ float query_skill(string skill) {
   if(pcp(this_object()))
     node = find_skill_node(skill);
   else
-    node = ([ "level": query_effective_level() * 4.0 ]);
+    node = ([
+      "level":  query_effective_level()
+              * to_float(mud_config("COMBAT.NPC_SKILL_MULTIPLIER")),
+    ]);
 
   if(!node)
     return null;
@@ -223,7 +226,9 @@ float query_skill_level(string skill) {
   if(pcp(this_object()))
     node = find_skill_node(skill);
   else
-    node = ([ "level": query_effective_level() * 4.0 ]);
+    node = ([ "level":  query_effective_level()
+                      * to_float(mud_config("COMBAT.NPC_SKILL_MULTIPLIER"))
+    ]);
 
   if(!node)
     return null;
@@ -466,8 +471,8 @@ public int adjust_skills_by_npc_level(float level) {
 }
 
 /**
- * Recursively set every skill's level to level * 4.0. NPC-only —
- * errors out if called on a user.
+ * Recursively set every skill's level to level * COMBAT.NPC_SKILL_MULTIPLIER.
+ * NPC-only — errors out if called on a user.
  *
  * @param {mapping} current_skills - The skills submapping at the
  *                                   current recursion depth.
@@ -486,7 +491,9 @@ private nomask mapping adjust_skill_levels(mapping current_skills, float level) 
     if(mapp(skill_data) && mapp(skill_data["subskills"]))
       adjust_skill_levels(skill_data["subskills"], level);
 
-    current_skills[sk]["level"] = level * 4.0;
+    current_skills[sk]["level"] =
+        level
+      * to_float(mud_config("COMBAT.NPC_SKILL_MULTIPLIER"));
   }
 
   return current_skills;


### PR DESCRIPTION
## Combat System Refactor

Combat-related configuration values have been consolidated under a single `COMBAT` namespace in `default.lpml`, replacing the top-level `DAMAGE_LEVEL_MODIFIER` and `DEFAULT_HIT_CHANCE` keys. The new `COMBAT` block introduces additional tunable values:

- `BASE_DAMAGE` — base damage before variance is applied
- `DAMAGE_LEVEL_MODIFIER` — reduced from 25 to 15
- `DAMAGE_VARIANCE` — controls the random spread around base damage
- `DEFAULT_HIT_CHANCE` — unchanged at 65
- `NPC_SKILL_MULTIPLIER` — replaces the hardcoded `* 4.0` used when computing NPC skill levels, now set to 2.0

### Damage Calculation

`receive_damage` now correctly applies the level modifier against `new_damage` rather than the original `damage` value, fixing a bug where the floored damage check and the final `adjust_hp` call were operating on the unreduced amount. `calculate_damage` now reads `BASE_DAMAGE` and `DAMAGE_VARIANCE` from config rather than using hardcoded values, and no longer factors raw attacker/victim levels directly into the damage roll. Instead, damage mitigation is routed through the appropriate defence skill (`combat.defence.evade` for arcane, `combat.defence.dodge` otherwise).

### Skill Path Correction

References to `arcane.combat.evade` have been replaced with `combat.defence.evade` across all spell files (`embers`, `motes`, `shard`, `shock`, `wither`), the wither effect object, and the combat hit-chance logic. This aligns the evade skill with the standard `combat.defence` hierarchy.

### Spell Skill Gain

On a successful hit, arcane discipline skill gain has been increased from `0.5` to `1.15`. On a miss, casters now receive a reduced skill tick (`0.25`) rather than no gain at all, rewarding practice even on failed casts.

### NPC Procs

`perform_simple_proc` now calls `can_strike` before executing a proc attack, so NPC special attacks respect the same hit-chance logic as normal strikes.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR consolidates combat configuration and updates damage, skill, and proc behavior. The main changes are:

- Moves combat tuning values into a nested `COMBAT` block.
- Revises damage calculation and level-based mitigation.
- Corrects arcane evade skill paths and spell progression.
- Makes NPC special attacks perform hit checks.
- Uses configurable NPC skill and proc weights.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aadm%2Fetc%2Fdefault.lpml%3A67-73%0A**Partial%20Combat%20Overrides%20Drop%20Defaults**%0A%0AThe%20config%20daemon%20merges%20custom%20settings%20at%20the%20top%20level%2C%20so%20a%20custom%20%60COMBAT%60%20mapping%20replaces%20this%20entire%20default%20block%20rather%20than%20merging%20its%20fields.%20An%20operator%20overriding%20only%20%60BASE_DAMAGE%60%2C%20for%20example%2C%20loses%20%60DEFAULT_HIT_CHANCE%60%2C%20%60DAMAGE_LEVEL_MODIFIER%60%2C%20and%20%60NPC_SKILL_MULTIPLIER%60%3B%20the%20changed%20consumers%20then%20request%20missing%20keys%20and%20raise%20runtime%20errors%20during%20combat.%20The%20config%20merge%20must%20preserve%20unspecified%20defaults%20within%20%60COMBAT%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Astd%2Fliving%2Fproc.lpc%3A155-156%0A**Misses%20Bypass%20Proc%20Cooldowns**%0A%0AA%20failed%20hit%20check%20returns%20before%20%60__npc_proc_cooldowns%5Btag%5D%60%20is%20updated.%20The%20same%20proc%20therefore%20remains%20eligible%20after%20a%20miss%20and%20can%20reroll%20on%20the%20next%20ordinary%20strike%2C%20so%20its%20configured%20cooldown%20limits%20successful%20hits%20instead%20of%20attack%20attempts.%0A%0A%23%23%23%20Issue%203%20of%203%0Astd%2Fliving%2Fdamage.lpc%3A106-107%0A**Level%20Scaling%20Overwhelms%20Damage**%0A%0AThis%20now-active%20modifier%20changes%20damage%20by%2015%25%20for%20every%20level%20of%20difference%20without%20a%20bound.%20A%20victim%20seven%20levels%20above%20the%20attacker%20receives%20more%20than%20100%25%20mitigation%20before%20defence%20and%20every%20hit%20is%20clamped%20to%20zero%2C%20while%20an%20attacker%20seven%20levels%20above%20deals%20more%20than%20double%20damage%3B%20ordinary%20level%20gaps%20therefore%20make%20the%20remaining%20damage%20calculation%20largely%20irrelevant.%0A%0A&repo=gesslar%2Foxidus-mudlib&pr=392&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["some tweaking"](https://github.com/gesslar/oxidus-mudlib/commit/7dc9e1a4e8814fc2e82cef36f2c438ca20b8d0af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45866994)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))

<!-- /greptile_comment -->