### PR TITLE
Fix typo: "assumingthe" → "assuming the" in http_client

### DIFF
--- a/std/daemon/http_client.lpc
+++ b/std/daemon/http_client.lpc
@@ -504,7 +504,7 @@ private nomask void process_response(int fd, mapping server) {
   // If someone identifies the format, please update this!
   else {
     _log(2, "No content-length or chunked transfer encoding found. "
-      "Therefore, assumingthe response is the entire body. 🤷🏻");
+      "Therefore, assuming the response is the entire body. 🤷🏻");
 
     response = buf;
   }


### PR DESCRIPTION
Fixed a typo in a log message where "assumingthe" was missing a space, correcting it to "assuming the".

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Corrects a missing space in an HTTP client fallback log message.
</details>

<sub>Reviews (3): Last reviewed commit: ["fixing typo"](https://github.com/gesslar/oxidus-mudlib/commit/56a085b35c9004c9513be25933e1bd5508a395fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47302586)</sub>

<!-- /greptile_comment -->