### PR TITLE
Refactor github_issues daemon: modernize syntax, use template strings, fix backlog scheduling, and remove dead `parse_time`

### DIFF
--- a/adm/daemons/github_issues.lpc
+++ b/adm/daemons/github_issues.lpc
@@ -1,21 +1,21 @@
 /**
  * @file /adm/daemons/github_issues.lpc
  *
- * Daemon to handle GitHub issues. Uses the GitHub Issues API to
- * create issues in the mud's GitHub repository.
+ * Daemon to handle GitHub issues. Uses the GitHub Issues API to create issues
+ * in the mud's GitHub repository.
  *
  * @created 2024-07-07 - Gesslar
- * @last_modified 2024-07-07 - Gesslar
+ * @last_modified 2026-07-25 - Gesslar
  *
  * @history
  * 2024-07-07 - Gesslar - Created
+ * 2026-07-25 - Gesslar - Some tidying and correction.
  */
 
 #include <daemons.h>
 
 inherit STD_HTTP_CLIENT;
 
-private nomask int parse_time(string str);
 private nomask int is_setup();
 private nomask void check_token();
 nomask void process_backlog();
@@ -23,12 +23,14 @@ private nomask void process_next(string *files);
 private nomask void execute_callback(mapping request, mapping response);
 
 private nomask nosave mapping api_calls = ([ ]);
+private nomask nosave int scheduled = 0;
+private nosave string pending_dir = "/data/github/issues/pending";
 
 void setup() {
   set_log_level(4);
   set_log_prefix("(GITHUB_ISSUES)");
 
-  assure_dir("/data/github/issues/pending");
+  assure_dir(pending_dir);
 
   process_backlog();
 }
