### PR TITLE
Updating file header documentations re: Rename `mudlib_setup` to `std_setup` in body and update NPC header and lifecycle comment

### DIFF
--- a/std/living/body.lpc
+++ b/std/living/body.lpc
@@ -4,11 +4,15 @@
  * Body object that is shared by players and NPCs.
  *
  * @created 2024-07-29 - Gesslar
- * @last_modified 2026-07-04 - Gesslar
+ * @last_modified 2026-07-23 - Gesslar
  *
  * @history
  * 2024-07-29 - Gesslar - Created
  * 2026-07-04 - Gesslar - Applied coding style and documentation
+ * 2026-07-23 - Gesslar - Renamed mudlib_setup() to std_setup(). It will now
+ *                        run before mudlib_setup() so inheritors will not need
+ *                        to make super calls.
+ *
  */
 
 #include <body.h>

--- a/std/living/npc.lpc
+++ b/std/living/npc.lpc
@@ -1,10 +1,16 @@
-/* npc.c
-
- Tacitus @ LPUniversity
- 28-JUNE-06
- Non-player character
-
-*/
+/**
+ * @file /std/living/npc.lpc
+ *
+ * NPC logic.
+ *
+ * @created ????-??-?? - Gesslar
+ * @last_modified 2026-07-23 - Gesslar
+ *
+ * @history
+ * ????-??-?? - Gesslar - Created
+ * 2026-07-23 - Gesslar - Removed the super call, since `STD_BODY` now handles
+ *                        lifecycle through std_setup().
+ */
 
 #include <npc.h>
 #include <logs.h>


### PR DESCRIPTION
Updating file header documentations re: Renames `mudlib_setup()` to `std_setup()` in `STD_BODY` so that base initialization runs before `mudlib_setup()`, eliminating the need for inheritors to make explicit super calls. Updates `npc.lpc` to remove the now-unnecessary super call and modernizes its file header to match current documentation standards.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates lifecycle documentation in the living body and modernizes the NPC file header.
- Documents that `std_setup()` runs before inheritor-defined `mudlib_setup()`.
- Replaces the legacy NPC header with current file and lifecycle documentation.
</details>

<sub>Reviews (1): Last reviewed commit: ["updating headers"](https://github.com/gesslar/oxidus-mudlib/commit/20e78628936e054dea140cb4dd8de5abaaea9201) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46796698)</sub>

<!-- /greptile_comment -->