### PR TITLE
Rename `mudlib_setup` to `std_setup` in body and remove redundant call in NPC

### DIFF
--- a/std/living/body.lpc
+++ b/std/living/body.lpc
@@ -42,7 +42,7 @@ inherit __DIR__ "wealth";
 inherit EXT_ACTION;
 inherit EXT_LOG;
 
-void mudlib_setup() {
+void std_setup() {
   if(!clonep() &&
      origin() != ORIGIN_LOCAL &&
      previous_object() != body_d()

--- a/std/living/npc.lpc
+++ b/std/living/npc.lpc
@@ -16,8 +16,6 @@ inherit STD_NPC_PROC;
 inherit __DIR__ "living";
 
 void mudlib_setup() {
-  ::mudlib_setup();
-
   init_living();
 
   if(clonep()) {


### PR DESCRIPTION
Renames `mudlib_setup()` to `std_setup()` in `body.lpc` and removes the explicit `::mudlib_setup()` call from `npc.lpc`, relying on `init_living()` directly instead.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Renames the shared body initialization hook to `std_setup()` and removes the now-redundant inherited setup call from NPC initialization.
- Moves shared body initialization into the standard setup stage.
- Keeps NPC living initialization and clone-specific setup in `mudlib_setup()`.
</details>

<sub>Reviews (2): Last reviewed commit: ["updating livings lifecycles"](https://github.com/gesslar/oxidus-mudlib/commit/4ca2cecaeb09e6f74e41c2fa2bd89515b47a6cb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46794263)</sub>

<!-- /greptile_comment -->