### PR TITLE
Revise type annotation guidance to prefer shallowest known type over minimum interface, and apply throughout

### DIFF
--- a/.claude/skills/lpc-coding-style/SKILL.md
+++ b/.claude/skills/lpc-coding-style/SKILL.md
@@ -360,11 +360,15 @@ mixed main(/** @type {STD_PLAYER} */ object caller, string str) {
 }
 ```
 
-Use the most specific `STD_*` macro whose interface matches the
-methods actually called on that parameter — the same principle as
-LPCDoc `@param` type selection (see the lpcdoc skill). Common
-macros: `STD_PLAYER`, `STD_BODY`, `STD_NPC`, `STD_OBJECT`,
-`STD_ROOM`, `STD_CONTAINER`.
+Go shallowest first — pick the shallowest macro the object is known
+to be (shallow in the inherit-traversal sense: `STD_PLAYER` is
+shallower than `STD_BODY` is shallower than `STD_OBJECT`). Reason
+from where the object comes from, not from the methods this function
+happens to call: a parameter fed by `main()` in a `cmds/adm/` or
+`cmds/dev/` command is a player, whatever the body does with it.
+Same principle as LPCDoc `@param` type selection (see the lpcdoc
+skill). Common macros: `STD_PLAYER`, `STD_BODY`, `STD_NPC`,
+`STD_OBJECT`, `STD_ROOM`, `STD_CONTAINER`.
 
 This annotation is a comment and has no effect on compilation — it
 exists solely to give the LSP enough information to validate

--- a/.claude/skills/lpcdoc/SKILL.md
+++ b/.claude/skills/lpcdoc/SKILL.md
@@ -395,10 +395,10 @@ mixed main(/** @type {STD_PLAYER} */ object caller, string str) {
 ```
 
 This lets the LSP resolve `call_other` methods (e.g.,
-`caller->set_env(...)`) that exist on the typed object. Use the
-most specific `STD_*` macro whose interface matches the methods
-called on that parameter. See the **lpc-coding-style** skill for
-full guidance.
+`caller->set_env(...)`) that exist on the typed object. Pick the
+macro by what the object is known to be, per **Named Objects**
+below — not by the methods this function happens to call. See the
+**lpc-coding-style** skill for full guidance.
 
 ### `@var`
 
