### PR TITLE
Fix two-handed weapon off-hand swing logic, disable debug tells, and block selling equipped or container items

### DIFF
--- a/adm/daemons/advance.lpc
+++ b/adm/daemons/advance.lpc
@@ -107,7 +107,7 @@ public int earn_xp(object tp, int amount) {
  *
  * @public
  * @param {STD_PLAYER} killer - The object that killed the opponent.
- * @param {STD_NPC | STD_PLAYER} killed - The object that was killed.
+ * @param {STD_BODY} killed - The object that was killed.
  * @returns {int} The amount of XP awarded, or 0 if either object is null.
  */
 int kill_xp(object killer, object killed) {

--- a/std/ext/shop.lpc
+++ b/std/ext/shop.lpc
@@ -312,7 +312,7 @@ mixed cmd_buy(object tp, string str) {
  *                         allowed, or an error message on failure.
  */
 mixed cmd_sell(object tp, string str) {
-  /** @type {STD_ITEM | STD_ARMOUR | STD_CLOTHING | STD_WEAPON} */ object ob;
+  object ob;
   /** @type {STD_ITEM*} */ object *obs;
   int sz;
   int use_mass = mud_config("USE_MASS");
@@ -353,13 +353,15 @@ mixed cmd_sell(object tp, string str) {
     int coins = sum(values(value));
     string mess, *list;
 
+    if(/** @type {STD_ARMOUR | STD_CLOTHING | STD_WEAPON} */ (ob)->equipped())
+      continue;
+    if(/** @type {STD_CONTAINER} */ (ob)->is_container())
+      continue;
+
     if(!cost) {
       tell(tp, "The shop refuses to buy your " + short + ".\n");
       continue;
     }
-
-    if(/** @type {STD_ARMOUR|STD_CLOTHING|STD_WEAPON} */ (ob)->equipped())
-      continue;
 
     if(use_mass) {
       int fill = tp->query_fill();

--- a/std/living/combat.lpc
+++ b/std/living/combat.lpc
@@ -153,7 +153,8 @@ int start_attack(object victim) {
  *  weapon instead of the main.
  */
 varargs void swing(int count, int multi) {
-  multi = !!multi;
+  int off_hand_swing = !!multi;
+  int next_multi = 0;
 
   object enemy = highest_threat();
   object weapon;
@@ -182,12 +183,15 @@ varargs void swing(int count, int multi) {
   if(sizeof(wielded)) {
     string main_slot = slots[0];
     object main_hand = wielded[main_slot];
-    mapping off_hands = filter(wielded, (: $1 != $(main_slot) :));
+    // A two-handed weapon occupies every slot it needs with the same object,
+    // so exclude the main hand by object as well as by slot.
+    mapping off_hands = filter(wielded,
+      (: $1 != $(main_slot) && $2 != $(main_hand) :));
 
-    if(multi) {
+    if(off_hand_swing) {
       object *possible = distinct_array(values(off_hands));
+
       weapon = element_of(possible);
-      multi = 0;
     } else {
       weapon = main_hand;
 
@@ -197,22 +201,14 @@ varargs void swing(int count, int multi) {
 
         float roll = random_float(100.0);
 
-        if(roll < multi_chance) {
-          multi = 1;
-        } else {
-          multi = 0;
-        }
-      } else {
-        multi = 0;
+        if(roll < multi_chance)
+          next_multi = 1;
       }
     }
   }
 
-  if(multi)
-    tell(this_object(), "{{909}}#-> {{res}}");
-
   if(can_strike(enemy, weapon)) {
-    strike_enemy(enemy, weapon);
+    strike_enemy(enemy, weapon, off_hand_swing);
   } else {
     enemy->use_skill("combat.defence.dodge");
     fail_strike(enemy, weapon);
@@ -222,11 +218,11 @@ varargs void swing(int count, int multi) {
   count--;
 
   // if we're doing second weapon, we gotta do it anyway
-  if(multi)
+  if(next_multi)
     count++;
 
   if(count)
-    swing(count, multi);
+    swing(count, next_multi);
 }
 
 /**
@@ -347,7 +343,7 @@ private fail_strike(object enemy, object weapon) {
  * @param {STD_WEAPON} [weapon] - The weapon used, or null for unarmed
  *                          or NPC defaults.
  */
-void strike_enemy(object enemy, object weapon) {
+void strike_enemy(object enemy, object weapon, int off_hand) {
   if(!valid_enemy(enemy))
     return;
 
@@ -369,6 +365,9 @@ void strike_enemy(object enemy, object weapon) {
 
   string mess = MESS_D->get_message("combat", wtype, to_int(ceil(dam)));
   string *messes = ACTION_D->action(({ this_object(), enemy }), mess, ({wname}));
+
+  if(off_hand)
+    tell(this_object(), "{{909}}#-> {{res}}");
 
   tell(this_object(), messes[0], MSG_COMBAT_HIT);
   tell(enemy, messes[1], MSG_COMBAT_HIT);

--- a/std/living/damage.lpc
+++ b/std/living/damage.lpc
@@ -51,7 +51,10 @@ public float deliver_damage(object victim, float damage, string type) {
     return 0;
 
   float received = victim->receive_damage(this_object(), damage, type);
+
+#if 0
   tell(this_object(), sprintf("delivering %O %O damage => %O\n", damage, type, received));
+#endif
 
   return received;
 }
@@ -86,7 +89,9 @@ public float receive_damage(object attacker, float damage, string type) {
   float new_damage = damage;
 
   if(damage < 0.0) {
+#if 0
     tell(this_object(), sprintf("receiving %O %O damage => %O\n", damage, type, new_damage));
+#endif
     return 0.0;
   }
 
@@ -109,7 +114,9 @@ public float receive_damage(object attacker, float damage, string type) {
   // The damage is reduced by the level modifier
   new_damage -= red;
 
+#if 0
   tell(this_object(), sprintf("receiving %O %O damage => %O\n", damage, type, new_damage));
+#endif
 
   if(new_damage < 0.0)
     new_damage = 0.0;
@@ -168,6 +175,7 @@ public varargs float calculate_damage(object enemy, mixed weapon_or_skill) {
     - enemy->query_skill_level(defence_skill)
   ;
 
+#if 0
   false && _debug("base %O + wbase %O + skill %O - enemy skill %O = %O",
     base,
     wbase,
@@ -175,6 +183,7 @@ public varargs float calculate_damage(object enemy, mixed weapon_or_skill) {
     enemy->query_skill_level(defence_skill),
     dam
   );
+#endif
 
   return dam;
 }

--- a/std/living/include/combat.h
+++ b/std/living/include/combat.h
@@ -7,7 +7,7 @@ varargs void swing(int count, int multi);
 int next_round();
 public int can_strike(object enemy, mixed weapon);
 private fail_strike(object enemy, object weapon);
-void strike_enemy(object enemy, object weapon);
+public varargs void strike_enemy(object enemy, object weapon, int off_hand);
 mapping query_weapon_info(object weapon);
 int attacking(object victim);
 varargs int stop_attack(object victim, int seen);


### PR DESCRIPTION
## Combat & Shop Improvements

### Off-Hand Weapon Fix
Two-handed weapons occupy multiple slots with the same object reference. Previously, off-hand filtering only excluded slots by name, meaning a two-handed weapon could incorrectly appear as an off-hand option. Off-hand candidates are now filtered by both slot name and object identity, preventing two-handed weapons from being treated as off-hand weapons.

### Off-Hand Swing Indicator
The `#->` indicator that signals an off-hand swing has been moved from `swing()` to `strike_enemy()`, so it only appears when the off-hand strike actually lands rather than when it is merely attempted. `strike_enemy()` now accepts an `off_hand` parameter and is marked `public varargs` to reflect this.

### Variable Clarity in `swing()`
The `multi` variable has been split into `off_hand_swing` (whether the current swing is an off-hand attack) and `next_multi` (whether the next swing should be an off-hand attack), making the intent of each value unambiguous.

### Shop: Block Selling Equipped or Container Items
The sell command now checks whether an item is equipped or is a container before evaluating its cost, rather than only checking equipped status after the cost check. This prevents containers from being sold and ensures equipped/container checks happen before any other sell logic.

### Debug Logging Disabled
Diagnostic `tell()` and `_debug()` calls in `damage.lpc` have been wrapped in `#if 0` blocks to suppress them without removing them.

### Minor Doc Fix
The `kill_xp` parameter type annotation has been corrected from `STD_NPC | STD_PLAYER` to `STD_BODY`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Corrects combat and shop eligibility behavior while suppressing diagnostic output.
- Excludes a two-handed weapon’s duplicate slot references from off-hand selection and emits the off-hand marker only for successful strikes.
- Separates current and next off-hand swing state and extends `strike_enemy()` with an optional off-hand indicator.
- Prevents equipped objects and containers from being sold.
- Disables combat damage diagnostics and corrects the documented type for killed bodies.
</details>

<sub>Reviews (1): Last reviewed commit: ["more miscellaneous combat updates"](https://github.com/gesslar/oxidus-mudlib/commit/edd83fab0f05ec9527fd75a2db021f755fe499b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46766996)</sub>

**Context used:**

- Knowledge Base — [Living and Player](https://app.greptile.com/gesslar/-/custom-context/knowledge-base/gesslar/oxidus-mudlib/-/docs/living-and-player.md)
- Knowledge Base — [Object and Item System](https://app.greptile.com/gesslar/-/custom-context/knowledge-base/gesslar/oxidus-mudlib/-/docs/object-and-item-system.md)

<!-- /greptile_comment -->