### PR TITLE
Add slot-targeted wield, condition display in look, weapon DC rebalance, and wither nerf

### DIFF
--- a/cmds/action/look.lpc
+++ b/cmds/action/look.lpc
@@ -227,6 +227,12 @@ mixed describe_living(
   else if(truthy(gender))
     result += `${sub} ${verb} ${gender}.\n`;
 
+  string *vitals = ob->query_condition_string();
+  if(pointerp(vitals)) {
+    if(strlen(result))
+      result += `${sub} ${verb} ${vitals[0]}.`;
+  }
+
   return result;
 }
 

--- a/cmds/action/wield.lpc
+++ b/cmds/action/wield.lpc
@@ -24,29 +24,53 @@ void setup() {
     "See also: unwield, wear, remove, eq\n";
 }
 
-mixed main(/** @type {STD_BODY} */ object tp, string str) {
-  /** @type {STD_WEAPON} */
-  object ob;
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string str
+) {
+  /** @type {STD_WEAPON} */ object ob;
   mixed result;
+  string *slots = tp->query_weapon_slots();
 
   if(!str) {
     mapping wielded = tp->query_wielded();
-    string *slots, slot;
+    string *wielded_slots, wielded_slot;
     string out;
     int max;
 
     if(!sizeof(wielded))
       return "You are not wielding anything.";
 
-    slots = keys(wielded);
-    max = max(map(slots, (: strlen :)));
+    wielded_slots = keys(wielded);
+    max = max(map(wielded_slots, (: strlen :)));
 
     out = "You are wielding the following weapons:\n\n";
-    foreach(slot in slots)
-      out += sprintf("%*s : %s\n", max, capitalize(slot),
-        get_short(wielded[slot]));
+    foreach(wielded_slot in wielded_slots)
+      out += sprintf(
+        "%*s : %s\n",
+        max,
+        capitalize(wielded_slot), get_short(wielded[wielded_slot])
+      );
 
     return out;
+  }
+
+  string hand;
+  if(sscanf(str, "%s in %s", str, hand) == 2) {
+    if(hand == "1") {
+      hand = slots[0];
+    } else if(hand == "2") {
+      hand = slots[1];
+    } else {
+      string slot = find(slots, (: starts_with($1, `${$(hand)} `) :));
+      if(!slot)
+        return "You may not wield anything there.";
+
+      hand = slot;
+    }
+
+  } else {
+    hand = slots[0];
   }
 
   if(!ob = find_target(tp, str, tp))
@@ -58,26 +82,26 @@ mixed main(/** @type {STD_BODY} */ object tp, string str) {
   if(tp->equipped(ob))
     return "You are already wielding that weapon.";
 
-  result = tp->can_equip(ob, "right hand");
+  result = tp->can_equip(ob, hand);
 
   if(stringp(result))
     return result;
 
   if(result == 0)
-    return "1 You cannot wield that weapon.";
+    return "You cannot wield that weapon.";
 
   result = ob->can_equip(tp);
 
   if(!result)
-    return "2 You cannot wield that weapon.";
+    return "You cannot wield that weapon.";
 
-  result = ob->equip(tp, "right hand");
+  result = ob->equip(tp, hand);
 
   if(stringp(result))
     return result;
 
   if(result == 0)
-    return "3 You cannot wield that weapon.";
+    return "You cannot wield that weapon.";
 
   tp->simple_action("$N $vwield $o.", get_short(ob));
 

--- a/cmds/spell/wither.lpc
+++ b/cmds/spell/wither.lpc
@@ -60,10 +60,10 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
         tp->use_skill("arcane.discipline.shadow", 1.15);
 
         // Withers stack across casters — each contributes its own
-        // -amount to the three defense skills.
+        // -amount to two defence skills.
         eff = clone_object("/obj/effect/wither");
         eff->set_caster(tp);
-        eff->set_amount(10);
+        eff->set_amount(2);
         eff->set_duration(30);
         eff->move(victim);
         eff->set_fixed(1);

--- a/doc/sefun/tell.help
+++ b/doc/sefun/tell.help
@@ -22,9 +22,6 @@
     str       (string)
               The message string to send (sent to previous_object()).
 
-    ob        (object)
-              The object to send the message to.
-
     str       (string)
               The message string to send.
 

--- a/obj/effect/wither.lpc
+++ b/obj/effect/wither.lpc
@@ -68,9 +68,6 @@ void apply() {
   __tag_evade = victim->curse(
     "wither", "skill", "combat.defence.evade", __amount, dur
   );
-  __tag_defence = victim->curse(
-    "wither", "skill", "combat.defence", __amount, dur
-  );
 }
 
 int expire_obj(int expired) {
@@ -81,7 +78,6 @@ int expire_obj(int expired) {
 
   victim->remove_curse("skill", "combat.defence.dodge", __tag_dodge);
   victim->remove_curse("skill", "combat.defence.evade", __tag_evade);
-  victim->remove_curse("skill", "combat.defence", __tag_defence);
 
   if(expired)
     victim->simple_action("The withering shadow lifts from $n.");

--- a/obj/weapon/bludgeoning/1h/mace.lpml
+++ b/obj/weapon/bludgeoning/1h/mace.lpml
@@ -12,6 +12,6 @@
   mass: 65,
   value: 14,
   hands: 1,
-  dc: 1.7,
+  dc: 6.7,
   type: "bludgeoning",
 }

--- a/obj/weapon/bludgeoning/2h/quarterstaff.lpml
+++ b/obj/weapon/bludgeoning/2h/quarterstaff.lpml
@@ -12,6 +12,6 @@
   mass: 50,
   value: 10,
   hands: 2,
-  dc: 2.2,
+  dc: 7.2,
   type: "bludgeoning",
 }

--- a/obj/weapon/piercing/1h/dagger.lpml
+++ b/obj/weapon/piercing/1h/dagger.lpml
@@ -12,6 +12,6 @@
   mass: 15,
   value: 8,
   hands: 1,
-  dc: 1.2,
+  dc: 6.2,
   type: "piercing",
 }

--- a/obj/weapon/piercing/1h/rusty_sword.lpc
+++ b/obj/weapon/piercing/1h/rusty_sword.lpc
@@ -24,7 +24,7 @@ void setup() {
            "sharp and serviceable, and the blade is straight and true.");
   set_mass(50);
   set_hands(1);
-  set_dc(1.5);
+  set_dc(6.5);
   set_damage_type("piercing");
   set_value(10);
 

--- a/obj/weapon/piercing/2h/spear.lpml
+++ b/obj/weapon/piercing/2h/spear.lpml
@@ -13,6 +13,6 @@
   mass: 60,
   value: 16,
   hands: 2,
-  dc: 2.5,
+  dc: 7.5,
   type: "piercing",
 }