@@ -743,22 +743,30 @@ If no macro exists, fall back to a full path:
 {"/path/to/object.lpc"}
 ```
 
-**Choosing the right macro:** Pick the most specific macro whose interface
-matches how the object is actually used within the function — not what the
-object might be at runtime. Look at which methods the function calls on the
-object, and choose the macro that defines those methods.
+**Choosing the right macro:** Go **shallowest first** — pick the shallowest
+type the object is *known* to be, the one you can get the most out of. Shallow
+and deep are used here in the inherit-traversal sense, as in
+`deep_inherit_list()`: parents are deeper, so `STD_PLAYER` is shallower than
+`STD_BODY`, which is shallower than `STD_OBJECT`. Descending toward
+`STD_OBJECT` only hides members you are entitled to call.
 
-- If the function calls methods specific to players (e.g. account operations),
-  use `{STD_PLAYER}`.
-- If it calls methods shared by players and NPCs (e.g. combat, vitals), use
+Reason from where the object comes from, not from which methods this function
+calls today:
+
+- It arrives as a command's `caller`/`tp`, or from `this_body()` on a command
+  path, and the command lives under `cmds/adm/` or `cmds/dev/` — no NPC walks
+  that path, so it is a player: `{STD_PLAYER}`.
+- It could be a player or an NPC (combat, vitals, anything a mob reaches) —
   `{STD_BODY}`.
-- If it only uses container operations (capacity, inventory) and the object
-  could be a bag, a room, or a body, use `{STD_CONTAINER}`.
-- If it only calls base object methods (e.g. query_id, move), use
-  `{STD_OBJECT}`.
+- It could genuinely be a bag, a room, or a body — `{STD_CONTAINER}`, or
+  `{STD_OBJECT}` if even that is more than the facts support.
 
-In short: the type should reflect the **interface the function depends on**,
-not the concrete type the caller is likely to pass.
+Descend only as far as the uncertainty actually forces, and fall back to bare
+`{object}` only when the type is genuinely unknowable at that point.
+
+In short: the type should reflect **what the object provably is**, not the
+minimum interface the function currently touches. Having to move the annotation
+shallower later, because a new call needs it, is churn it should have avoided.
 
 ### Class/Struct Types
 

--- a/adm/daemons/body.lpc
+++ b/adm/daemons/body.lpc
@@ -47,8 +47,7 @@ object create_body(string name) {
   body->set_name(name);
   set_privs(body, name);
   body->restore_body();
-  body->mudlib_setup();
-
+  body->std_setup();
 
   return body;
 }

--- a/adm/daemons/shutdown.lpc
+++ b/adm/daemons/shutdown.lpc
@@ -69,7 +69,7 @@ void setup() {
  * @returns {int} A feedback result (always 1) sent to the invoking operator.
  */
 public int request(int how, string arg) {
-  object who = this_body();
+  /** @type {STD_PLAYER} */ object who = this_body();
   string first, rest, junk;
   int minutes;
 
@@ -111,7 +111,7 @@ public int request(int how, string arg) {
  * announcement, and arms the countdown warnings plus the final fire. A zero
  * delay fires at once.
  *
- * @param {object} who - The operator scheduling it.
+ * @param {STD_PLAYER} who - The operator scheduling it.
  * @param {int} how - SYS_SHUTDOWN or SYS_REBOOT.
  * @param {int} minutes - Delay in minutes; 0 means immediately.
  * @param {string} why - The reason, possibly empty.
@@ -158,7 +158,7 @@ private int schedule(object who, int how, int minutes, string why) {
  * Cancels a pending shutdown/reboot, clears the armed call_outs, announces
  * the cancellation, and emits the matching cancel signal.
  *
- * @param {object} who - The operator cancelling it.
+ * @param {STD_PLAYER} who - The operator cancelling it.
  * @returns {int} A feedback result for the operator.
  */
 private int do_halt(object who) {
@@ -186,7 +186,7 @@ private int do_halt(object who) {
 /**
  * Reports the current shutdown/reboot status to the operator.
  *
- * @param {object} who - The operator asking.
+ * @param {STD_PLAYER} who - The operator asking.
  * @returns {int} A feedback result for the operator.
  */
 private int report_status(object who) {

--- a/adm/daemons/signal.lpc
+++ b/adm/daemons/signal.lpc
@@ -148,7 +148,7 @@ private nomask void invalidate_slots() {
  * other handlers.
  *
  * @param {mixed} sig - The signal identifier to dispatch
- * @param {mixed} arg... - Arguments to pass to the signal handlers
+ * @param {mixed...} arg - Arguments to pass to the signal handlers
  */
 public nomask void dispatch_signal(string sig, mixed arg...) {
   mapping sig_slot;

--- a/cmds/ability/strike.lpc
+++ b/cmds/ability/strike.lpc
@@ -47,7 +47,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
   if(!ob1)
     return 1;
 
-  /** @type {OBJ_STRIKER} */ object ob2 = carried_or_local_target(tp, id2);
+  /** @type {LIB_STRIKER} */ object ob2 = carried_or_local_target(tp, id2);
   if(!ob2)
     return 1;
 

--- a/cmds/dev/exits.lpc
+++ b/cmds/dev/exits.lpc
@@ -17,12 +17,12 @@ void setup() {
 "Shows all the exits in the current room and where they lead.";
 }
 
-mixed main(object tp, string args) {
+mixed main(object tp, string _args) {
   string *exits;
   string str;
   int i;
   mapping x;
-  object room = environment(tp);
+  /** @type {STD_ROOM} */ object room = environment(tp);
 
   exits = keys(room->query_exits());
   if(!sizeof(exits)) {

--- a/cmds/dev/gauge.lpc
+++ b/cmds/dev/gauge.lpc
@@ -20,9 +20,11 @@ void setup() {
   "many milliseconds of CPU the command took.";
 }
 
-mixed main(object tp, string cmd) {
+mixed main(
+  /** @type {STD_PLAYER} */ object tp,
+  string cmd
+) {
   mapping before, after;
-  int start_cost, end_cost;
   int stime, usertime, eval_cost;
 
   if(!cmd)

--- a/cmds/dev/gimme.lpc
+++ b/cmds/dev/gimme.lpc
@@ -21,7 +21,10 @@ void setup() {
     "hold.";
 }
 
-mixed main(object tp, string str) {
+mixed main(
+  /** @type {STD_PLAYER} */ object tp,
+  string str
+) {
   string type;
   int number;
 

--- a/cmds/dev/gr.lpc
+++ b/cmds/dev/gr.lpc
@@ -27,7 +27,7 @@ void setup() {
 }
 
 void handle_pstatus(mapping request, mapping response, object tp);
-void handle_gstatus(mapping request, mapping response, object tp);
+void handle_gstatus(mapping request, mixed response, object tp, string game);
 
 mixed main(object tp, string str) {
   string cmd, arg;
@@ -73,7 +73,7 @@ void handle_pstatus(mapping request, mixed response, object tp) {
   }
 }
 
-void handle_gstatus(mapping request, mixed response, object tp, string game) {
+void handle_gstatus(mapping _request, mixed response, object tp, string _game) {
   if(!tp) {
     return;
   }

--- a/cmds/dev/mgenerate.lpc
+++ b/cmds/dev/mgenerate.lpc
@@ -80,7 +80,7 @@ private string generate_terrain(string area_type, mixed seed) {
     }
 }
 
-string generate_area(string area_name, string area_type, int width, int height) {
+string generate_area(string _area_name, string area_type, int width, int height) {
     string *map;
     int y, x, seed, terrain_seed;
     string line;

--- a/cmds/dev/reset.lpc
+++ b/cmds/dev/reset.lpc
@@ -25,18 +25,18 @@ void setup() {
     "or an error if the target cannot be found.";
 }
 
-mixed main(object tp, string arg) {
-    object ob;
+mixed main(object _tp, string arg) {
+  object ob;
 
-    if(!arg)
-        arg = "here";
+  if(!arg)
+    arg = "here";
 
-    ob = get_object(arg);
+  ob = get_object(arg);
 
-    if(!objectp(ob))
-        return _error("Unable to find %s.", arg);
+  if(!objectp(ob))
+    return _error("Unable to find %s.", arg);
 
-    call_if(ob, "reset");
+  call_if(ob, "reset");
 
-    return _ok("Reset called on %s (%s).", get_short(ob), file_name(ob));
+  return _ok("Reset called on %s (%s).", get_short(ob), file_name(ob));
 }

--- a/cmds/dev/sc.lpc
+++ b/cmds/dev/sc.lpc
@@ -42,7 +42,7 @@ mixed main(object tp, string arg) {
   return str;
 }
 
-string deep_scan(object tp, object *inv, int indent) {
+string deep_scan(object _tp, object *inv, int indent) {
   object ob;
   string str;
 

--- a/cmds/dev/summon.lpc
+++ b/cmds/dev/summon.lpc
@@ -20,7 +20,10 @@ void setup() {
 "Use this command with care, as it can be disruptive to the game experience.";
 }
 
-mixed main(object tp, string arg) {
+mixed main(
+  /** @type {STD_PLAYER} */ object tp,
+  string arg
+) {
   object target, env, tenv;
   string name, tname;
 

--- a/cmds/dev/touch.lpc
+++ b/cmds/dev/touch.lpc
@@ -19,7 +19,10 @@ void setup() {
 "force the creation of the necessary directories.";
 }
 
-mixed main(object tp, string str) {
+mixed main(
+  /** @type {STD_PLAYER} */ object tp,
+  string str
+) {
     string file;
     int ret;
     int force;

--- a/cmds/object/trace.lpc
+++ b/cmds/object/trace.lpc
@@ -91,12 +91,20 @@ private mixed do_trace(object caller, string spec, int del) {
   return out;
 }
 
+/**
+ * 
+ * @param caller 
+ * @param blueprint 
+ * @param {STD_OBJECT} master_ob 
+ * @param clone_list 
+ */
 private mixed delete_matches(object caller, string blueprint, object master_ob,
                              object *clone_list) {
   int done;
 
+  /** @type {STD_OBJECT} */ object ob;
   if(sizeof(clone_list)) {
-    foreach(object ob in clone_list) {
+    foreach(ob in clone_list) {
       if(!objectp(ob))
         continue;
 
@@ -124,6 +132,11 @@ private mixed delete_matches(object caller, string blueprint, object master_ob,
   return _info(caller, "No loaded objects match %s.", blueprint);
 }
 
+/**
+ * 
+ * @param {STD_PLAYER} caller 
+ * @param spec 
+ */
 private string resolve_blueprint(object caller, string spec) {
   // A file path takes precedence, so an object reference never shadows a real
   // file you named. get_object() only loads real paths, and we've already


### PR DESCRIPTION
This PR refines the type annotation guidance in both the `lpc-coding-style` and `lpcdoc` skills to clarify how `STD_*` macros should be chosen, and applies that corrected guidance across several files.

## Type Annotation Philosophy Change

The previous guidance said to pick the most specific macro whose interface matches the methods the function actually calls. This was backwards — it caused annotations to drift shallower over time as new calls were added, and it ignored knowable facts about where objects come from.

The new rule is **shallowest first**: pick the shallowest type the object is provably known to be, reasoning from the object's origin rather than the function's current call sites. For example, a `caller` arriving through `main()` in a `cmds/adm/` or `cmds/dev/` command is always a player — no NPC walks that path — so it should be typed `STD_PLAYER` regardless of which methods the function happens to call today. Descend toward `STD_OBJECT` only as far as genuine uncertainty forces.

## Applied Fixes

- `adm/daemons/shutdown.lpc`: `this_body()` in `request()` annotated as `STD_PLAYER`; `@param` docs for `who` in `schedule`, `do_halt`, and `report_status` updated to `{STD_PLAYER}`.
- `adm/daemons/signal.lpc`: Variadic `@param` corrected to `{mixed...}` form.
- `adm/daemons/body.lpc`: `mudlib_setup()` call replaced with `std_setup()`.
- `cmds/ability/strike.lpc`: `ob2` annotation corrected from `OBJ_STRIKER` to `LIB_STRIKER`.
- `cmds/dev/exits.lpc`: `room` annotated as `STD_ROOM`; unused `args` parameter prefixed with `_`.
- `cmds/dev/gauge.lpc`, `gimme.lpc`, `summon.lpc`, `touch.lpc`: `tp` annotated as `STD_PLAYER`.
- `cmds/dev/gr.lpc`: Forward declaration corrected to match actual signature; unused parameters prefixed with `_`.
- `cmds/dev/mgenerate.lpc`, `reset.lpc`, `sc.lpc`: Unused parameters prefixed with `_`; `reset.lpc` indentation normalized.
- `cmds/object/trace.lpc`: `ob` hoisted out of `foreach` so it can carry a `@type` annotation; stub JSDoc blocks added to `delete_matches` and `resolve_blueprint`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR revises LPC type-annotation guidance and applies the corrected conventions across command and daemon code.
- Documents origin-based, shallowest-known `STD_*` annotation selection.
- Corrects annotations, callback declarations, variadic documentation, and unused parameter names.
- Replaces player-body `mudlib_setup()` initialization with the applicable `std_setup()` stage.
- Hoists a trace-command iterator so it can carry an LPCDoc type annotation.
</details>

<sub>Reviews (1): Last reviewed commit: ["various annotation changes"](https://github.com/gesslar/oxidus-mudlib/commit/763ad4808223710b9854e1114a04ddd06ee61fdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47424542)</sub>

<!-- /greptile_comment -->