### PR TITLE
Fix `add_module` multi-module handling and rename `race` `setup` to `base_setup`

### DIFF
--- a/std/modules/race/human.lpc
+++ b/std/modules/race/human.lpc
@@ -12,8 +12,6 @@
 inherit __DIR__ "race";
 
 void setup() {
-  ::setup();
-
   regen_rate = ([
     "hp" : 2.0,
     "sp" : 2.0,

--- a/std/modules/race/race.lpc
+++ b/std/modules/race/race.lpc
@@ -77,7 +77,7 @@ protected nosave mapping body_part_modifiers = ([ ]);
 
 protected nosave mapping equipment_slots = ([ ]);
 
-void setup() {
+void base_setup() {
   module_name = "race";
 }
 

--- a/std/object/module.lpc
+++ b/std/object/module.lpc
@@ -141,7 +141,7 @@ public varargs object add_module(string module_file, mixed args...) {
   string name = mod->query_name();
   mixed existing = __modules[name];
 
-  if(!nullp(existing) && !pointerp(existing)) {
+  if(!mod->allows_multi() && !nullp(existing)) {
     mod->remove();
     return 0;
   }
@@ -160,12 +160,14 @@ public varargs object add_module(string module_file, mixed args...) {
     return 0;
   }
 
-  if(pointerp(existing))
-    __modules[name] = push(ref __modules, mod);
-  else if(mod->allows_multi())
-    __modules[name] = ({ mod });
-  else
+  if(mod->allows_multi()) {
+    if(pointerp(existing))
+      push(ref __modules[name], mod);
+    else
+      __modules[name] = ({ mod });
+  } else {
     __modules[name] = mod;
+  }
 
   call_if(this_object(), "add_destruct", (:on_destruct_function:));
 


### PR DESCRIPTION
Renames `setup()` to `base_setup()` in the base race module to avoid conflicts with subclass `setup()` calls, removing the need for `human.lpc` to explicitly call `::setup()`.

Also fixes a bug in `add_module` where the multi-module check and storage logic was inverted. The guard condition now correctly checks `allows_multi()` before checking for an existing entry, and the storage logic properly pushes into an existing array or initializes a new one when multi is allowed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes race initialization and multi-module storage. The main changes are:

- Moves base race naming from `setup()` to `base_setup()`.
- Removes the redundant parent setup call from the human race.
- Corrects the multi-module guard and array append path.
</details>

<sub>Reviews (1): Last reviewed commit: ["update"](https://github.com/gesslar/oxidus-mudlib/commit/dd3fd189538f316aa9b8d25c3129d68117d5f4ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46139669)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Rule used - Prefer pointerp() over arrayp() for array type che... ([source](.greptile))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))
</details>

<!-- /greptile_comment -->