### PR TITLE
Fix exit code semantics: exit 1 == reboot, exit 0 == clean shutdown

### DIFF
--- a/adm/dist/docker/README.md
+++ b/adm/dist/docker/README.md
@@ -116,8 +116,8 @@ the `TLS_CERT` / `TLS_KEY` config keys.
   `OXIDUS_UID:OXIDUS_GID` (default `1000`) via `gosu` and runs the driver
   unprivileged.
 - **Reboot loop.** The driver runs in a reboot loop mirroring `adm/dist/run`: an
-  in-game reboot (`exit 0`) restarts it automatically, while a real shutdown
-  stops the container.
+  in-game reboot (`exit 1`) restarts it automatically, while a real shutdown
+  (`exit 0`) stops the container.
 
 ## Running vs. rebuilding (stable at run, fresh at build)
 

--- a/adm/dist/docker/docker-compose.yml
+++ b/adm/dist/docker/docker-compose.yml
@@ -19,7 +19,13 @@ services:
     # image: ghcr.io/gesslar/oxidus:latest
     container_name: oxidus
     init: true                 # tini as PID 1: clean signal forwarding + zombie reaping
-    restart: unless-stopped
+    # "no", not unless-stopped/on-failure: mirrors adm/dist/run, where only an
+    # in-game reboot restarts the driver. Reboot (exit 1) is absorbed by the
+    # entrypoint's own loop and never surfaces here, so the container process
+    # only exits on a clean shutdown (0) or a crash (non-zero) — both must stay
+    # down. Auto-restarting a crash would bury the fault in a boot loop; leave
+    # the dead container up for triage instead.
+    restart: "no"
     stop_grace_period: 30s     # give the driver time to save on shutdown
     ports:
       - "1336:1336"            # plain telnet

--- a/adm/dist/docker/docker-entrypoint.sh
+++ b/adm/dist/docker/docker-entrypoint.sh
@@ -150,7 +150,8 @@ if [ "$(id -u)" = "0" ]; then
 fi
 
 # --- Phase 2: unprivileged driver loop (we are now PUID:PGID) -------------
-# Reboot loop with signal handling (mirrors adm/dist/run; exit 0 == reboot).
+# Reboot loop with signal handling (mirrors adm/dist/run; exit 1 == reboot,
+# exit 0 == clean shutdown, anything else == crash — both stop the container).
 set +e
 child=""
 shutdown() {
@@ -167,10 +168,10 @@ while true; do
   wait "${child}"
   status=$?
   echo "[entrypoint] driver exited with status ${status}"
-  if [ "${status}" -eq 0 ]; then
+  if [ "${status}" -eq 1 ]; then
     echo "[entrypoint] reboot requested, restarting..."
-    # No delay between reboots, matching bin/run (sleep commented out there).
-    # This also leaves no window for a stop signal to land between drivers.
+    # No delay between reboots, matching adm/dist/run's intent. This also
+    # leaves no window for a stop signal to land between drivers.
   else
     break
   fi


### PR DESCRIPTION
The reboot loop exit code convention was inverted in the Docker entrypoint and its surrounding documentation. Previously, `exit 0` was treated as a reboot signal and `exit 1` as a shutdown, which is backwards from standard Unix conventions where `0` means success/clean exit.

This corrects the logic so that `exit 1` triggers an in-game reboot (restarting the driver loop) and `exit 0` or any other non-1 exit code stops the container. The `docker-compose.yml` restart policy is also changed from `unless-stopped` to `"no"`, since the entrypoint manages its own reboot loop internally — only `exit 1` ever causes a restart, and that is absorbed before Docker sees it. Any other exit (clean shutdown or crash) should leave the container stopped for inspection rather than being automatically restarted and potentially hiding a fault in a boot loop. Documentation in the README is updated to reflect the corrected exit code behavior.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Corrects Docker lifecycle semantics so that the entrypoint restarts only for the driver’s reboot status.
- Treats exit status 1 as an in-game reboot and all other statuses as terminal.
- Disables Docker-level automatic restarts so crashes remain stopped for inspection.
- Updates Docker documentation to describe exit 0 as shutdown and exit 1 as reboot.
</details>

<sub>Reviews (1): Last reviewed commit: ["updating docker"](https://github.com/gesslar/oxidus-mudlib/commit/635748cc82cd27bd807aa7cc4df0e33877975c82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47083653)</sub>

**Context used:**

- Knowledge Base — [Bootstrap and Build](https://app.greptile.com/gesslar/-/custom-context/knowledge-base/gesslar/oxidus-mudlib/-/docs/bootstrap-and-build.md)

<!-- /greptile_comment -->