### PR TITLE
Refactor master.lpc with modern syntax, clean up headers, remove dead code, and reformat time simul_efuns

### DIFF
--- a/adm/obj/login.lpc
+++ b/adm/obj/login.lpc
@@ -112,7 +112,7 @@ public void gmcp_authenticated(string _username, string char) {
     write_file(
       log_dir() + LOG_LOGIN,
       capitalize(old_body->query_real_name()) + " reconnected from " +
-        query_ip_number(this_object()) + " on " + ctime(time()) + "\n"
+        query_ip_number(this_object()) + " on " + ldatetime() + "\n"
     );
 
     if(interactive(old_body)) {
@@ -395,7 +395,7 @@ private void character_menu_input(string str, string prompt) {
   write_file(
     log_dir() + LOG_LOGIN,
     capitalize(characters[i]) + " logged in from " +
-    query_ip_number(this_object()) + " on " + ctime(time()) + "\n"
+    query_ip_number(this_object()) + " on " + ldatetime() + "\n"
   );
 
   enter_world(characters[i], 0);
@@ -443,7 +443,7 @@ private void new_character(string str) {
   write_file(
     log_dir() + LOG_LOGIN,
     capitalize(str) + " logged in from " +
-    query_ip_number(this_object()) + " on " + ctime(time()) + "\n"
+    query_ip_number(this_object()) + " on " + ldatetime() + "\n"
   );
 
   assure_dir(str);
@@ -495,7 +495,7 @@ private void reconnect(string str, string name) {
     write_file(
       log_dir() + LOG_LOGIN,
       capitalize(body->query_real_name()) + " reconnected from " +
-      query_ip_number(this_object()) + " on " + ctime(time()) + "\n"
+      query_ip_number(this_object()) + " on " + ldatetime() + "\n"
     );
 
     if(interactive(body)) {
@@ -511,7 +511,7 @@ private void reconnect(string str, string name) {
     write_file(
       log_dir() + LOG_LOGIN,
       capitalize(str) + " logged in from " + query_ip_number(this_object()) +
-      " on " + ctime(time()) + "\n"
+      " on " + ldatetime() + "\n"
     );
 
     enter_world(name, 0);
@@ -675,7 +675,7 @@ private string parse_tokens(string text) {
       ", and " + filter(users()->query_name(),
       (: $1 != "login" :))[<1]);
     text = replace_string(text, "%user_count", "" + sizeof(users()));
-    text = replace_string(text, "%date", ctime(time()));
+    text = replace_string(text, "%date", ldatetime());
     text = replace_string(text, "%open_status", open_status());
     text = replace_string(text, "%email", admin_email());
     text = replace_string(text, "%lib_name", lib_name());

--- a/adm/obj/master.lpc
+++ b/adm/obj/master.lpc
@@ -1,20 +1,18 @@
-/* master.c
+/**
+ * @file /adm/obj/master.lpc
+ *
+ * Short description of this file and its purpose.
+ *
+ * @rewritten 2026-07-24 - Gesslar
+ * @last_modified 2026-07-24 - Gesslar
+ *
+ * @history
+ * 2026-07-24 - Gesslar - Rewritten from legacy LPU.
+ */
 
- Tacitus @ LPUniversity
- April 15th, 2005
- master object
 
- Last edited on July 14th, 2006 by Tacitus
-
-*/
-
-/* Preprocessor Statement */
-
-#include <localtime.h>
 #include <logs.h>
 #include <shutdown.h>
-
-/* inherits */
 
 inherit __DIR__ "master/security";
 
@@ -121,52 +119,44 @@ protected void epilog(int _load_empty) {
 
   for(i = 0; i < sizeof(lines); i++) {
     out = "";
-    out += "Preloading : " + lines[i] + "...";
+    out += `Loading object ${lines[i]}: `;
     time = time_frac();
     err = catch(ob = load_object(lines[i]));
     if(err != 0) {
-      out += "\nError " + err + " when loading " + lines[i];
+      out += `${err}`;
     } else {
-      out += sprintf(" Done (%.2fs)", time_frac() - time);
+      out += `OK`;
     }
 
     if(!lpcshell)
       debug_message(out);
   }
 
+  // The boot daemon will have loaded by now from preload.
   emit(SIG_SYS_BOOT);
 }
 
-void tune_into_error() {
-  // CHAN_D->tune("error", query_privs(), 1);
-}
-
 protected void log_error(string _file, string message) {
+  object tp = this_body();
   string username;
 
-  if(this_body())
-    username = query_privs(this_body());
+  if(tp)
+    username = query_privs(tp);
   else
     username = "(none)";
 
-  if(stringp(username)) {
-    string path = home_path(username);
-    if(directory_exists(path)) {
-      write_file(path + "log", "\n" + message);
-    }
-
-    if(devp(this_body())) {
-        if(this_body()->query_pref("error_output") != "off")
-          tell_me(message);
-      }
+  string path = home_path(username);
+  if(directory_exists(path)) {
+    write_file(`${path}log`, `\n${message}`);
   }
 
-  log_file("compile",
-    "---\n" +
-    ctime() + "\n" +
-    message + "\n" +
-    call_trace()
-  );
+  if(tp && devp(tp)) {
+    if(tp->query_pref("error_output") != "off") {
+      tell(tp, message);
+    }
+  }
+
+  log_file("compile",`---\n${ldatetime()}\n${message}\n${call_trace()}`);
 }
 
 // Blatanly stolen from Lima
@@ -189,11 +179,11 @@ string trace_line(object obj, string prog, string file, int line) {
 
   ret = objfn;
   if(different(objfn, prog))
-    ret += sprintf(" (%s)", prog);
+    ret += ` (${prog})`;
   if(file != prog)
-    ret += sprintf(" at %s:%d\n", file, line);
+    ret += ` ${file}:${line}\n`;
   else
-    ret += sprintf(" at line %d\n", line);
+    ret += ` at line ${line}\n`;
 
   return ret;
 }
@@ -203,7 +193,7 @@ varargs string standard_trace(mapping mp, int flag) {
   mapping *trace;
   int i, n;
 
-  ret = ctime(time());
+  ret = `${ldatetime()}`;
   ret += "\n";
   ret += mp["error"] + "Object: " + trace_line(mp["object"], mp["program"], mp["file"], mp["line"]);
   ret += "\n";
@@ -242,94 +232,37 @@ void error_handler(mapping mp, int caught) {
   write_file(logfile, ret);
 
   // TODO Temporary notifications, undo when above fixed
-  message("error", sprintf("(%s) Error logged %s\n%s\n",
-    logfile,
-    ret,
-    trace_line(mp["object"], mp["program"], mp["file"], mp["line"])
-), filter(users(), (: devp :)));
+  message("error",
+    `(${logfile} Error logged ${ret}\n`
+    `${trace_line(mp["object"], mp["program"], mp["file"], mp["line"])}`,
+    filter(users(), (: devp :))
+  );
 }
 
-#if 0
-void error_handler(mapping mp, int caught) {
-    string ret;
-    string logfile = caught ? mud_config("LOG_CATCH") : mud_config("LOG_RUNTIME");
-    string what = mp["error"];
-    string userid;
-
-    ret = "---\n" + standard_trace(mp, 1);
-    write_file(logfile, ret);
-
-    // If an object didn't load, they get compile errors. Don't spam
-    // or confuse them
-    // if(what[0..23] == "*Error in loading object")
-    //     return;
-
-    if(this_body()) {
-        userid = query_privs(this_body());
-        if(!userid || userid == "")
-            userid = "(none)";
-        printf("%sTrace written to %s\n", what, logfile);
-        errors[userid] = mp;
-    } else {
-        userid = "(none)";
-    }
-    errors["last"] = mp;
-
-    // Strip trailing \n, and indent nicely
-    what = replace_string(what[0.. < 2], "\n", "\n         *");
-
-    // TODO: This isn't working for some reason, so we'll return to this
-    // temporarily notifying all admins of errors in real time, regardless
-    // of the kind.
-#if 0
-    CHAN_D->chat(
-        "error",
-        query_privs(),
-        sprintf("(%s) Error logged %s\n%s\n",
-            logfile,
-            what,
-            trace_line(mp["object"], mp["program"], mp["file"], mp["line"])
-        )
-    );
-#endif
-    // TODO: Temporary notifications, undo when above fixed
-    // message("error", sprintf("(%s) Error logged %s\n%s\n",
-    //     logfile,
-    //     ret,
-    //     trace_line(mp["object"], mp["program"], mp["file"], mp["line"])
-    // ), filter(users(), (: devp :)));
-
-}
-#endif
 private void crash(string crash_message, object command_giver, object current_object) {
   string mess;
 
   emit(SIG_SYS_CRASH);
 
-  shout(
-    "Master object shouts: Damn!\n"
-    "Master object tells you: The game is crashing.\n"
-  );
+  shout(`${mud_name()} is crashing.\n`);
 
   // This is to allow all pending messages to be printed
   // https://www.fluffos.info/efun/system/flush_messages.html
   flush_messages();
 
-  mess = MUD_NAME + " crashed on: " + ctime(time()) + ", error: " + crash_message + "\n";
+  mess = `${MUD_NAME} crashed on ${ldatetime()}, error: ${crash_message}\n`;
 
   log_file("shutdown", mess);
   log_file("crashes", mess);
 
   if(command_giver) {
-    log_file("crashes", "this_player: " +
-      file_name(command_giver) + " :: " +
-      query_privs(command_giver) +
-      "\n"
+    log_file("crashes",
+      `command giver: ${command_giver} (${query_privs(command_giver)})\n`
     );
   }
 
   if(current_object)
-    log_file("crashes", "this_object: " + file_name(current_object) + "\n");
+    log_file("crashes", `current object: ${current_object}\n`);
 }
 
 // This doesn't actually seem to work and generates *Too long evaluation.

--- a/adm/obj/master/security.lpc
+++ b/adm/obj/master/security.lpc
@@ -35,11 +35,10 @@
  * adm/obj/master.lpc->privs_file(string filename) decides what objects
  * identify as when loaded.
  *
- * @created 2005-04-23 - Tacitus
+ * @rewritten 2026-06-16 - Gesslar
  * @last_modified 2026-06-16 - Gesslar
  *
  * @history
- * 2005-04-23 - Tacitus - Created as valid.c
  * 2026-06-16 - Gesslar - Rebuilt as the role/group security model
  */
 

--- a/adm/obj/simul_efun.lpc
+++ b/adm/obj/simul_efun.lpc
@@ -1,9 +1,3 @@
-//simul_efun.c
-
-//Tacitus @ LPUniversity
-//02-APR-05
-//Simul-efun object
-
 // Last Change: 2022/08/23: Gesslar
 // Order does not matter.
 // 1. When adding new simul_efuns, prototype them in /adm/obj/simul_efun.h

--- a/adm/simul_efun/file.lpc
+++ b/adm/simul_efun/file.lpc
@@ -165,7 +165,7 @@ varargs string tail(string path, int line_count) {
  * @param {mixed} [arg] - Optional formatting arguments
  * @returns {int} 1 on success, 0 on failure
  * @example
- * log_file("system.log", "Server started at %s", ctime());
+ * log_file("system.log", "Server started at %s", ldatetime());
  */
 varargs int log_file(string file, string str, mixed arg...) {
   if(!file || !str)

--- a/adm/simul_efun/time.lpc
+++ b/adm/simul_efun/time.lpc
@@ -9,19 +9,20 @@
  * @returns {string} The formatted date string.
  */
 varargs string ldate(int x, int brief) {
-    string fmt;
+  x ??= time();
 
-    if(nullp(x)) x = time();
+  if(x == 1) {
+    brief = 1;
+    x = time();
+  }
 
-    if(x == 1) {
-        brief = 1;
-        x = time();
-    }
+  string fmt;
+  if(brief)
+    fmt = "%m-%d";
+  else
+    fmt = "%Y-%m-%d";
 
-    if(brief) fmt = "%m-%d";
-    else fmt = "%Y-%m-%d";
-
-    return strftime(fmt, x);
+  return strftime(fmt, x);
 }
 
 /**
@@ -33,19 +34,21 @@ varargs string ldate(int x, int brief) {
  * @returns {string} The formatted time string.
  */
 varargs string ltime(int x, int brief) {
-    string fmt;
+  x ??= time();
 
-    if(nullp(x)) x = time();
+  if(x == 1) {
+    brief = 1;
+    x = time();
+  }
 
-    if(x == 1) {
-        brief = 1;
-        x = time();
-    }
+  string fmt;
 
-    if(brief) fmt = "%H:%M";
-    else fmt = "%H:%M:%S";
+  if(brief)
+    fmt = "%H:%M";
+  else
+    fmt = "%H:%M:%S";
 
-    return strftime(fmt, x);
+  return strftime(fmt, x);
 }
 
 /**
@@ -58,33 +61,33 @@ varargs string ltime(int x, int brief) {
  *                          time format (YYYY-MM-DD HH:MM:SS).
  */
 varargs string ldatetime(int x, int brief) {
-    return ldate(x, brief) + " " + ltime(x, brief);
+  return ldate(x, brief) + " " + ltime(x, brief);
 }
 
 /**
- * Converts a time value from nanoseconds to milliseconds.
- * This function takes a time value in nanoseconds and converts it
- * to milliseconds by dividing the input by 1,000,000.
+ * Converts a time value from nanoseconds to milliseconds. This function takes
+ * a time value in nanoseconds and converts it to milliseconds by dividing the
+ * input by 1,000,000.
  *
  * @param {int} nanoseconds - The time value in nanoseconds. Defaults to the
  *                            current time in nanoseconds if not provided.
  * @returns {int} The time value converted to milliseconds.
  */
 varargs int time_ms(int nanoseconds) {
-    nanoseconds = nanoseconds || time_ns();
-    return nanoseconds / 1_000_000;
+  nanoseconds = nanoseconds || time_ns();
+  return nanoseconds / 1_000_000;
 }
 
 /**
  * Converts a time value from nanoseconds to a fractional value in seconds.
- * This function takes a time value in nanoseconds and converts it to
- * a fractional value representing seconds by dividing the input by 1,000,000,000.
+ * This function takes a time value in nanoseconds and converts it to a
+ * fractional value representing seconds by dividing the input by 1,000,000,000.
  *
  * @param {int} nanoseconds - The time value in nanoseconds. Defaults to the current
  *                            time in nanoseconds if not provided.
  * @returns {float} The time value converted to a fractional value in seconds.
  */
 varargs float time_frac(int nanoseconds) {
-    nanoseconds = nanoseconds || time_ns();
-    return nanoseconds / 1_000_000_000.0;
+  nanoseconds = nanoseconds || time_ns();
+  return nanoseconds / 1_000_000_000.0;
 }

--- a/std/ext/gmcp.lpc
+++ b/std/ext/gmcp.lpc
@@ -49,7 +49,7 @@ void gmcp(string message) {
     gmcp_module = DIR_STD_HANDLERS "gmcp/" + gmcp.package + ".lpc";
     if(!file_exists(gmcp_module)) {
         log_file("system/gmcp", "[%s] Module %s not found [%O]",
-            ctime(),
+            ldatetime(),
             gmcp_module,
             previous_object() || this_object()
         );

--- a/std/living/ghost.lpc
+++ b/std/living/ghost.lpc
@@ -86,7 +86,7 @@ void net_dead() {
         tell_all(environment(), query_name()+ " begins to fade.\n");
 
     add_extra_short("link_dead", "[fading]");
-    log_file(LOG_LOGIN, query_real_name() + " went link-dead on " + ctime(time()) + "\n");
+    log_file(LOG_LOGIN, query_real_name() + " went link-dead on " + ldatetime() + "\n");
 
 }
 
@@ -106,7 +106,7 @@ void heart_beat() {
             if((time() - query_last_login()) > 3600) {
                 if(environment())
                     tell_them(query_name() + " fades out of existance.\n");
-                log_file(LOG_LOGIN, query_real_name() + " auto-quit after 1 hour of net-dead at " + ctime(time()) + ".\n");
+                log_file(LOG_LOGIN, query_real_name() + " auto-quit after 1 hour of net-dead at " + ldatetime() + ".\n");
                 remove();
                 return;
             }

--- a/std/living/npc.lpc
+++ b/std/living/npc.lpc
@@ -97,7 +97,7 @@ void heart_beat() {
         if(environment())
           tell_them(query_name() + " fades out of existance.\n");
 
-        log_file(LOG_LOGIN, query_real_name() + " auto-quit after 1 hour of net-dead at " + ctime(time()) + ".\n");
+        log_file(LOG_LOGIN, query_real_name() + " auto-quit after 1 hour of net-dead at " + ldatetime() + ".\n");
         destruct(this_object());
       }
     } else {

--- a/std/living/player.lpc
+++ b/std/living/player.lpc
@@ -170,7 +170,7 @@ void net_dead() {
     tell_all(environment(), query_name()+ " falls into stupor.\n");
 
   add_extra_short("link_dead", "[stupor]");
-  log_file(LOG_LOGIN, query_real_name() + " went link-dead on " + ctime(time()) + "\n");
+  log_file(LOG_LOGIN, query_real_name() + " went link-dead on " + ldatetime() + "\n");
 
   if(interactive(this_object()))
     emit(SIG_USER_LINKDEAD, this_object());
@@ -211,7 +211,7 @@ void heart_beat() {
       if((time() - query_last_login()) > 3600) {
         if(environment())
           simple_action("$N $vfade out of existence.");
-        log_file(LOG_LOGIN, query_real_name() + " auto-quit after 1 hour of net-dead at " + ctime(time()) + ".\n");
+        log_file(LOG_LOGIN, query_real_name() + " auto-quit after 1 hour of net-dead at " + ldatetime() + ".\n");
         remove();
         return;
       }

--- a/std/object/inventory.lpc
+++ b/std/object/inventory.lpc
@@ -106,7 +106,7 @@ varargs object add_inventory(mixed file, string uuid, mixed *args...) {
     }
 
     log_file("OBJECT", "%s %s add_inventory clone error: %s\n  file: %s\n",
-      ctime(), file_name(), e, fname || file_name(f));
+      ldatetime(), file_name(), e, fname || file_name(f));
   }
 
   if(!ob)
@@ -126,7 +126,7 @@ varargs object add_inventory(mixed file, string uuid, mixed *args...) {
   e = catch(ob->move(this_object()));
   if(e) {
     log_file("OBJECT", "%s %s add_inventory move error: %s\n  ob: %s\n",
-      ctime(), file_name(), e, file_name(ob));
+      ldatetime(), file_name(), e, file_name(ob));
     ob->remove();
     return 0;
   }

--- a/std/object/object.lpc
+++ b/std/object/object.lpc
@@ -1,14 +1,14 @@
 /**
  * @file /std/object/object.lpc
- * Base object implementation that provides core functionality
- * for all game objects.
+ * 
+ * Base object implementation that provides core functionality for all game
+ * objects.
  *
- * @created 2005-04-04 - Tacitus
+ * @created 2024-07-24 - Gesslar
  * @last_modified 2025-03-16 - GitHub Copilot
  *
  * @history
- * 2005-04-04 - Tacitus - Created
- * 2006-07-14 - Tacitus - Last updated
+ * 2024-07-24 - Entirely replaced originally distributed, legacy code.
  * 2025-03-16 - GitHub Copilot - Added documentation
  */
 
@@ -44,8 +44,8 @@ private nosave mixed _prevent_get = 0;
 /**
  * Driver apply called when the object is created.
  *
- * Sets up the object and processes the setup chain, then calls reset().
- * This function is private so only the driver can call it.
+ * Sets up the object and processes the setup chain, then calls reset(). This
+ * function is private so only the driver can call it.
  *
  * @param {mixed...} args - Variable arguments passed during creation
  */


### PR DESCRIPTION
Replaces `ctime(time())` with `ldatetime()` across login, master, and living objects for consistent datetime formatting.

- Replaces all `ctime(time())` and `ctime()` calls with `ldatetime()` in `adm/obj/login.lpc`, `adm/obj/master.lpc`, `std/living/ghost.lpc`, `std/living/npc.lpc`, `std/living/player.lpc`, `std/object/inventory.lpc`, and `std/ext/gmcp.lpc`
- Replaces `sprintf`-based string concatenation with template string literals throughout `master.lpc`
- Removes the commented-out `#if 0` block of the old `error_handler` implementation
- Removes the unused `tune_into_error` function
- Fixes `log_error` to cache `this_body()` in a local variable, removes the now-redundant `stringp(username)` guard, and switches `tell_me` to `tell(tp, ...)`
- Updates the crash handler shout to use `mud_name()` instead of a hardcoded string
- Adds a comment in `epilog` noting that the boot daemon will have loaded before `SIG_SYS_BOOT` is emitted
- Removes the `#include <localtime.h>` that was no longer needed
- Reformats `adm/simul_efun/time.lpc` to consistent two-space indentation and replaces `nullp(x)` checks with the `??=` null-coalescing operator
- Updates file headers in `master.lpc`, `security.lpc`, and `object.lpc` to reflect current authorship and rewrite history

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Refactors master-object logging and trace formatting, standardizes timestamps on `ldatetime()`, modernizes time simul-efuns, removes obsolete code, and updates file headers.
</details>

<sub>Reviews (4): Last reviewed commit: ["recognising that things have been rewrit..."](https://github.com/gesslar/oxidus-mudlib/commit/11f5e1907b37dc3ca3691780c91eac1d6b6bf316) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46911740)</sub>

<!-- /greptile_comment -->