### PR TITLE
Remove unused `ok` variable in `access_gate`

### DIFF
--- a/adm/obj/master/security.lpc
+++ b/adm/obj/master/security.lpc
@@ -907,9 +907,6 @@ private nomask int access_ok(string file, object user, string op) {
  * @returns {int} 1 if permitted (or shadowed), 0 if enforced-denied.
  */
 private nomask int access_gate(string file, object user, string op, string func) {
-  int ok;
-
-
   // A nested check (the logging below reads/writes files) must not
   // recurse; permit it and let the outermost call decide.
   if(in_access_check)


### PR DESCRIPTION
Removes two unused variable declarations and a blank line from `access_gate`, cleaning up dead code left over from a previous refactor.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes an unused local variable and excess blank lines from `access_gate`; executable behavior is unchanged.
</details>

<sub>Reviews (3): Last reviewed commit: ["removing unused"](https://github.com/gesslar/oxidus-mudlib/commit/384d96028d946fc5cff14cf801d7800d57d95852) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47302587)</sub>

<!-- /greptile_comment -->