### PR TITLE
Add `load_json()` simul_efun with tests

### DIFF
--- a/adm/include/simul_efun.h
+++ b/adm/include/simul_efun.h
@@ -103,6 +103,7 @@ varargs string tail(string path, int line_count);
 varargs string temp_file(mixed arg);
 varargs void implode_file(string file, string *lines, int overwrite);
 varargs mixed load_lpml(string file, string root);
+mixed load_json(string file);
 void assure_file(string file);
 string source_file(string path_and_file);
 mapping as_directory(string str);

--- a/adm/simul_efun/file.lpc
+++ b/adm/simul_efun/file.lpc
@@ -270,13 +270,45 @@ varargs mixed load_lpml(string file, string root) {
   string err = catch(contents = read_file(file));
   set_privs(this_object(), old_privs);
 
-  if(err)
+  if(err || !stringp(contents))
     return undefined;
 
   if(stringp(root) && truthy(root))
     return lpml_decode(contents, root);
   else
     return lpml_decode(contents);
+}
+
+/**
+ * Loads and decodes a JSON file.
+ *
+ * Reads the file and parses it via json_decode(). Unlike load_lpml(), JSON
+ * has no include mechanism, so there is no base path to resolve against.
+ *
+ * @param {string} file - Path to the JSON file to load
+ * @returns {mixed} Decoded JSON value, "" if the file is missing or empty, or
+ *  undefined if it could not be read
+ * @errors If file is not a non-zero length string
+ * @example
+ * mapping cfg = load_json("/d/village/spawn.json");
+ */
+mixed load_json(string file) {
+  string contents, old_privs;
+
+  assert_arg(stringp(file) && truthy(file), 1, "File must be a non-zero length string.");
+
+  if(!file_exists(file) || file_size(file) == 0)
+    return "";
+
+  old_privs = query_privs();
+  set_privs(this_object(), query_privs(previous_object()));
+  string err = catch(contents = read_file(file));
+  set_privs(this_object(), old_privs);
+
+  if(err || !stringp(contents))
+    return undefined;
+
+  return json_decode(contents);
 }
 
 /**

--- a/tests/adm/simul_efun/__fixtures/load_json.json
+++ b/tests/adm/simul_efun/__fixtures/load_json.json
@@ -1,0 +1,13 @@
+{
+  "name": "cave bat",
+  "level": 3,
+  "loot chance": 70.5,
+  "nocturnal": true,
+  "tamed": false,
+  "owner": null,
+  "id": ["cave bat", "bat"],
+  "coins": {
+    "copper": 25,
+    "silver": 2
+  }
+}

--- a/tests/adm/simul_efun/__fixtures/load_json_bad.json
+++ b/tests/adm/simul_efun/__fixtures/load_json_bad.json
@@ -1,0 +1,1 @@
+{ "unterminated": "value"

--- a/tests/adm/simul_efun/file.test.lpc
+++ b/tests/adm/simul_efun/file.test.lpc
@@ -1,0 +1,69 @@
+// @lpc-nocheck
+/**
+ * @file /tests/adm/simul_efun/file.test.lpc
+ *
+ * Tests for the file.lpc simul_efuns. Currently covers load_json():
+ * happy-path decoding of a JSON fixture, the missing/empty-file "" return,
+ * argument validation, and error propagation from json_decode() on
+ * malformed input.
+ */
+
+#include <test.h>
+
+inherit STD_TEST;
+
+#define FIXTURE_DIR "/tests/adm/simul_efun/__fixtures"
+#define FIXTURE FIXTURE_DIR "/load_json.json"
+#define EMPTY_FIXTURE FIXTURE_DIR "/load_json_empty.json"
+#define BAD_FIXTURE FIXTURE_DIR "/load_json_bad.json"
+
+void setup() {
+  describe("load_json decoding", ({
+    test("scalar fields decode", function() {
+      mixed r = load_json(FIXTURE);
+      ASSERT_EQ("cave bat", r["name"]);
+      ASSERT_EQ(3, r["level"]);
+      ASSERT_EQ(70.5, r["loot chance"]);
+    }),
+    test("booleans decode to 1 and 0", function() {
+      mixed r = load_json(FIXTURE);
+      ASSERT_EQ(1, r["nocturnal"]);
+      ASSERT_EQ(0, r["tamed"]);
+    }),
+    test("null decodes to undefined with the key present", function() {
+      mixed r = load_json(FIXTURE);
+      ASSERT_EQ(1, nullp(r["owner"]));
+      ASSERT_NE(-1, member_array("owner", keys(r)));
+    }),
+    test("arrays decode with order preserved", function() {
+      mixed r = load_json(FIXTURE);
+      ASSERT_EQ(1, same_array(({ "cave bat", "bat" }), r["id"], 1));
+    }),
+    test("nested objects decode to mappings", function() {
+      mixed r = load_json(FIXTURE);
+      ASSERT_EQ(25, r["coins"]["copper"]);
+      ASSERT_EQ(2, r["coins"]["silver"]);
+    }),
+  }));
+
+  describe("load_json missing and empty files", ({
+    test("missing file returns an empty string", function() {
+      ASSERT_EQ("", load_json(FIXTURE_DIR "/does_not_exist.json"));
+    }),
+    test("empty file returns an empty string", function() {
+      ASSERT_EQ("", load_json(EMPTY_FIXTURE));
+    }),
+  }));
+
+  describe("load_json bad input", ({
+    test("non-string argument raises an error", function() {
+      ASSERT_NE(0, catch(load_json(0)));
+    }),
+    test("empty string argument raises an error", function() {
+      ASSERT_NE(0, catch(load_json("")));
+    }),
+    test("malformed JSON raises an error", function() {
+      ASSERT_NE(0, catch(load_json(BAD_FIXTURE)));
+    }),
+  }));
+}


### PR DESCRIPTION
Adds a `load_json()` simul_efun that reads a file from disk and parses it via `json_decode()`. The function validates that the path argument is a non-empty string, returns `""` for missing or empty files, temporarily adopts the calling object's privileges when reading, and propagates errors from malformed JSON.

The function signature is declared in `simul_efun.h` alongside the existing `load_lpml()` declaration.

Tests cover scalar field decoding, boolean and null handling, array ordering, nested object decoding, missing and empty file behavior, invalid argument types, and malformed JSON error propagation. Fixtures include a well-formed JSON document, an empty file, and a syntactically invalid JSON file.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a globally available JSON file loader and completes the existing LPML loader’s failed-read handling.
- Declares `load_json()` in the shared simul-efun header.
- Reads JSON using the calling object’s privileges and decodes successful string results.
- Returns documented sentinel values for missing, empty, or unreadable files.
- Adds decoding, validation, missing-file, empty-file, and malformed-input tests.
</details>

<sub>Reviews (2): Last reviewed commit: ["adding load\_json"](https://github.com/gesslar/oxidus-mudlib/commit/3f2dd2abefd917b28f476efd2121b04fb07a1434) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47302583)</sub>

**Context used:**

- Knowledge Base — [Simul-efuns and Utilities](https://app.greptile.com/gesslar/-/custom-context/knowledge-base/gesslar/oxidus-mudlib/-/docs/simul-efuns-and-utilities.md)
- Knowledge Base — [Testing Infrastructure](https://app.greptile.com/gesslar/-/custom-context/knowledge-base/gesslar/oxidus-mudlib/-/docs/testing-infrastructure.md)

<!-- /greptile_comment -->