### PR TITLE
Add racial attribute modifiers and new race modules for dwarf, elf, gnome, orc, and troll

### DIFF
--- a/std/living/attributes.lpc
+++ b/std/living/attributes.lpc
@@ -1,20 +1,48 @@
 /**
  * @file /std/living/attributes.lpc
- * Player attributes.
+ *
+ * Core attributes (e.g. strength, dexterity) for living objects.
+ * Holds each living's per-attribute base scores and reconciles them
+ * against the configured attribute set, layering race modifiers and
+ * boon/curse effects on top when queried.
  *
  * @created 2024-07-30 - Gesslar
- * @last_modified 2024-07-30 - Gesslar
+ * @last_modified 2026-07-21 - Gesslar
  *
  * @history
  * 2024-07-30 - Gesslar - Created
+ * 2026-07-21 - Gesslar - Documented
  */
 
 #include <attributes.h>
 #include <boon.h>
+#include <module.h>
 
+/**
+ * The canonical set of attribute names, sourced from the
+ * "ATTRIBUTES" mud config. Used to seed and prune __attributes.
+ *
+ * @type {string*}
+ */
 private nomask nosave string *__default_attributes = ({});
+
+/**
+ * Per-attribute base scores for this living, keyed by attribute
+ * name. Race modifiers and boons are applied on read, not stored
+ * here.
+ *
+ * @type {([ string: int ])}
+ */
 private nomask mapping __attributes = ([]);
 
+/**
+ * Reconciles this living's stored attributes against the configured
+ * attribute set. Missing attributes are seeded to a base score of 5,
+ * and any stored attributes no longer present in the configuration
+ * are removed.
+ *
+ * @returns {void}
+ */
 void init_attributes() {
   string key;
   mixed data;
@@ -36,6 +64,16 @@ void init_attributes() {
   }
 }
 
