### PR TITLE
Comment out combat chance debug statements

### DIFF
--- a/std/living/combat.lpc
+++ b/std/living/combat.lpc
@@ -296,9 +296,9 @@ public int can_strike(object enemy, mixed weapon) {
           - enemy->query_skill_level(defence_skill)
   ;
 
-  debug("->  Chance = %O", chance);
+  //debug("->  Chance = %O", chance);
   chance = 50.0 + dim_sigmoid(chance - 50.0, 45.0, 0.03);
-  debug("->> Chance = %O", chance);
+  // debug("->> Chance = %O", chance);
   result = random_float(100.0);
 
   enemy->use_skill(defence_skill);


### PR DESCRIPTION
Commented out debug logging statements in the `can_strike` function that were printing hit chance values during combat calculations.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Disables two combat hit-chance debug messages without changing chance calculation, skill use, or strike resolution.
</details>

<sub>Reviews (1): Last reviewed commit: ["commenting out debug code"](https://github.com/gesslar/oxidus-mudlib/commit/ade55cf7e60b4ac9dae3621e0cf0308bcf9628db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46911733)</sub>

**Context used:**

- Knowledge Base — [Living and Player](https://app.greptile.com/gesslar/-/custom-context/knowledge-base/gesslar/oxidus-mudlib/-/docs/living-and-player.md)

<!-- /greptile_comment -->