@@ -39,10 +41,10 @@ void setup() {
  * @param {string} type - The type of issue to create
  * @param {string} title - The title of the issue
  * @param {string} body - The body of the issue
- * @param {mixed*} [callback] - The callback function to call
- *                               when the request is complete
- * @returns {int | string} 1 if the request was successful, or
- *                         an error message string
+ * @param {mixed*} [callback] - The callback function to call when the request
+ *  is complete
+ * @returns {int | string} 1 if the request was successful, or an error message
+ *  string
  */
 
 varargs mixed create_issue(string type, string title, string body, mixed *callback) {
@@ -52,7 +54,7 @@ varargs mixed create_issue(string type, string title, string body, mixed *callba
     return "Type must be a valid string";
 
   if(member_array(type, config["types"]) == -1)
-    return "Invalid type. Available types: " + implode(config["types"], ", ");
+    return `Invalid type. Available types: ${implode(config["types"], ", ")}.`;
 
   if(!stringp(title))
     return "Title must be a string";
@@ -63,22 +65,20 @@ varargs mixed create_issue(string type, string title, string body, mixed *callba
   if(!config["owner"] || !config["repo"] || !config["token"])
     return "GitHub Issues API not setup in adm/etc/config.json";
 
-  string url = sprintf(
-      "https://api.github.com/repos/%s/%s/issues",
-      config["owner"], config["repo"]
-    );
+  string url =
+    `https://api.github.com/repos/${config["owner"]}/${config["repo"]}/issues`;
 
   mapping request = http_request(
     url,
     "POST",
     ([
-      "Authorization": sprintf("token %s", config["token"]),
+      "Authorization": `token ${config["token"]}`,
       "Accept": "application/vnd.github.v3+json",
       "Content-Type": "application/json; charset=utf-8"
     ]),
     json_encode(([
       "title": title,
-      "body": "```\n" + body + "\n```\n",
+      "body": `\`\`\`\n${body}\n\`\`\`\n`,
       "labels": ({ type })
     ])),
   );
@@ -92,6 +92,8 @@ varargs mixed create_issue(string type, string title, string body, mixed *callba
     "caller" : previous_object(),
     "request" : request
   ]);
+
+  _log(2, "Request %O", request);
 
   return mapp(request) ? 1 : 0;
 }
@@ -120,8 +122,9 @@ void http_handle_shutdown(mapping response) {
       body
     );
     file = time_ns() + ".txt";
-    write_file("/data/github/issues/pending/" + file, json_encode(request));
-    _log(2, "Request saved to /data/github/pending/%s", file);
+    string write_to = `${pending_dir}/${file}`;
+    write_file(write_to, json_encode(request));
+    _log(2, "Request saved to %s", write_to);
     return;
   }
 
@@ -134,8 +137,7 @@ void http_handle_shutdown(mapping response) {
 /**
  * Execute the callback function.
  *
- * @param {mapping} request - The request containing the callback
- *                            function
+ * @param {mapping} request - The request containing the callback function
  * @param {mapping} response - The response from the GitHub API
  */
 void execute_callback(mapping request, mapping response) {
@@ -163,17 +165,22 @@ void execute_callback(mapping request, mapping response) {
 }
 
 /**
- * Process the backlog of requests in the
- * /data/github/issues/pending directory. Passes a list of files
- * to process_next() to process each request.
+ * Process the backlog of requests in the /data/github/issues/pending directory.
+ * Passes a list of files to process_next() to process each request.
  */
 public nomask void process_backlog() {
-  string *files = get_dir("/data/github/issues/pending/*.txt");
+  string *files = get_dir(`${pending_dir}/*.txt`);
+  files = map(files, (: `${pending_dir}/${$1}` :));
 
   if(!sizeof(files))
-      return;
+    return;
 
   process_next(files);
+
+  if(scheduled && find_call_out(scheduled) <= 0)
+    return;
+
+  scheduled = call_out(process_backlog, 60);
 }
 
 /**
@@ -185,46 +192,50 @@ public nomask void process_backlog() {
 private nomask void process_next(string *files) {
   function schedule_next = (: call_out_walltime("process_next", 5.0, $1) :);
 
-  if(!sizeof(files))
-    return;
+  if(!sizeof(files)) {
+    _log(2, "No files to process. Exiting.");
 
-  string file = files[0];
+    return;
+  }
+
+  string file = shift(ref files);
+  _log(2, "Processing file %O", file);
 
   if(!file_exists(file)) {
     if(sizeof(files) > 1)
-      schedule_next(files[1..]);
+      schedule_next(files);
     else
-    return;
-}
+      return;
+  }
 
   mapping request;
-  string err = catch(request = json_decode(read_file("/data/github/issues/pending/" + file)));
+  string err = catch(request = load_json(file));
   if(err) {
     _log(2, "Error reading request file %s: %O", file, err);
 
     if(sizeof(files) > 1)
-      schedule_next(files[1..]);
+      schedule_next(files);
 
     return;
   }
 
   if(!mapp(request)) {
-    _log(2, "Invalid request in /data/github/issues/pending/%s", file);
+    _log(2, "Invalid request in %s", file);
 
     if(sizeof(files) > 1)
-      schedule_next(files[1..]);
+      schedule_next(files);
 
     return;
   }
 
   if(!mapp(request["request"])) {
-    _log(2, "Invalid request in /data/github/issues/pending/%s", file);
+    _log(2, "Invalid request in %s", file);
     return;
   }
 
-  _log(2, "Processing request from /data/github/issues/pending/%s", file);
+  _log(2, "Processing request from %s", file);
   _log(2, "Request: %O", request);
-  _log(2, "Resubmitting request from /data/github/issues/pending/%s", file);
+  _log(2, "Resubmitting request from %s", file);
 
   // Do appropriate function based on its type
   err = catch {
@@ -237,10 +248,15 @@ private nomask void process_next(string *files) {
           request["callback"]
         });
 
-        create_issue(new_request...);
         _log(2, "Submitting create issue request: %O", new_request);
+
+        mixed result = create_issue(new_request...);
+
+        _log(2, "Result of submission %O", result);
+
         break;
       }
+
       default:
         _log(2, "Invalid request type: %s", request["type"]);
         break;
@@ -248,34 +264,13 @@ private nomask void process_next(string *files) {
   };
 
   if(err) {
-      _log(2, "Error sending request: %O", err);
+    _log(2, "Error sending request: %O", err);
   } else {
-    rm("/data/github/issues/pending/" + file);
+    rm(file);
 
     if(sizeof(files) > 1)
-      schedule_next(files[1..]);
+      schedule_next(files);
 
-    _log(2, "Request resubmitted for /data/github/issues/pending/%s", file);
+    _log(2, "Request resubmitted for %s", file);
   }
-}
-/**
- * Convert a GitHub date-time string to an epoch time.
- *
- * @param {string} datetime - The date-time string to convert
- * @returns {int} The epoch time
- */
-private nomask int parse_time(string datetime) {
-    // Convert the date-time string to a time structure using strptime
-  int epoch_time;
-  string err = catch(epoch_time = strptime("%Y-%m-%dT%H:%M:%SZ", datetime));
-  if(err) {
-    _log(0, "Error parsing date-time string %s: %O", datetime, err);
-    return -1;
-  }
-
-  // If strptime returns -1, it means the date-time string is invalid
-  if(!epoch_time)
-    error("Invalid date-time string");
-
-  return epoch_time;
 }


### PR DESCRIPTION
This PR tidies up the GitHub Issues daemon with several improvements:

- Replaces `sprintf` string formatting with template literals throughout for cleaner, more readable string construction
- Extracts the pending directory path into a `pending_dir` constant to eliminate repeated hardcoded path strings and ensure log messages accurately reflect the actual file paths being used
- Adds a `scheduled` flag to prevent duplicate `process_backlog` call-outs from being registered, with `process_backlog` now scheduling itself to re-run every 60 seconds if there were backlog items to have been processed. Basically, a re-check guard. Once the queue is drained, it will stop re-scheduling.
- Fixes `process_next` to use `shift` on the files array rather than manually slicing with `files[1..]`, simplifying iteration logic
- Replaces `json_decode(read_file(...))` with `load_json` for reading pending request files
- Adds logging of the HTTP request at submission time and captures and logs the return value of `create_issue` during backlog reprocessing
- Removes the unused `parse_time` function that was never called externally

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR modernizes the GitHub Issues daemon and revises its disk-backed backlog processing.
- Replaces formatted strings and repeated pending-directory paths with template strings and a shared path.
- Adds periodic backlog scheduling and request-submission logging.
- Changes pending-file iteration to shift entries and load them through load_json.
- Removes the unused parse_time helper.
</details>

<sub>Reviews (7): Last reviewed commit: ["fixing up the github issues daemon"](https://github.com/gesslar/oxidus-mudlib/commit/c079aa5b3ad3f54358afdf0700b3a66e1165a019) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47302591)</sub>

**Context used:**

- Knowledge Base — [Networking and External Services](https://app.greptile.com/gesslar/-/custom-context/knowledge-base/gesslar/oxidus-mudlib/-/docs/networking-and-external-services.md)

<!-- /greptile_comment -->