### PR TITLE
Prefix unused parameters with `_` across race modules and boon

### DIFF
--- a/std/living/boon.lpc
+++ b/std/living/boon.lpc
@@ -210,7 +210,7 @@ private nomask int query(
   if(!of(cl, src) || !of(type, src[cl]))
     return 0;
 
-  foreach(int tag, mapping data in src[cl][type]) {
+  foreach(int _tag, mapping data in src[cl][type]) {
     total += data["amt"];
   }
 

--- a/std/modules/race/dwarf.lpc
+++ b/std/modules/race/dwarf.lpc
@@ -26,6 +26,6 @@ void setup() {
   ]);
 }
 
-int set_up_body_parts(object ob, mixed args...) {
+int set_up_body_parts(object _ob, mixed _args...) {
   return use_default_body_parts();
 }

--- a/std/modules/race/elf.lpc
+++ b/std/modules/race/elf.lpc
@@ -26,6 +26,6 @@ void setup() {
   ]);
 }
 
-int set_up_body_parts(object ob, mixed args...) {
+int set_up_body_parts(object _ob, mixed _args...) {
   return use_default_body_parts();
 }

--- a/std/modules/race/gnome.lpc
+++ b/std/modules/race/gnome.lpc
@@ -25,6 +25,6 @@ void setup() {
   ]);
 }
 
-int set_up_body_parts(object ob, mixed args...) {
+int set_up_body_parts(object _ob, mixed _args...) {
   return use_default_body_parts();
 }

--- a/std/modules/race/human.lpc
+++ b/std/modules/race/human.lpc
@@ -24,6 +24,6 @@ void setup() {
   ]);
 }
 
-int set_up_body_parts(object ob, mixed args...) {
+int set_up_body_parts(object _ob, mixed _args...) {
   return use_default_body_parts();
 }

--- a/std/modules/race/orc.lpc
+++ b/std/modules/race/orc.lpc
@@ -26,6 +26,6 @@ void setup() {
   ]);
 }
 
-int set_up_body_parts(object ob, mixed args...) {
+int set_up_body_parts(object _ob, mixed _args...) {
   return use_default_body_parts();
 }

--- a/std/modules/race/race.lpc
+++ b/std/modules/race/race.lpc
@@ -218,11 +218,11 @@ int add_body_part_vitalness(string part, int vitalness_mod) {
   return new_vitalness_mod;
 }
 
-int query_body_part_size_modifier(string part) {
+int query_body_part_size_modifier(string _part) {
   return 0;
 }
 
-int query_body_part_vitalness_modifier(string part) {
+int query_body_part_vitalness_modifier(string _part) {
   return 0;
 }
 
@@ -232,10 +232,10 @@ int query_body_part_vitalness_modifier(string part) {
  * and is a key in the body_parts mapping. Force is an optional argument that
  * will force the function to forgo the check for membership in the body_parts
  * @param {string} part - the body part to check
- * @param {int} [force=0] - optional, default 0
+ * @param {int} [_force=0] - optional, default 0
  * @returns {int} 1 if the body part is valid, 0 otherwise
  */
-int valid_body_part(string part, int force: (: 0 :)) {
+int valid_body_part(string part, int _force: (: 0 :)) {
   if(!stringp(part))
     return 0;
 

--- a/std/modules/race/troll.lpc
+++ b/std/modules/race/troll.lpc
@@ -27,6 +27,6 @@ void setup() {
   ]);
 }
 
-int set_up_body_parts(object ob, mixed args...) {
+int set_up_body_parts(object _ob, mixed _args...) {
   return use_default_body_parts();
 }


### PR DESCRIPTION
Unused parameters in `set_up_body_parts`, `query_body_part_size_modifier`, `query_body_part_vitalness_modifier`, `valid_body_part`, and the `foreach` loop variable in `boon.lpc` have been prefixed with `_` to indicate they are intentionally unused.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR marks intentionally unused LPC parameters and loop variables with an underscore prefix. The main changes are:

- Renames the unused boon mapping key variable.
- Renames unused race body-setup parameters.
- Renames unused body-part modifier and validation parameters.
</details>

<sub>Reviews (1): Last reviewed commit: ["cleanliness"](https://github.com/gesslar/oxidus-mudlib/commit/0e4c2f8b80bcca3033e1b3112e6bddd8590ac450) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46160431)</sub>

**Context used:**

- Rule used - weighted priority system than just "P1, that thing... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=0e553e6b-dbb2-4604-8a43-503f988cc3fd))
- Context used - This repository is Oxidus, a MUD library written i... ([source](.greptile))

<!-- /greptile_comment -->