### PR TITLE
Replace `ctime()` with `ldatetime()` in alarm, death, and GMCP daemon logs

### DIFF
--- a/adm/daemons/alarm.lpc
+++ b/adm/daemons/alarm.lpc
@@ -278,19 +278,19 @@ private void execute_alarm(class Alarm alarm) {
 
   if(!cfile_exists(alarm.file)) {
     log_file("system/alarm", "[%s] File %s does not exist\n",
-      ctime(), alarm.file);
+      ldatetime(), alarm.file);
     return;
   }
 
   if(err = catch(ob = load_object(alarm.file))) {
     log_file("system/alarm", "[%s] Unable to load file %s: %O\n",
-      ctime(), alarm.file, err);
+      ldatetime(), alarm.file, err);
     return;
   }
 
   if(!ob) {
     log_file("system/alarm", "[%s] Unable to load file %s\n",
-      ctime(), alarm.file);
+      ldatetime(), alarm.file);
     return;
   }
 
@@ -301,7 +301,7 @@ private void execute_alarm(class Alarm alarm) {
 
   if(err) {
     log_file("system/alarm", "[%s] Error executing alarm %s: %O\n",
-      ctime(), alarm.func, err);
+      ldatetime(), alarm.func, err);
   }
 
   save_data();
@@ -418,7 +418,7 @@ class Alarm create_alarm(string *parts, int silent) {
   };
   if(err) {
     log_file("system/alarm", "[%s] Error in create_alarm: %O",
-      ctime(), err);
+      ldatetime(), err);
     return null;
   }
 
@@ -564,7 +564,7 @@ int calculate_alarm_time(class Alarm alarm, int next) {
 
   if(err) {
     log_file("system/alarm", "[%s] Error in calculate_alarm_time: %O",
-      ctime(), err);
+      ldatetime(), err);
     return -1;
   }
 
@@ -660,7 +660,7 @@ int validate_alarm(class Alarm alarm, int silent) {
 
   if(!cfile_exists(alarm.file)) {
     log_file("system/alarm", "[%s] File %s does not exist\n%O",
-      ctime(), alarm.file, alarm);
+      ldatetime(), alarm.file, alarm);
     if(!silent)
       throw("File does not exist");
     return 0;
@@ -668,7 +668,7 @@ int validate_alarm(class Alarm alarm, int silent) {
 
   if(err = catch(ob = load_object(alarm.file))) {
     log_file("system/alarm", "[%s] Unable to load file %s: %O\n%O",
-      ctime(), alarm.file, err, alarm);
+      ldatetime(), alarm.file, err, alarm);
     if(!silent)
       throw("Unable to load file");
     return 0;
@@ -677,7 +677,7 @@ int validate_alarm(class Alarm alarm, int silent) {
   if(!function_exists(alarm.func, ob)) {
     log_file("system/alarm",
       "[%s] Function %s does not exist in file %s\n%O",
-      ctime(), alarm.func, alarm.file, alarm);
+      ldatetime(), alarm.func, alarm.file, alarm);
     if(!silent)
       throw("Function does not exist");
     return 0;
@@ -688,7 +688,7 @@ int validate_alarm(class Alarm alarm, int silent) {
 
     if(time < time()) {
       log_file("system/alarm", "[%s] Time is in the past\n%O",
-        ctime(), alarm);
+        ldatetime(), alarm);
       if(!silent)
         throw("Time is in the past");
       return 0;
@@ -719,7 +719,7 @@ varargs void test_alarm(class Alarm alarm) {
     return;
 
   debug_message(sprintf("Alarm %O: %O called at %s",
-    alarm.args..., ctime()));
+    alarm.args..., ldatetime()));
   log_file("alarms",
-    sprintf("Alarm %O: %O called at %s", alarm.args..., ctime()));
+    sprintf("Alarm %O: %O called at %s", alarm.args..., ldatetime()));
 }

--- a/adm/daemons/death.lpc
+++ b/adm/daemons/death.lpc
@@ -28,7 +28,7 @@ void setup() {
  */
 void player_died(object player, object killer) {
   log_file("death", sprintf("[%s] %s was killed by %s [%O]\n",
-      ctime(),
+      ldatetime(),
       player->query_name(),
       killer ? killer->query_name() : "unknown",
       environment(player)
@@ -44,7 +44,7 @@ void player_died(object player, object killer) {
  */
 void player_revived(object player) {
   log_file("death", sprintf("[%s] %s was revived [%O]\n",
-      ctime(),
+      ldatetime(),
       player->query_name(),
       environment(player)
     )

--- a/adm/daemons/gmcp.lpc
+++ b/adm/daemons/gmcp.lpc
@@ -134,7 +134,7 @@ varargs void send_gmcp(object body, string gmcp_package, mixed arg) {
 
   if(!file_exists(gmcp_module)) {
     log_file("system/gmcp", "[%s] Module %s not found [%O]",
-      ctime(),
+      ldatetime(),
       gmcp_module,
       previous_object()->query_gmcp_module() ?
         previous_object(1) :


### PR DESCRIPTION
Updates log timestamps across alarm, death, and GMCP daemons to use `ldatetime()` instead of `ctime()` for consistent datetime formatting in log entries.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Replaces `ctime()` with the existing zero-argument `ldatetime()` helper for consistent local timestamp formatting.
- Updates alarm execution, validation, calculation-error, and test log timestamps.
- Updates player death and revival log timestamps.
- Updates missing GMCP module log timestamps.
</details>

<sub>Reviews (1): Last reviewed commit: ["oops missed some last pass"](https://github.com/gesslar/oxidus-mudlib/commit/b7d33c102c0536702ab606733b12bdd3e9dd1c4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46914117)</sub>

<!-- /greptile_comment -->