+/**
+ * Sets the base score for an attribute, overwriting any existing
+ * value. Race modifiers and boons are not affected. Only known
+ * attributes (present in the current set) may be set.
+ *
+ * @param {string} key - The attribute name.
+ * @param {int} value - The new base score.
+ * @returns {int | undefined} The stored score, or undefined if the
+ *                            attribute is unknown.
+ */
 int set_attribute(string key, int value) {
   if(!of(key, __attributes)) {
     return null;
@@ -46,17 +84,41 @@ int set_attribute(string key, int value) {
   return __attributes[key];
 }
 
+/**
+ * Returns the effective score for an attribute. The stored base
+ * score is always combined with the living's race modifier for that
+ * attribute; the raw form omits boon/curse effects while the default
+ * form includes them.
+ *
+ * @param {string} key - The attribute name.
+ * @param {int} [raw=0] - When truthy, excludes boon/curse effects
+ *                        (base score plus race modifier only).
+ * @returns {int | undefined} The effective score, or undefined if
+ *                            the attribute is unknown.
+ */
 varargs int get_attribute(string key, int raw) {
   if(!of(key, __attributes)) {
     return null;
   }
 
-  if(raw)
-    return __attributes[key];
+  int attribute_mod = module("race", "query_attribute_mod", key);
 
-  return __attributes[key] + query_effective_boon("attribute", key);
+  if(raw)
+    return __attributes[key] + attribute_mod;
+
+  return __attributes[key] + query_effective_boon("attribute", key) + attribute_mod;
 }
 
+/**
+ * Adjusts an attribute's base score by a relative amount. The value
+ * is added to the current base score (pass a negative value to
+ * decrease it). Only known attributes may be modified.
+ *
+ * @param {string} key - The attribute name.
+ * @param {int} value - The amount to add to the base score.
+ * @returns {int | undefined} The new base score, or undefined if the
+ *                            attribute is unknown.
+ */
 int modify_attribute(string key, int value) {
   if(!of(key, __attributes)) {
     return null;
@@ -67,6 +129,24 @@ int modify_attribute(string key, int value) {
   return __attributes[key];
 }
 
+/**
+ * Returns a copy of all attribute scores with race modifiers folded
+ * in. Boon/curse effects are not included. The result is a copy, so
+ * callers may mutate it freely.
+ *
+ * @returns {([ string: int ])} Attribute names mapped to their
+ *                              race-adjusted scores.
+ */
 mapping get_attributes() {
-  return copy(__attributes);
+  mapping attributes = copy(__attributes);
+  mapping mods = module("race", "query_attribute_mod");
+
+  if(!mapp(mods))
+    return attributes;
+
+  foreach(string attrib, int value in mods) {
+    attributes[attrib] += value;
+  }
+
+  return attributes;
 }

--- a/std/modules/race/dwarf.lpc
+++ b/std/modules/race/dwarf.lpc
@@ -1,0 +1,31 @@
+/**
+ * @file /std/modules/race/dwarf.lpc
+ * Dwarf racial module
+ *
+ * @created 2026-07-21 - Gesslar
+ * @last_modified 2026-07-21 - Gesslar
+ *
+ * @history
+ * 2026-07-21 - Gesslar - Created
+ */
+
+inherit __DIR__ "race";
+
+void setup() {
+  __regen_rate += ([
+    "hp" : 3.0,
+    "sp" : 2.0,
+    "mp" : 2.0,
+  ]);
+
+  __attribute_mod += ([
+    "constitution": 2,
+    "strength": 1,
+    "dexterity": -1,
+    "charisma": -1,
+  ]);
+}
+
+int set_up_body_parts(object ob, mixed args...) {
+  return use_default_body_parts();
+}

--- a/std/modules/race/elf.lpc
+++ b/std/modules/race/elf.lpc
@@ -1,0 +1,31 @@
+/**
+ * @file /std/modules/race/elf.lpc
+ * Elf racial module
+ *
+ * @created 2026-07-21 - Gesslar
+ * @last_modified 2026-07-21 - Gesslar
+ *
+ * @history
+ * 2026-07-21 - Gesslar - Created
+ */
+
+inherit __DIR__ "race";
+
+void setup() {
+  __regen_rate += ([
+    "hp" : 1.0,
+    "sp" : 2.0,
+    "mp" : 5.0,
+  ]);
+
+  __attribute_mod += ([
+    "dexterity": 2,
+    "intelligence": 1,
+    "constitution": -1,
+    "strength": -1,
+  ]);
+}
+
+int set_up_body_parts(object ob, mixed args...) {
+  return use_default_body_parts();
+}

--- a/std/modules/race/gnome.lpc
+++ b/std/modules/race/gnome.lpc
@@ -1,0 +1,30 @@
+/**
+ * @file /std/modules/race/gnome.lpc
+ * Gnome racial module
+ *
+ * @created 2026-07-21 - Gesslar
+ * @last_modified 2026-07-21 - Gesslar
+ *
+ * @history
+ * 2026-07-21 - Gesslar - Created
+ */
+
+inherit __DIR__ "race";
+
+void setup() {
+  __regen_rate += ([
+    "hp" : 1.0,
+    "sp" : 2.0,
+    "mp" : 5.0,
+  ]);
+
+  __attribute_mod += ([
+    "intelligence": 2,
+    "dexterity": 1,
+    "strength": -2,
+  ]);
+}
+
+int set_up_body_parts(object ob, mixed args...) {
+  return use_default_body_parts();
+}

--- a/std/modules/race/human.lpc
+++ b/std/modules/race/human.lpc
@@ -12,10 +12,15 @@
 inherit __DIR__ "race";
 
 void setup() {
-  regen_rate = ([
+  __regen_rate += ([
     "hp" : 2.0,
     "sp" : 2.0,
     "mp" : 4.0,
+  ]);
+
+  __attribute_mod += ([
+    "constitution": 1,
+    "strength": 1,
   ]);
 }
 

--- a/std/modules/race/orc.lpc
+++ b/std/modules/race/orc.lpc
@@ -1,0 +1,31 @@
+/**
+ * @file /std/modules/race/orc.lpc
+ * Orc racial module
+ *
+ * @created 2026-07-21 - Gesslar
+ * @last_modified 2026-07-21 - Gesslar
+ *
+ * @history
+ * 2026-07-21 - Gesslar - Created
+ */
+
+inherit __DIR__ "race";
+
+void setup() {
+  __regen_rate += ([
+    "hp" : 3.0,
+    "sp" : 2.0,
+    "mp" : 1.0,
+  ]);
+
+  __attribute_mod += ([
+    "strength": 2,
+    "constitution": 1,
+    "intelligence": -1,
+    "charisma": -1,
+  ]);
+}
+
+int set_up_body_parts(object ob, mixed args...) {
+  return use_default_body_parts();
+}

--- a/std/modules/race/race.lpc
+++ b/std/modules/race/race.lpc
@@ -38,15 +38,17 @@ int valid_equipment_slot(string slot);
 int covers_body_part(string slot, string part);
 string covered_by_slot(string part);
 
-protected nosave string race;
-protected nosave mapping regen_rate = ([ "hp" : 0.0, "sp" : 0.0, "mp" : 0.0 ]);
+protected nosave string __race;
+protected nosave mapping __regen_rate = ([ "hp" : 0.0, "sp" : 0.0, "mp" : 0.0 ]);
+protected nosave mapping __attribute_mod = allocate_mapping(mud_config("ATTRIBUTES"), 0);
 
 // This is a mapping of body parts and their target sizes on the body.
 // Each body part has an array of two integers. The first integer is the
 // size of the body part, and the second integer vitalness of the body part.
 //
 // Size controls how likely it is to be selected when a random body part is
-// requested.
+// requested. Vitalness is a factor of how deadly injuries to that body part
+// would be.
 protected nosave mapping default_body_parts = ([
   "head"      : ({  3, 3 }),
   "neck"      : ({  2, 2 }),
@@ -292,9 +294,16 @@ string covered_by_slot(string part) {
   return 0;
 }
 
-varargs mapping query_regen_rate(string type) {
+varargs mixed query_regen_rate(string type) {
   if(type)
-    return regen_rate[type];
+    return __regen_rate[type];
 
-  return copy(regen_rate);
+  return copy(__regen_rate);
+}
+
+varargs mixed query_attribute_mod(string attr) {
+  if(attr)
+    return __attribute_mod[attr];
+
+  return copy(__attribute_mod);
 }

--- a/std/modules/race/troll.lpc
+++ b/std/modules/race/troll.lpc
@@ -1,0 +1,32 @@
+/**
+ * @file /std/modules/race/troll.lpc
+ * Troll racial module
+ *
+ * @created 2026-07-21 - Gesslar
+ * @last_modified 2026-07-21 - Gesslar
+ *
+ * @history
+ * 2026-07-21 - Gesslar - Created
+ */
+
+inherit __DIR__ "race";
+
+void setup() {
+  __regen_rate += ([
+    "hp" : 6.0,
+    "sp" : 1.0,
+    "mp" : 1.0,
+  ]);
+
+  __attribute_mod += ([
+    "strength": 3,
+    "constitution": 2,
+    "dexterity": -1,
+    "intelligence": -2,
+    "charisma": -2,
+  ]);
+}
+
+int set_up_body_parts(object ob, mixed args...) {
+  return use_default_body_parts();
+}


### PR DESCRIPTION
## Racial Attribute Modifiers

Introduces per-race attribute modifiers that are folded into attribute scores at query time rather than stored on the living.

### `attributes.lpc`

- `get_attribute` now adds the living's race modifier for the requested attribute on top of the base score. The `raw` flag continues to exclude boon/curse effects but now still includes the race modifier.
- `get_attributes` folds all race modifiers into the returned mapping so callers always receive race-adjusted totals.

### `race.lpc`

- Adds `__attribute_mod`, a mapping seeded from the mud's configured attribute set with all values initialised to `0`. Subclasses add their deltas via `+=` in `setup()`.
- Adds `query_attribute_mod`, which returns either a single modifier by name or a full copy of the mapping.
- Renames `race` and `regen_rate` to `__race` and `__regen_rate` for consistency with the new naming convention, and updates `query_regen_rate` accordingly.

### Race modules

- **Human** — gains `+1 constitution`, `+1 strength`. Regen rate assignment updated to use `__regen_rate +=`.
- **Dwarf** — new. `+2 constitution`, `+1 strength`, `-1 dexterity`, `-1 charisma`. High HP regen.
- **Elf** — new. `+2 dexterity`, `+1 intelligence`, `-1 constitution`, `-1 strength`. High MP regen.
- **Gnome** — new. `+2 intelligence`, `+1 dexterity`, `-2 strength`. High MP regen.
- **Orc** — new. `+2 strength`, `+1 constitution`, `-1 intelligence`, `-1 charisma`. High HP regen.
- **Troll** — new. `+3 strength`, `+2 constitution`, `-1 dexterity`, `-2 intelligence`, `-2 charisma`. Very high HP regen, low MP regen.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds race-based modifiers to living attributes. The main changes are:

- Applies race modifiers when querying one or all attributes.
- Adds shared modifier storage and query methods to race modules.
- Adds dwarf, elf, gnome, orc, and troll race modules.
- Updates the human race with attribute modifiers.
</details>

<sub>Reviews (2): Last reviewed commit: ["attributes and races"](https://github.com/gesslar/oxidus-mudlib/commit/56c289e99394c2ed571679dd1ede0dc8a931f18b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46152722)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->