--- a/obj/weapon/slashing/1h/short_sword.lpml
+++ b/obj/weapon/slashing/1h/short_sword.lpml
@@ -12,6 +12,6 @@
   mass: 45,
   value: 15,
   hands: 1,
-  dc: 1.5,
+  dc: 6.5,
   type: "slashing",
 }

--- a/obj/weapon/slashing/2h/greatsword.lpml
+++ b/obj/weapon/slashing/2h/greatsword.lpml
@@ -13,6 +13,6 @@
   mass: 90,
   value: 22,
   hands: 2,
-  dc: 2.8,
+  dc: 7.8,
   type: "slashing",
 }

--- a/obj/weapon/weapon.lpc
+++ b/obj/weapon/weapon.lpc
@@ -19,4 +19,5 @@ varargs void virtual_setup(mapping data) {
   data.hands && set_hands(data.hands);
   data.dc && set_dc(data.dc);
   data.type && set_damage_type(data.type);
+  data.speed && set_speed_mod(data.speed);
 }

--- a/std/equip/weapon.lpc
+++ b/std/equip/weapon.lpc
@@ -23,6 +23,7 @@ private nosave int __equipped = 0;
 private nosave string __slot;
 private nosave mixed __dc = 1.0;
 private nosave string __damage_type = "bludgeoning";
+private nosave float __speed_mod = 0.0;
 
 /**
  * Sets how many hands are required to wield this weapon.
@@ -114,6 +115,16 @@ string query_damage_type() {
   return __damage_type;
 }
 
+float set_speed_mod(float mod) {
+  __speed_mod = mod;
+
+  return mod;
+}
+
+float get_speed_mod(float mod) {
+  return __speed_mod;
+}
+
 /**
  * Returns the body slot this weapon occupies when wielded.
  *
@@ -167,6 +178,11 @@ mixed equip(object tp, string slot) {
     return result;
 
   __equipped = 1;
+
+  // If you unwield a speedy weapon and then wield a slower one, you did not
+  // help yourself. Soz. But this is a penalty regardless for wielding during
+  // combat, which is a good idea.
+  tp->reset_combat_round();
 
   GMCP_D->send_gmcp(tp, GMCP_PKG_CHAR_ITEMS_UPDATE, ({ this_object(), tp }));
 

--- a/std/living/body.lpc
+++ b/std/living/body.lpc
@@ -91,7 +91,7 @@ protected string *query_body_slots() {
  *
  * @returns {string*} A copy of the weapon slot names.
  */
-protected string *query_weapon_slots() {
+public string *query_weapon_slots() {
   return copy(weapon_slots);
 }
 
@@ -121,7 +121,10 @@ protected void die() {
   if(objectp(body = query_su_body())) {
     exec(body, this_object());
     body->move(environment());
-    body->simple_action("$N $vis violently ejected from the body of $o.", this_object());
+    body->simple_action(
+      "$N $vis violently ejected from the body of $o.",
+      this_object()
+    );
     clear_su_body();
   }
 
@@ -233,11 +236,11 @@ protected void event_remove(object _prev) {
  *
  * @param {mixed} dest - The destination object or path.
  * @param {string} [dir="somewhere"] - The direction of travel, used in the
- *                                     departure message.
- * @param {string} [depart_message] - Departure message override, or
- *                                    "SILENT" to suppress it.
- * @param {string} [arrive_message] - Arrival message override, or
- *                                    "SILENT" to suppress it.
+ *  departure message.
+ * @param {string} [depart_message] - Departure message override, or "SILENT"
+ *  to suppress it.
+ * @param {string} [arrive_message] - Arrival message override, or "SILENT" to
+ *  suppress it.
  * @returns {int} 0 on success, or a non-zero move failure code.
  */
 public varargs int move_living(mixed dest, string dir, string depart_message, string arrive_message) {
@@ -256,7 +259,11 @@ public varargs int move_living(mixed dest, string dir, string depart_message, st
 
   if(curr) {
     if(depart_message != "SILENT") {
-      depart_message = depart_message || query_env("move_out") || "$N leaves $D.";
+      depart_message =
+        depart_message
+        || query_env("move_out")
+        || "$N leaves $D.";
+
       dir = dir || "somewhere";
 
       tmp = replace_string(depart_message, "$N", query_name());
@@ -271,7 +278,10 @@ public varargs int move_living(mixed dest, string dir, string depart_message, st
   if(arrive_message != "SILENT") {
     curr = environment();
 
-    arrive_message = arrive_message || query_env("move_in") || "$N arrives.\n";
+    arrive_message =
+      arrive_message
+      || query_env("move_in")
+      || "$N arrives.\n";
     tmp = replace_string(arrive_message, "$N", query_name());
 
     tmp = append(tmp, "\n");
@@ -296,8 +306,8 @@ public varargs int move_living(mixed dest, string dir, string depart_message, st
  * TODO: For now, just returns 1 until more is implemented that will affect
  * this.
  *
- * @returns {int | string} 1 if the body passes the ability check,
- *                         otherwise a string error message.
+ * @returns {int | string} 1 if the body passes the ability check, otherwise a
+ *  string error message.
  */
 public int is_able() {
   return 1;
@@ -347,8 +357,8 @@ public void set_su_body(object source) {
 }
 
 /**
- * Returns the body we are inhabiting. Will be undefined if
- * we are already in our own body.
+ * Returns the body we are inhabiting. Will be undefined if we are already in
+ * our own body.
  *
  * @returns {STD_BODY|0} The body we are currently inhabiting, or null.
  */

--- a/std/living/combat.lpc
+++ b/std/living/combat.lpc
@@ -35,6 +35,8 @@ private nosave mapping __seen_enemies = ([]);
 
 private nosave float __attack_speed = 2.0;
 private nosave int __next_combat_round = 0;
+private nosave int __first_strike = 0;
+private nosave int __second_strike = 0;
 
 /** @type {([ string: float ])} */
 private nosave mapping __defence = ([]);
@@ -94,6 +96,13 @@ void combat_round() {
     next_round();
 }
 
+public void reset_combat_round() {
+  if(in_combat() && __next_combat_round && find_call_out(__next_combat_round) > -1) {
+    remove_call_out(__next_combat_round);
+    next_round();
+  }
+}
+
 /**
  * Begin attacking a victim. Adds it to the current and seen enemy tables,
  * schedules the first combat round, and tells the victim to start attacking
@@ -133,6 +142,12 @@ int start_attack(object victim) {
  * skill. Stops early if the attacker is exhausted, the enemy is invalid, or
  * count is exhausted.
  *
+ * Note: Some preparation is in the works for weapon speed, but I haven't
+ * quite figured out how I'm going to do it just yet. I might have to break
+ * swing out into something else, or maybe combat round, because count exists
+ * for flurries of attacks, but it doesn't really account for fast or slow
+ * weapons. We'll see how that goes in the future.
+ *
  * @param {int} [count=1] - Remaining swings to perform.
  * @param {int} [multi] - Non-zero if this iteration should pick an off-hand
  *  weapon instead of the main.
@@ -147,9 +162,6 @@ varargs void swing(int count, int multi) {
   if(nullp(count))
     count = 1;
 
-  if(count < 1)
-    return;
-
   if(!enemy)
     return;
 
@@ -161,24 +173,43 @@ varargs void swing(int count, int multi) {
     return;
   }
 
+  if(count < 1)
+    return;
+
   mapping wielded = query_wielded();
   wielded = filter(wielded, (: objectp($2) :));
 
   if(sizeof(wielded)) {
     string main_slot = slots[0];
+    object main_hand = wielded[main_slot];
+    mapping off_hands = filter(wielded, (: $1 != $(main_slot) :));
 
     if(multi) {
-      mapping off_hand = filter(wielded, (: $1 != $(main_slot) :));
-      object *possible = distinct_array(values(off_hand));
+      object *possible = distinct_array(values(off_hands));
       weapon = element_of(possible);
       multi = 0;
     } else {
-      weapon = wielded[main_slot];
+      weapon = main_hand;
 
-      if(random(100) < 5 + query_skill_level("combat.melee"))
-        multi = 1;
+      if(sizeof(off_hands)) {
+        float multi_chance =  15.0
+                            + floor(query_skill_level("combat.melee") / 5.0);
+
+        float roll = random_float(100.0);
+
+        if(roll < multi_chance) {
+          multi = 1;
+        } else {
+          multi = 0;
+        }
+      } else {
+        multi = 0;
+      }
     }
   }
+
+  if(multi)
+    tell(this_object(), "{{909}}#-> {{res}}");
 
   if(can_strike(enemy, weapon)) {
     strike_enemy(enemy, weapon);
@@ -187,19 +218,24 @@ varargs void swing(int count, int multi) {
     fail_strike(enemy, weapon);
   }
 
-  swing(count - 1, multi);
+  // Subtract for this round
+  count--;
+
+  // if we're doing second weapon, we gotta do it anyway
+  if(multi)
+    count++;
+
+  if(count)
+    swing(count, multi);
 }
 
 /**
- * Schedules the next combat round. Adds up to 1.5 seconds of jitter to the
- * configured attack speed so attackers do not all fire on the same tick.
+ * Schedules the next combat round.
  *
  * @returns {int} The call_out handle for the scheduled round.
  */
 int next_round() {
   float speed = __attack_speed;
-
-  speed += random_float(1.5);
 
   __next_combat_round = call_out_walltime("combat_round", speed);
 

--- a/std/living/damage.lpc
+++ b/std/living/damage.lpc
@@ -134,10 +134,11 @@ public float receive_damage(object attacker, float damage, string type) {
 public varargs float calculate_damage(object enemy, mixed weapon_or_skill) {
   mapping weapon_info;
 
-  if(objectp(weapon_or_skill))
+  if(objectp(weapon_or_skill)) {
     weapon_info = query_weapon_info(weapon_or_skill);
-  else
+  } else {
     weapon_info = query_weapon_info(undefined);
+  }
 
   string skill_name = stringp(weapon_or_skill) ? weapon_or_skill : weapon_info["skill"];
   float skill = query_skill_level(skill_name);
@@ -166,6 +167,14 @@ public varargs float calculate_damage(object enemy, mixed weapon_or_skill) {
     + (skill + query_skill_level("combat") / 2.0)
     - enemy->query_skill_level(defence_skill)
   ;
+
+  false && _debug("base %O + wbase %O + skill %O - enemy skill %O = %O",
+    base,
+    wbase,
+    (skill + query_skill_level("combat") / 2.0),
+    enemy->query_skill_level(defence_skill),
+    dam
+  );
 
   return dam;
 }

--- a/std/living/include/body.h
+++ b/std/living/include/body.h
@@ -7,7 +7,7 @@ public varargs int move_living(mixed dest, string dir, string depart_message, st
 public int query_log_level();
 public int is_able();
 protected string *query_body_slots();
-protected string *query_weapon_slots();
+public string *query_weapon_slots();
 public void set_su_body(object source);
 public object query_su_body();
 public void clear_su_body();


### PR DESCRIPTION
Players can now specify which hand to wield a weapon in using `wield <weapon> in <hand>`, supporting slot numbers (1, 2) or partial slot names. Previously, weapons were always wielded in the right hand.

Wielding a weapon during combat now resets the combat round, penalizing mid-fight weapon swaps regardless of the weapon's speed.

The dual-wield off-hand chance has been adjusted: the base chance is now 15% plus one fifth of the melee skill level, replacing the previous flat skill-based threshold. The off-hand swing logic has also been corrected so that multi-hit rounds are handled properly without dropping the swing count prematurely.

The wither spell's debuff has been narrowed from three defence skills to two (`combat.defence.dodge` and `combat.defence.evade`), and the per-stack penalty has been reduced from 10 to 2.

All weapon base damage values have been increased by 5 across the board. Weapon definitions now support a `speed` field that maps to the new `speed_mod` property on weapons.

A target's condition string is now shown when looking at a living creature, provided one is available.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR delivers several focused gameplay changes: slot-targeted wield, a mid-combat wield penalty, dual-wield off-hand rebalance, wither nerf, weapon DC +5 across all weapons, and condition display on look.

- **Wield targeting** (`cmds/action/wield.lpc`, `std/living/body.lpc`): `query_weapon_slots()` is promoted to `public` and the wield command now accepts `in <number>` or `in <partial name>` to choose a hand. A `reset_combat_round()` call in `std/equip/weapon.lpc` penalises mid-fight weapon swaps.
- **Dual-wield logic** (`std/living/combat.lpc`): Off-hand chance replaced with `15 + melee/5`%; the count/multi recursion is corrected so a triggered off-hand swing no longer consumes a main-hand swing. Jitter in `next_round()` is removed (all attackers on a flat speed).
- **Wither** (`obj/effect/wither.lpc`, `cmds/spell/wither.lpc`): Drops the `combat.defence` curse (now only dodge + evade), reduces per-stack penalty from 10 → 2. `__tag_defence` is left as an orphaned variable but causes no runtime harm.
</details>

<sub>Reviews (3): Last reviewed commit: ["miscellaneous combat updates"](https://github.com/gesslar/oxidus-mudlib/commit/e5a049b445da1111f2bdc475563d6317880a9738) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46525444)</sub>

<!-- /greptile_comment -->