### PR TITLE
Normalize indentation, add missing `help_text`, and modernize string formatting across commands

### DIFF
--- a/cmds/ability/punch.lpc
+++ b/cmds/ability/punch.lpc
@@ -24,11 +24,11 @@ void setup() {
   ]);
 
   usage_text = "punch <target>";
-  help_text = sprintf(
-"Use your fist to punch a target. This ability costs %.1f MP and has a "
-"cooldown of %d seconds.",
-  evaluate(mp_cost), evaluate(cooldowns["punch"][1])
-  );
+  help_text =
+    `Use your fist to punch a target. This ability costs ${evaluate(mp_cost)} `
+    `\n\n`
+    `MP and has a cooldown of ${evaluate(cooldowns["punch"][1])} seconds.`
+  ;
 }
 
 mixed use(/** @type {STD_BODY} */ object tp, string arg) {

--- a/cmds/ability/strike.lpc
+++ b/cmds/ability/strike.lpc
@@ -22,15 +22,15 @@ void setup() {
   ]);
 
   usage_text = "strike <object 1> with <object 2> [> <object3>]";
-  help_text = sprintf(
-"Use one object against another quickly, usually to perform an effect. "
-"Sometimes, you can direct the effect of your strike at a third object. "
-"Such as when building a fire, you can strike your firesteel with your flint "
-"and target some kindling."
-"\n"
-"This ability costs %.1f MP and has a cooldown of %d seconds.",
-  evaluate(mp_cost), evaluate(cooldowns["strike"][1])
-  );
+  help_text =
+    `Use one object against another quickly, usually to perform an effect. `
+    `Sometimes, you can direct the effect of your strike at a third object. `
+    `Such as when building a fire, you can strike your firesteel with your `
+    `flint and target some kindling.`
+    `\n\n`
+    `This ability costs ${evaluate(mp_cost)} MP and has a cooldown of `
+    `${evaluate(cooldowns["strike"][1])} seconds.`
+  ;
 }
 
 mixed use(/** @type {STD_BODY} */ object tp, string arg) {

--- a/cmds/action/eq.lpc
+++ b/cmds/action/eq.lpc
@@ -17,7 +17,8 @@ void setup() {
   help_text =
     "This command will list all the items you currently have equipped, "
     "including the clothing and armour you are wearing and the weapons you "
-    "are wielding, organised by the slot each occupies.\n\n"
+    "are wielding, organised by the slot each occupies."
+    "\n\n"
     "See also: remove, wear, wield, unwield";
 }
 

--- a/cmds/action/get.lpc
+++ b/cmds/action/get.lpc
@@ -27,8 +27,8 @@ void setup() {
     "get all from <container>\n"
     "get all <object> from <container>\n";
   help_text =
-    "This command picks things up off the ground or out of a container. Name a "
-    "single object to get just that one, or use 'all' to get everything (or "
+    "This command picks things up off the ground or out of a container. Name "
+    "a single object to get just that one, or use 'all' to get everything (or "
     "everything of a given type). With 'from <container>', it takes from the "
     "named container instead of the room.\n"
     "\n"

--- a/cmds/action/look.lpc
+++ b/cmds/action/look.lpc
@@ -12,6 +12,19 @@
 
 inherit STD_ACT;
 
+void setup() {
+  help_text =
+    "Describes your surroundings, or something in particular. On its own it "
+    "shows the room you are standing in, the ways out of it, and everything "
+    "you can see there. Name a target — 'look at sword' or just "
+    "'look sword' — to examine that instead, or 'look me' to examine "
+    "yourself. 'look in <container>' lists what a container holds. Targets "
+    "are searched for in your inventory first and then in the room; adding "
+    "'here' to the end skips your inventory and looks only at the room.\n"
+    "\n"
+    "See also: inventory\n";
+}
+
 mixed identify_filename(object ob, int vm);
 mixed describe_environment(object tp);
 mixed describe_object(object tp, object ob);

--- a/cmds/action/say.lpc
+++ b/cmds/action/say.lpc
@@ -15,7 +15,7 @@ inherit STD_ACT;
 void setup() {
     usage_text = "say <message>";
     help_text =
-"This command enables you to speak to the room.";
+      "This command enables you to speak to the room.";
 }
 
 mixed main(

--- a/cmds/dev/alarm.lpc
+++ b/cmds/dev/alarm.lpc
@@ -90,25 +90,25 @@ void setup() {
   "      (any unambiguous prefix; boot is config-file only)\n";
 
   help_text =
-  "This command inspects, adds, removes, and rehashes alarms registered "
-  "with the central alarm daemon (ALARM_D).\n\n"
-  "Recurring alarms (hourly/daily/weekly/monthly/yearly) and boot alarms "
-  "typically live in the configured ALARMS_PATH and are rehashed "
-  "automatically at boot. One-shot (\"once\") alarms added at runtime via "
-  "\"alarm add once\" persist across reboots.\n\n"
-  "\"alarm rehash\" rereads all config files and discards any runtime-added "
-  "alarms.\n\n"
-  "Only an admin may add an alarm with root permissions or rehash the "
-  "alarm daemon.\n\n"
-  "PATTERNS BY TYPE:\n"
-  "  once     YY-MM-DD@HH:MM\n"
-  "  hourly   MM\n"
-  "  daily    HH:MM\n"
-  "  weekly   D@HH:MM     (D = day-of-week, Sunday = 0)\n"
-  "  monthly  D@HH:MM     (D = day-of-month)\n"
-  "  yearly   MM-DD@HH:MM\n"
-  "  boot     <seconds after boot> (config-file only)\n";
-}
+    "This command inspects, adds, removes, and rehashes alarms registered "
+    "with the central alarm daemon (ALARM_D).\n\n"
+    "Recurring alarms (hourly/daily/weekly/monthly/yearly) and boot alarms "
+    "typically live in the configured ALARMS_PATH and are rehashed "
+    "automatically at boot. One-shot (\"once\") alarms added at runtime via "
+    "\"alarm add once\" persist across reboots.\n\n"
+    "\"alarm rehash\" rereads all config files and discards any runtime-added "
+    "alarms.\n\n"
+    "Only an admin may add an alarm with root permissions or rehash the "
+    "alarm daemon.\n\n"
+    "PATTERNS BY TYPE:\n"
+    "  once     YY-MM-DD@HH:MM\n"
+    "  hourly   MM\n"
+    "  daily    HH:MM\n"
+    "  weekly   D@HH:MM     (D = day-of-week, Sunday = 0)\n"
+    "  monthly  D@HH:MM     (D = day-of-month)\n"
+    "  yearly   MM-DD@HH:MM\n"
+    "  boot     <seconds after boot> (config-file only)\n";
+  }
 
 mixed main(object tp, string arg) {
   string type;

--- a/cmds/dev/callouts.lpc
+++ b/cmds/dev/callouts.lpc
@@ -37,20 +37,23 @@ void setup() {
   "                            name matches <pattern>\n";
 
   help_text =
-  "This command inspects the driver's pending call_out() queue "
-  "(call_out_info). Each entry shows the object, the function that will run, "
-  "and the time remaining before it fires, soonest first. The remaining time "
-  "is coloured by urgency.\n\n"
-  "This is a read-only diagnostic. A call_out belongs to the object that "
-  "scheduled it and can only be removed by that object, so this command does "
-  "not remove call_outs - it is for seeing what is scheduled and, via "
-  "\"callouts count\", where they are piling up. A leak shows up as a large "
-  "count against one object (clones collapsed to their base) or one "
-  "function.\n\n"
-  "\"callouts time\" shows absolute fire times instead of countdowns. A bare "
-  "argument other than \"time\" or \"count\" is treated as a filter matched "
-  "against both the object name and the function name.\n\n"
-  "See also: alarm\n";
+    "This command inspects the driver's pending call_out() queue "
+    "(call_out_info). Each entry shows the object, the function that will "
+    "run, and the time remaining before it fires, soonest first. The "
+    "remaining time is coloured by urgency.\n"
+    "\n"
+    "This is a read-only diagnostic. A call_out belongs to the object that "
+    "scheduled it and can only be removed by that object, so this command "
+    "does not remove call_outs - it is for seeing what is scheduled and, via "
+    "\"callouts count\", where they are piling up. A leak shows up as a large "
+    "count against one object (clones collapsed to their base) or one "
+    "function.\n"
+    "\n"
+    "\"callouts time\" shows absolute fire times instead of countdowns. A "
+    "bare argument other than \"time\" or \"count\" is treated as a filter "
+    "matched against both the object name and the function name.\n"
+    "\n"
+    "See also: alarm\n";
 }
 
 mixed main(object tp, string arg) {

--- a/cmds/dev/claude.lpc
+++ b/cmds/dev/claude.lpc
@@ -20,10 +20,10 @@ inherit STD_CMD;
 void setup() {
   usage_text = "claude <description of activity>";
   help_text =
-  "Logs a timestamped, one-line description of what the Claude agent is "
-  "about to do to the 'claude' log file, and notifies any online admins. "
-  "Intended for automated telnet sessions so agent activity is auditable "
-  "and visible in real time.";
+    "Logs a timestamped, one-line description of what the Claude agent is "
+    "about to do to the 'claude' log file, and notifies any online admins. "
+    "Intended for automated telnet sessions so agent activity is auditable "
+    "and visible in real time.";
 }
 
 mixed main(object tp, string arg) {

--- a/cmds/dev/dlevel.lpc
+++ b/cmds/dev/dlevel.lpc
@@ -21,9 +21,9 @@ void setup() {
   help_text =
     "Views and toggles driver debug levels. With no argument, it lists every "
     "known debug level with an on/off indicator showing its current state. "
-    "Give a valid <level> name to toggle that level: if it is currently off it "
-    "is enabled, and if it is currently on it is disabled. After toggling, the "
-    "updated list of debug levels is displayed.";
+    "Give a valid <level> name to toggle that level: if it is currently off "
+    "it is enabled, and if it is currently on it is disabled. After toggling, "
+    "the updated list of debug levels is displayed.";
 }
 
 varargs mixed main(object tp, string str) {

--- a/cmds/dev/do.lpc
+++ b/cmds/dev/do.lpc
@@ -23,11 +23,11 @@ void setup() {
   "  been executed 2, 2, 3 times.\n";
 
   help_text =
-  "Executes a list of commands and/or repeatedly. If a number is given, the "
-  "command is executed that many times. If a list of commands is given, each "
-  "command is executed the number of times specified. If the ! is used, all "
-  "commands are executed the number of times specified, repeating as "
-  "necessary to match the number of times specified for each commands.";
+    "Executes a list of commands and/or repeatedly. If a number is given, "
+    "the command is executed that many times. If a list of commands is given, "
+    "each command is executed the number of times specified. If the ! is "
+    "used, all commands are executed the number of times specified, repeating "
+    "as necessary to match the number of times specified for each commands.";
 }
 
 mixed main(

--- a/cmds/dev/echo.lpc
+++ b/cmds/dev/echo.lpc
@@ -16,15 +16,15 @@ inherit STD_CMD;
 void setup() {
   usage_text = "echo <message>";
   help_text =
-"This command provides a developer with the ability to print a message to everyone "
-"in the room.\n"
-"\n"
-"* The message is printed as-is\n"
-"* Colour codes are substituted\n"
-"* The message is not wrapped\n"
-"* The message is not echoed to the self, but the echoed message is confirmed\n"
-"\n"
-"Note: This will not print to anybody if you are hidden.";
+    "This command provides a developer with the ability to print a message to "
+    "everyone in the room.\n"
+    "\n"
+    "* The message is printed as-is\n"
+    "* Colour codes are substituted\n"
+    "* The message is not wrapped\n"
+    "* The message is not echoed to the self, but the echoed message is confirmed\n"
+    "\n"
+    "Note: This will not print to anybody if you are hidden.";
 }
 
 mixed main(

--- a/cmds/dev/env.lpc
+++ b/cmds/dev/env.lpc
@@ -21,15 +21,19 @@ void setup() {
   ;
 
   help_text =
-"This command allows you, the user, to setup, modify, or delete settings "
-"for your player object.\n\n"
-"To set a setting, you would type 'env setting value'. If you omit "
-"the second argument and a setting with a name matching the first argument "
-"exists, then that setting will be deleted.\n\n"
-"If the preference name ends with '_colour', and the value is 'prompt', then "
-"you will be prompted to select a colour from the available colours.\n\n"
-"See also: preferences, colour\n\n"
-"View {{ul1}}help settings{{ul0}} for available settings.";
+    "This command allows you, the user, to setup, modify, or delete settings "
+    "for your player object.\n\n"
+    "To set a setting, you would type 'env setting value'. If you omit the "
+    "second argument and a setting with a name matching the first argument "
+    "exists, then that setting will be deleted.\n"
+    "\n"
+    "If the preference name ends with '_colour', and the value is 'prompt', "
+    "then you will be prompted to select a colour from the available "
+    "colours.\n"
+    "\n"
+    "See also: preferences, colour\n"
+    "\n"
+    "View {{ul1}}help settings{{ul0}} for available settings.";
 }
 
 void prompt_colour_result(string input, object tp, string variable);

--- a/cmds/dev/eval.lpc
+++ b/cmds/dev/eval.lpc
@@ -16,9 +16,9 @@ inherit STD_CMD;
 void setup() {
   usage_text = "eval <lpc-statements>";
   help_text =
-"This command allows you to execute stand-alone lpc statements. Everything "
-"executed is done as {{bl1}}you{{bl0}}, so care should be taken that what you run "
-"is intended.";
+    "This command allows you to execute stand-alone lpc statements. "
+    "Everything executed is done as {{bl1}}you{{bl0}}, so care should be "
+    "taken that what you run is intended.";
 }
 
 mixed main(/** @type {STD_PLAYER} */ object caller, string arg) {

--- a/cmds/dev/exits.lpc
+++ b/cmds/dev/exits.lpc
@@ -14,7 +14,7 @@ inherit STD_CMD;
 void setup() {
   usage_text = "exits";
   help_text =
-"Shows all the exits in the current room and where they lead.";
+    "Shows all the exits in the current room and where they lead.";
 }
 
 mixed main(object tp, string _args) {

--- a/cmds/dev/gauge.lpc
+++ b/cmds/dev/gauge.lpc
@@ -16,8 +16,8 @@ inherit STD_CMD;
 void setup() {
   usage_text = "gauge <command>";
   help_text =
-  "The gauge command will execute the given command, and will tell you how "
-  "many milliseconds of CPU the command took.";
+    "The gauge command will execute the given command, and will tell you how "
+    "many milliseconds of CPU the command took.";
 }
 
 mixed main(

--- a/cmds/dev/gimme.lpc
+++ b/cmds/dev/gimme.lpc
@@ -16,9 +16,9 @@ void setup() {
   usage_text = "gimme <number> <type>";
   help_text =
     "Adds coins to your own wealth. Give the number of coins and the currency "
-    "type, which must be a valid currency from the currency daemon's list. The "
-    "number must be at least one. Fails if the amount would exceed what you can "
-    "hold.";
+    "type, which must be a valid currency from the currency daemon's list. "
+    "The number must be at least one. Fails if the amount would exceed what "
+    "you can hold.";
 }
 
 mixed main(

--- a/cmds/dev/killme.lpc
+++ b/cmds/dev/killme.lpc
@@ -16,8 +16,9 @@ inherit STD_CMD;
 void setup() {
   usage_text = "killme";
   help_text =
-"This command is used to coerce all NPCs in a room to attack you. It does not "
-"change their current target if they are already attacking someone else.";
+    "This command is used to coerce all NPCs in a room to attack you. It does "
+    "not change their current target if they are already attacking someone "
+    "else.";
 }
 
 mixed main(/** @type {STD_PLAYER} */ object caller, string _args) {

--- a/cmds/dev/mgenerate.lpc
+++ b/cmds/dev/mgenerate.lpc
@@ -14,15 +14,15 @@ inherit STD_CMD;
 inherit EXT_LOG;
 
 void setup() {
-    usage_text = "mgenerate <area name> <area type> <width> <height>\n";
-    help_text =
-        "Procedurally generates an area map file and writes it to your home "
-        "directory as <area name>.map. The area type controls the terrain "
-        "distribution: 'forest' (mostly forest with clearings), 'mountain' "
-        "(mostly mountain with hills), or 'desert' (mostly sand with the odd "
-        "oasis); any other type falls back to plains. Each cell is assigned a "
-        "smoothed elevation value alongside its terrain glyph. Width and "
-        "height are capped at 100 each.";
+  usage_text = "mgenerate <area name> <area type> <width> <height>\n";
+  help_text =
+    "Procedurally generates an area map file and writes it to your home "
+    "directory as <area name>.map. The area type controls the terrain "
+    "distribution: 'forest' (mostly forest with clearings), 'mountain' "
+    "(mostly mountain with hills), or 'desert' (mostly sand with the odd "
+    "oasis); any other type falls back to plains. Each cell is assigned a "
+    "smoothed elevation value alongside its terrain glyph. Width and "
+    "height are capped at 100 each.";
 }
 
 private string generate_cell(string area_type, int x, int y, int width, int ref *elevation_map, int ref terrain_seed);

--- a/cmds/dev/sc.lpc
+++ b/cmds/dev/sc.lpc
@@ -17,8 +17,9 @@ void setup() {
   help_text =
     "Deep scans an object, listing its entire nested inventory tree with each "
     "level indented beneath its container. The object may be named by any "
-    "resolvable reference; when omitted, the current room ('here') is scanned. "
-    "Each entry shows the object's file/id and its short description.";
+    "resolvable reference; when omitted, the current room ('here') is "
+    "scanned. Each entry shows the object's file/id and its short "
+    "description.";
 }
 
 string deep_scan(object tp, object *inv, int indent);

--- a/cmds/dev/summon.lpc
+++ b/cmds/dev/summon.lpc
@@ -14,10 +14,12 @@ inherit STD_CMD;
 void setup() {
   usage_text = "summon <user>";
   help_text =
-"This command allows you to move a user to your environment. You cannot "
-"summon admins, and if you are a developer you cannot summon other "
-"developers.\n\n"
-"Use this command with care, as it can be disruptive to the game experience.";
+    "This command allows you to move a user to your environment. You cannot "
+    "summon admins, and if you are a developer you cannot summon other "
+    "developers.\n"
+    "\n"
+    "Use this command with care, as it can be disruptive to the game "
+    "experience.";
 }
 
 mixed main(

--- a/cmds/dev/todo.lpc
+++ b/cmds/dev/todo.lpc
@@ -16,16 +16,16 @@
 inherit STD_REPORTER;
 
 void setup() {
-    set_report_type(query_file_name());
-    set_git_hub_label(query_file_name());
+  set_report_type(query_file_name());
+  set_git_hub_label(query_file_name());
 
-    usage_text = "todo [<subject>]";
-    help_text =
-        "Records a todo item for the game's maintainers. If you supply a "
-        "subject on the command line it is used directly; otherwise you are "
-        "prompted to enter one. You are then placed in the editor to describe "
-        "the todo in detail. When you finish editing, the report is written to "
-        "the local todo log and, where GitHub reporting is configured, filed "
-        "as an issue. Leaving the subject empty or exiting the editor without "
-        "content aborts the report.";
+  usage_text = "todo [<subject>]";
+  help_text =
+    "Records a todo item for the game's maintainers. If you supply a "
+    "subject on the command line it is used directly; otherwise you are "
+    "prompted to enter one. You are then placed in the editor to describe "
+    "the todo in detail. When you finish editing, the report is written to "
+    "the local todo log and, where GitHub reporting is configured, filed "
+    "as an issue. Leaving the subject empty or exiting the editor without "
+    "content aborts the report.";
 }

--- a/cmds/dev/touch.lpc
+++ b/cmds/dev/touch.lpc
@@ -12,11 +12,11 @@
 inherit STD_CMD;
 
 void setup() {
-    usage_text = "touch [-f] <file>";
-    help_text =
-"Creates a new empty file at the specified path. If the path does not exist, "
-"the function will fail to create the file unless the -f flag is used to "
-"force the creation of the necessary directories.";
+  usage_text = "touch [-f] <file>";
+  help_text =
+    "Creates a new empty file at the specified path. If the path does not "
+    "exist, the function will fail to create the file unless the -f flag is "
+    "used to force the creation of the necessary directories.";
 }
 
 mixed main(

--- a/cmds/dev/wall.lpc
+++ b/cmds/dev/wall.lpc
@@ -14,6 +14,11 @@ inherit STD_CMD;
 
 void setup() {
   usage_text = "wall <text>";
+  help_text =
+    "Broadcasts a message to every player currently in the game, stamped "
+    "with the server time and your name. There is no way for anyone to opt "
+    "out of receiving it, so keep it for announcements that genuinely "
+    "concern everybody.";
 }
 
 mixed main(

--- a/cmds/file/cd.lpc
+++ b/cmds/file/cd.lpc
@@ -12,6 +12,16 @@
 
 inherit STD_CMD;
 
+void setup() {
+  help_text =
+    "Changes your working directory — the directory that the other file "
+    "commands resolve relative paths against. The path may be absolute or "
+    "relative to where you already are, and with no path at all you are "
+    "returned to your own home directory.\n"
+    "\n"
+    "See also: ls, pwd\n";
+}
+
 mixed main(
   /** @type {STD_PLAYER} */ object caller,
   string str

--- a/cmds/file/ls.lpc
+++ b/cmds/file/ls.lpc
@@ -14,6 +14,24 @@
 
 inherit STD_CMD;
 
+void setup() {
+  help_text =
+    "Lists the contents of a directory, or a single entry if you name a "
+    "file. With no path it lists your current working directory. Wildcards "
+    "('*' and '?') are matched against the directory they appear in.\n"
+    "\n"
+    "Entries are coloured by kind — directories, source, headers, data, and "
+    "save files — and loaded objects are marked with an asterisk. Each "
+    "colour is a preference of its own — 'ls_directory', 'ls_source', "
+    "'ls_loaded', 'ls_header', 'ls_data', 'ls_save', and 'ls_other' — so "
+    "'set ls_source 6cf' will recolour source files.\n"
+    "\n"
+    "The '-l' flag switches to a long listing, adding each entry's size and "
+    "the date it was last modified.\n"
+    "\n"
+    "See also: cd, pwd, cat\n";
+}
+
 private mixed perform_ls(string target, string *flags);
 private mapping resolve_entry(string dir, mixed *entry);
 private mapping decorate_entry(mapping entry);

--- a/cmds/file/pwd.lpc
+++ b/cmds/file/pwd.lpc
@@ -10,6 +10,16 @@
  * 2026-07-16 - Gesslar - Created
  */
 
+inherit STD_CMD;
+
+void setup() {
+  help_text =
+    "Reports your current working directory — the directory that the other "
+    "file commands resolve relative paths against.\n"
+    "\n"
+    "See also: cd, ls\n";
+}
+
 mixed main(
   /** @type {STD_PLAYER} */ object caller,
   string _str

--- a/cmds/object/clean.lpc
+++ b/cmds/object/clean.lpc
@@ -12,6 +12,16 @@
 
 inherit STD_CMD;
 
+void setup() {
+  help_text =
+    "Empties an object's inventory, destructing everything in it. With no "
+    "argument it cleans the room you are standing in. Livings are left "
+    "alone; everything else is asked to remove itself first and destructed "
+    "outright if it survives that.\n"
+    "\n"
+    "See also: dest\n";
+}
+
 mixed main(
   /** @type {STD_PLAYER} */ object _tp,
   string str

--- a/cmds/object/dest.lpc
+++ b/cmds/object/dest.lpc
@@ -14,6 +14,17 @@ inherit STD_CMD;
 
 void setup() {
   usage_text = "dest <target|file>";
+  help_text =
+    "Destructs an object. The argument may be a file path, in which case the "
+    "loaded object for that file is destructed if one exists, or the name of "
+    "something in your inventory or in the room. Paths are resolved against "
+    "your current working directory, and a path that names a file which is "
+    "not loaded is reported rather than loaded just to destruct it.\n"
+    "\n"
+    "Destructing a player requires admin standing, and only an owner may "
+    "destruct another owner.\n"
+    "\n"
+    "See also: clean, update\n";
 }
 
 private int can_destruct(object tp, object ob);

--- a/cmds/object/showtree.lpc
+++ b/cmds/object/showtree.lpc
@@ -19,9 +19,9 @@ void setup() {
     "showtree <func> in <file>\n";
   help_text =
     "In its first version, shows you the full inheritance tree for the named "
-    "object. In its second form, it shows you all files in the inheritance tree "
-    "which contain the function you name, specifically noting those objects which "
-    "have definitions for the function."
+    "object. In its second form, it shows you all files in the inheritance "
+    "tree which contain the function you name, specifically noting those "
+    "objects which have definitions for the function."
   ;
 }
 

--- a/cmds/object/trace.lpc
+++ b/cmds/object/trace.lpc
@@ -27,15 +27,15 @@ void setup() {
     "trace <file|object>\n"
     "trace -d <file|object>";
   help_text =
-    "Finds every loaded object matching <file|object> - the master (blueprint) "
-    "and all of its clones.\n"
+    "Finds every loaded object matching <file|object> - the master "
+    "(blueprint) and all of its clones.\n"
     "\n"
     "<file|object> may be a file path (absolute or relative to your current "
     "working directory) or an object reference ('me', 'here', something in "
     "your inventory or room, or a living by name), whose blueprint is used.\n"
     "\n"
-    "With -d, the matching clones are destructed. If a blueprint has no clones, "
-    "the master copy itself is destructed instead.\n"
+    "With -d, the matching clones are destructed. If a blueprint has no "
+    "clones, the master copy itself is destructed instead.\n"
     "\n"
     "See also: clone, dest, update";
 }

--- a/cmds/object/update.lpc
+++ b/cmds/object/update.lpc
@@ -12,6 +12,29 @@
 
 inherit STD_CMD;
 
+void setup() {
+  usage_text =
+    "update [<file|object>]\n"
+    "update -r [<file|object>]\n"
+    "update -R [<file|object>]\n"
+  ;
+
+  help_text =
+    "Reloads an object from source, putting any players who were inside it "
+    "back afterwards. The target may be a file path or something you can "
+    "name in your inventory or the room; with no target at all, your current "
+    "working file is used, which is whatever you updated last.\n"
+    "\n"
+    "'-r' also reloads the object's immediate inheritables, and '-R' walks "
+    "the whole inheritance tree beneath it. Virtual objects are reloaded "
+    "through their virtual master.\n"
+    "\n"
+    "This command cannot update itself — destruct it instead and it will "
+    "reload on next use.\n"
+    "\n"
+    "See also: dest, showtree\n";
+}
+
 private nomask mapping resolve_target(mixed target, string kind);
 private nomask void generate_graph(mapping target, string kind);
 private nomask mixed reload_it(mixed target);

--- a/cmds/spell/arcanist/embers.lpc
+++ b/cmds/spell/arcanist/embers.lpc
@@ -24,11 +24,11 @@ void setup() {
   ]);
 
   usage_text = "embers <target>";
-  help_text = sprintf(
-"Hurl glowing embers at a target that cling and burn over a short "
-"time. This spell costs %.1f SP and has a cooldown of %d seconds.",
-    evaluate(sp_cost), evaluate(cooldowns["embers"][1])
-  );
+  help_text =
+    "Hurl glowing embers at a target that cling and burn over a short "
+    `time. This spell costs ${evaluate(sp_cost)} SP and has a cooldown of `
+    `${evaluate(cooldowns["embers"][1])} seconds.`
+  ;
 }
 
 mixed use(/** @type {STD_BODY} */ object tp, string arg) {

--- a/cmds/spell/arcanist/motes.lpc
+++ b/cmds/spell/arcanist/motes.lpc
@@ -23,11 +23,11 @@ void setup() {
   ]);
 
   usage_text = "motes <target>";
-  help_text = sprintf(
-"Summon motes of light to strike a target. This spell costs "
-"%.1f SP and has a cooldown of %d seconds.",
-    evaluate(sp_cost), evaluate(cooldowns["motes"][1])
-  );
+  help_text =
+    "Summon motes of light to strike a target. This spell costs "
+    `${evaluate(sp_cost)} SP and has a cooldown of `
+    `${evaluate(cooldowns["motes"][1])} seconds.`
+  ;
 }
 
 mixed use(/** @type {STD_BODY} */ object tp, string arg) {

--- a/cmds/spell/arcanist/shard.lpc
+++ b/cmds/spell/arcanist/shard.lpc
@@ -24,13 +24,12 @@ void setup() {
   ]);
 
   usage_text = "shard <target>";
-  help_text = sprintf(
-"Drive a wicked shard of magical ice into a target. The shard "
-"strikes for a small initial wound, then shatters a few seconds "
-"later for a burst of cold damage. This spell costs %.1f SP and "
-"has a cooldown of %d seconds.",
-    evaluate(sp_cost), evaluate(cooldowns["shard"][1])
-  );
+  help_text =
+    "Drive a wicked shard of magical ice into a target. The shard strikes "
+    "for a small initial wound, then shatters a few seconds later for a "
+    `burst of cold damage. This spell costs ${evaluate(sp_cost)} SP and has `
+    `a cooldown of ${evaluate(cooldowns["shard"][1])} seconds.`
+  ;
 }
 
 mixed use(/** @type {STD_BODY} */ object tp, string arg) {

--- a/cmds/spell/arcanist/shock.lpc
+++ b/cmds/spell/arcanist/shock.lpc
@@ -24,13 +24,12 @@ void setup() {
   ]);
 
   usage_text = "shock <target>";
-  help_text = sprintf(
-"Loose a bolt of lightning at a target. The bolt strikes "
-"immediately with no incantation — paid for in SP and a "
-"longer cooldown. This spell costs %.2f SP and has a cooldown "
-"of %d seconds.",
-    evaluate(sp_cost), evaluate(cooldowns["shock"][1])
-  );
+  help_text =
+    "Loose a bolt of lightning at a target. The bolt strikes immediately "
+    "with no incantation — paid for in SP and a longer cooldown. This "
+    `spell costs ${evaluate(sp_cost)} SP and has a cooldown of `
+    `${evaluate(cooldowns["shock"][1])} seconds.`
+  ;
 }
 
 mixed use(

--- a/cmds/spell/arcanist/wither.lpc
+++ b/cmds/spell/arcanist/wither.lpc
@@ -24,12 +24,11 @@ void setup() {
   ]);
 
   usage_text = "wither <target>";
-  help_text = sprintf(
-"Weave grasping shadow that clings to a target and weakens "
-"their defenses for a time. This spell costs %.1f SP and has "
-"a cooldown of %d seconds.",
-    evaluate(sp_cost), evaluate(cooldowns["wither"][1])
-  );
+  help_text =
+    "Weave grasping shadow that clings to a target and weakens their "
+    `defences for a time. This spell costs ${evaluate(sp_cost)} SP and has `
+    `a cooldown of ${evaluate(cooldowns["wither"][1])} seconds.`
+  ;
 }
 
 mixed use(/** @type {STD_BODY} */ object tp, string arg) {

--- a/cmds/std/attr.lpc
+++ b/cmds/std/attr.lpc
@@ -14,26 +14,26 @@
 inherit STD_CMD;
 
 void setup() {
-    usage_text = "attr";
-    help_text =
-        "Displays your character's attributes and their current values. Each "
-        "of the game's configured attributes is listed on its own line with "
-        "its name and numeric value. The command takes no arguments.";
+  usage_text = "attr";
+  help_text =
+    "Displays your character's attributes and their current values. Each "
+    "of the game's configured attributes is listed on its own line with "
+    "its name and numeric value. The command takes no arguments.";
 }
 
 mixed main(/** @type {STD_BODY} */ object tp,
-    string _str) {
-    string *attrs, attr;
-    string out = "";
+  string _str) {
+  string *attrs, attr;
+  string out = "";
 
-    attrs = mud_config("ATTRIBUTES");
+  attrs = mud_config("ATTRIBUTES");
 
-    foreach(attr in attrs) {
-        out += sprintf("%-15s: %d\n",
-            capitalize(attr),
-            tp->get_attribute(attr)
-        );
-    }
+  foreach(attr in attrs) {
+    out += sprintf("%-15s: %d\n",
+      capitalize(attr),
+      tp->get_attribute(attr)
+    );
+  }
 
-    return out;
+  return out;
 }

--- a/cmds/std/bug.lpc
+++ b/cmds/std/bug.lpc
@@ -16,16 +16,16 @@
 inherit STD_REPORTER;
 
 void setup() {
-    set_report_type(query_file_name());
-    set_git_hub_label(query_file_name());
+  set_report_type(query_file_name());
+  set_git_hub_label(query_file_name());
 
-    usage_text = "bug [<subject>]";
-    help_text =
-        "Reports a bug to the game's maintainers. If you supply a subject on "
-        "the command line it is used directly; otherwise you are prompted to "
-        "enter one. You are then placed in the editor to describe the bug in "
-        "detail. When you finish editing, the report is written to the local "
-        "bug log and, where GitHub reporting is configured, filed as an issue. "
-        "Leaving the subject empty or exiting the editor without content "
-        "aborts the report.";
+  usage_text = "bug [<subject>]";
+  help_text =
+    "Reports a bug to the game's maintainers. If you supply a subject on "
+    "the command line it is used directly; otherwise you are prompted to "
+    "enter one. You are then placed in the editor to describe the bug in "
+    "detail. When you finish editing, the report is written to the local "
+    "bug log and, where GitHub reporting is configured, filed as an issue. "
+    "Leaving the subject empty or exiting the editor without content "
+    "aborts the report.";
 }

--- a/cmds/std/colour.lpc
+++ b/cmds/std/colour.lpc
@@ -18,17 +18,17 @@ void setup() {
   usage_text = "colour [<on>|<off>|list|show [#]]";
 
   help_text =
-"With no arguments, this command will tell you if you currently have "
-"colour enabled or disabled. You can also toggle colour by providing the "
-"arguments {{ul1}}on{{ul0}} to enable or {{ul1}}off{{ul0}} to disable.\n"
-"\n"
-"Use the {{ul1}}list{{ul0}} argument to list all the available colours.\n"
-"\n"
-"Use the {{ul1}}show{{ul0}} argument to see how a specific colour code "
-"will appear in the foreground and background. The argument must be a "
-"number between 0 and 255.\n"
-"\n"
-"See also: set";
+    "With no arguments, this command will tell you if you currently have "
+    "colour enabled or disabled. You can also toggle colour by providing the "
+    "arguments {{ul1}}on{{ul0}} to enable or {{ul1}}off{{ul0}} to disable.\n"
+    "\n"
+    "Use the {{ul1}}list{{ul0}} argument to list all the available colours.\n"
+    "\n"
+    "Use the {{ul1}}show{{ul0}} argument to see how a specific colour code "
+    "will appear in the foreground and background. The argument must be a "
+    "number between 0 and 255.\n"
+    "\n"
+    "See also: set";
 }
 
 mixed main(/** @type {STD_PLAYER} */ object caller, string str) {

--- a/cmds/std/con.lpc
+++ b/cmds/std/con.lpc
@@ -13,61 +13,59 @@
 inherit STD_CMD;
 
 void setup() {
-    help_text =
-"This will show you the current condition of the target. Without a target, "
-"it will show your own condition.\n"
-"\n"
-"When comparing yourself to a non-player target, it will also give you a "
-"rough idea of how you compare in strength.\n";
-
-    usage_text = "con [target]";
+  usage_text = "con [target]";
+  help_text =
+    "This will show you the current condition of the target. Without a "
+    "target, it will show your own condition.\n"
+    "\n"
+    "When comparing yourself to a non-player target, it will also give you a "
+    "rough idea of how you compare in strength.\n";
 }
 
-mixed main(/** @type {STD_BODY} */ object tp,
-    string str) {
-    object ob;
-    string name;
-    string target;
-    string result = "";
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string str) {
+  object ob;
+  string result = "";
 
-    if(!str) {
-        ob = tp;
-    } else {
-        object room = environment(tp);
-        if(!ob = find_target(tp, str))
-            return "You don't see that here.\n";
-    }
+  if(!str) {
+    ob = tp;
+  } else {
+    if(!ob = find_target(tp, str))
+      return "You don't see that here.\n";
+  }
 
-    if(!living(ob))
-        return ob->query_name() + " is " + ob->query_name();
+  string name = /** @type {STD_OBJECT} */ (ob)->query_name();
 
-    name = ob->query_name();
-    if(ob == tp) {
-        string *conditions = ob->query_condition_string();
-        result += "You are " + conditions[0] + ".\n";
-        result += "Your mind feels " + conditions[1] + ".\n";
-        result += "You are feeling " + conditions[2] + ".\n";
-    } else {
-        if(ob->is_npc()) {
-            float lvl = tp->query_level();
-            float ob_lvl = ob->query_level();
-            float diff = lvl - ob_lvl;
+  if(!living(ob))
+    return `${name} is ${name}.`;
 
-            if(diff > 5.0) {
-                result += name + " is much weaker than you.\n";
-            } else if(diff > 0.0) {
-                result += name + " is weaker than you.\n";
-            } else if(diff < -5.0) {
-                result += name + " is much stronger than you.\n";
-            } else if(diff < 0.0) {
-                result += name + " is stronger than you.\n";
-            } else {
-                result += name + " is about as strong as you.\n";
-            }
+  string *conditions = /** @type {STD_BODY} */ (ob)->query_condition_string();
+  if(ob == tp) {
+    result += `You are ${conditions[0]}.\n`;
+    result += `Your mind feels ${conditions[1]}.\n`;
+    result += `You are feeling ${conditions[2]}.\n`;
+  } else {
+      if(npcp(ob)) {
+        float lvl = tp->query_level();
+        float ob_lvl = ob->query_level();
+        float diff = lvl - ob_lvl;
+
+        if(diff > 5.0) {
+          result += `${name} is much weaker than you.\n`;
+        } else if(diff > 0.0) {
+          result += `${name} is weaker than you.\n`;
+        } else if(diff < -5.0) {
+          result += `${name} is much stronger than you.\n`;
+        } else if(diff < 0.0) {
+          result += `${name} is stronger than you.\n`;
+        } else {
+          result += `${name} is about as strong as you.\n`;
         }
+      }
 
-        result += name + " is " + ob->query_condition_string()[0] + ".\n";
-    }
+      result += `${name} is ${conditions[0]}.\n`;
+  }
 
-    return result;
+  return result;
 }

--- a/cmds/std/date.lpc
+++ b/cmds/std/date.lpc
@@ -12,6 +12,15 @@
 
 inherit STD_CMD;
 
+void setup() {
+  help_text =
+    "Reports the current date and time on the server that runs the game. "
+    "This is real-world time, not the time of day in the world itself. The "
+    "command takes no arguments.\n"
+    "\n"
+    "See also: time\n";
+}
+
 mixed main(
   /** @type {STD_PLAYER} */ object _tp,
   string _str

--- a/cmds/std/detail.lpc
+++ b/cmds/std/detail.lpc
@@ -16,49 +16,67 @@
 inherit STD_CMD;
 
 void setup() {
-    usage_text = "detail features - list the available features to detail\n"
-                 "detail <feature> - detail a feature\n";
+  usage_text = "detail features - list the available features to detail\n"
+               "detail <feature> - detail a feature\n";
+
+  help_text =
+    "Fills in the descriptive details of your character. Name the feature "
+    "you want to work on and an editor opens for it — 'detail description' "
+    "sets the long description others read when they look at you, and is "
+    "limited to 800 characters.\n"
+    "\n"
+    "See also: look, score\n";
 }
 
-mixed main(object tp, string str) {
-    mixed result;
+mixed main(
+  /** @type {STD_PLAYER} */ object tp,
+  string str
+) {
+  mixed result;
 
-    if(!str)
-        return "Usage:\n" + usage_text;
+  if(!str)
+    return _usage(tp);
 
-    result = call_if(this_object(), sprintf("detail_%s", str), tp);
+  result = call_if(this_object(), sprintf("detail_%s", str), tp);
 
-    return result || "Unknown feature.";
+  return result || "Unknown feature.";
 }
 
 private void finish_description(int status, string file, string temp_file, object tp);
-private mixed detail_description(object tp) {
-    string prompt;
 
-    prompt = "Enter your long description. You are limited to 800 characters\n\n";
-    tell(tp, prompt);
-    tp->start_edit(
-        null,
-        assemble_call_back((: finish_description :), tp)
-    );
+private mixed detail_description(/** @type {STD_PLAYER} */ object tp) {
+  string prompt;
 
-    return 1;
+  prompt = "Enter your long description. You are limited to 800 characters\n\n";
+  tell(tp, prompt);
+  tp->start_edit(
+    null,
+    assemble_call_back((: finish_description :), tp)
+  );
+
+  return 1;
 }
 
-private void finish_description(int status, string file, string temp_file, object tp) {
-    string text;
+private void finish_description(
+  int status,
+  string temp_file,
+  string _file,
+  /** @type {STD_PLAYER} */ object tp
+) {
+  string text;
 
-    defer((: rm, temp_file :));
+  defer((: rm, temp_file :));
 
-    if(status == ED_STATUS_ABORTED || file_size(temp_file) < 1) {
-        if(interactive(tp))
-            _info(tp, "Description aborted.");
-        return;
-    }
+  if(status == ED_STATUS_ABORTED || file_size(temp_file) < 1) {
+    if(interactive(tp))
+      _info(tp, "Description aborted.");
 
-    text = read_file(temp_file);
+    return;
+  }
 
-    tp->set_long(text);
+  text = read_file(temp_file);
 
-    tell(tp, "Description updated.\n");
+  tp->set_long(text);
+
+  tell(tp, "Description updated.\n");
 }

--- a/cmds/std/gmcp.lpc
+++ b/cmds/std/gmcp.lpc
@@ -20,20 +20,20 @@ private void gmcp_gui_result(mapping response, object tp);
 
 void setup() {
     usage_text =
-"gmcp - Displays your current GMCP status.\n"
-"gmcp <on/off> - Enables or disables GMCP.\n"
-"gmcp gui - Requests the Mudlet GUI install from the server.\n";
+      "gmcp - Displays your current GMCP status.\n"
+      "gmcp <on/off> - Enables or disables GMCP.\n"
+      "gmcp gui - Requests the Mudlet GUI install from the server.\n";
 
     help_text =
-"Displays your current GMCP status or enables/disables GMCP. GMCP is a "
-"protocol that allows the server to send information to the client. This "
-"information can be used to enhance the user interface and provide additional "
-"information to the player. GMCP is only available if the client supports it "
-"and it is enabled in the client and the server.\n"
-"\n"
-"You can also use the 'gui' option to request the Mudlet GUI information from "
-"the server. This will automatically install the latest version of the GUI "
-"for the "+mud_name()+" client.\n";
+      "Displays your current GMCP status or enables/disables GMCP. GMCP is a "
+      "protocol that allows the server to send information to the client. "
+      "This information can be used to enhance the user interface and provide "
+      "additional information to the player. GMCP is only available if the "
+      "client supports it and it is enabled in the client and the server.\n"
+      "\n"
+      "You can also use the 'gui' option to request the Mudlet GUI "
+      "information from the server. This will automatically install the "
+      `latest version of the GUI for the ${mud_name()} client.`;
 }
 
 mixed main(/** @type {STD_PLAYER} */ object tp, string arg) {
@@ -83,7 +83,7 @@ mixed main(/** @type {STD_PLAYER} */ object tp, string arg) {
     return "Syntax: gmcp OR gmcp [on|off]";
 }
 
-private mixed gmcp_status(object tp) {
+private mixed gmcp_status(/** @type {STD_PLAYER} */ object tp) {
     if(tp->gmcp_enabled())
         return "GMCP is currently enabled.";
 

--- a/cmds/std/help.lpc
+++ b/cmds/std/help.lpc
@@ -19,9 +19,10 @@ private mixed get_file_help(object tp, string topic);
 void setup() {
   usage_text = "help <topic>";
   help_text =
-"Looks up help on a topic. If the topic names a command on your command path, "
-"that command's own help is shown; otherwise the help files are searched for a "
-"matching topic. With no topic, a brief reminder of the syntax is shown.";
+    "Looks up help on a topic. If the topic names a command on your command "
+    "path, that command's own help is shown; otherwise the help files are "
+    "searched for a matching topic. With no topic, a brief reminder of the "
+    "syntax is shown.";
 }
 
 mixed main(

--- a/cmds/std/idea.lpc
+++ b/cmds/std/idea.lpc
@@ -17,16 +17,16 @@
 inherit STD_REPORTER;
 
 void setup() {
-    set_report_type(query_file_name());
-    set_git_hub_label("enhancement");
+  set_report_type(query_file_name());
+  set_git_hub_label("enhancement");
 
-    usage_text = "idea [<subject>]";
-    help_text =
-        "Submits an idea or enhancement suggestion to the game's maintainers. "
-        "If you supply a subject on the command line it is used directly; "
-        "otherwise you are prompted to enter one. You are then placed in the "
-        "editor to describe your idea in detail. When you finish editing, the "
-        "report is written to the local idea log and, where GitHub reporting "
-        "is configured, filed as an enhancement issue. Leaving the subject "
-        "empty or exiting the editor without content aborts the report.";
+  usage_text = "idea [<subject>]";
+  help_text =
+    "Submits an idea or enhancement suggestion to the game's maintainers. "
+    "If you supply a subject on the command line it is used directly; "
+    "otherwise you are prompted to enter one. You are then placed in the "
+    "editor to describe your idea in detail. When you finish editing, the "
+    "report is written to the local idea log and, where GitHub reporting "
+    "is configured, filed as an enhancement issue. Leaving the subject "
+    "empty or exiting the editor without content aborts the report.";
 }

--- a/cmds/std/inventory.lpc
+++ b/cmds/std/inventory.lpc
@@ -12,6 +12,16 @@
 
 inherit STD_CMD;
 
+void setup() {
+  help_text =
+    "Lists what you are carrying, and how much of your carrying capacity is "
+    "spoken for. Anything you have equipped is marked with an asterisk. "
+    "Give an argument to narrow the list to the items answering to that "
+    "name.\n"
+    "\n"
+    "See also: look, eq, wealth\n";
+}
+
 private string *format_contents(object *obs, int fns);
 
 mixed main(

--- a/cmds/std/passwd.lpc
+++ b/cmds/std/passwd.lpc
@@ -19,39 +19,40 @@ private void new_password(string str, object tp);
 private void confirm_password(string str, string pass, object tp);
 
 void setup() {
-    usage_text = "passwd";
+  usage_text = "passwd";
 
-    help_text =
-"This command allows you to change your current passwd. You will be asked to "
-"enter your current passwd for security purposes and then it will request you "
-"to input your new passwd and then will ask again to confirm. After you have "
-"provided the requested information, the command will inform you if the change "
-"was succesful.";
+  help_text =
+    "This command allows you to change your current passwd. You will be asked "
+    "to enter your current passwd for security purposes and then it will "
+    "request you to input your new passwd and then will ask again to confirm. "
+    "After you have provided the requested information, the command will "
+    "inform you if the change was succesful.";
 }
 
-mixed main(object tp, string arg) {
-    _info("Changing your password.");
-    prompt_password(tp, 3, assemble_call_back((:password_confirmed:), tp));
+mixed main(object tp, string _arg) {
+  _info("Changing your password.");
+  prompt_password(tp, 3, assemble_call_back((:password_confirmed:), tp));
 
-    return 1;
+  return 1;
 }
 
 private void password_confirmed(int status, object tp) {
-    if(status) {
-        _question("Please enter your new password: ");
-        input_to((:new_password:), I_NOECHO | I_NOESC, tp);
-    } else {
-        _error("Password change failed.");
-    }
+  if(status) {
+    _question("Please enter your new password: ");
+    input_to((:new_password:), I_NOECHO | I_NOESC, tp);
+  } else {
+    _error("Password change failed.");
+  }
 }
 
 private void new_password(string str, object tp) {
-    if(!str || str == "") {
-        _error("Password cannot be empty.");
-        return;
-    }
-    _question("Please confirm your new password: ");
-    input_to((:confirm_password:), I_NOECHO | I_NOESC, str, tp);
+  if(!str || str == "") {
+    _error("Password cannot be empty.");
+    return;
+  }
+
+  _question("Please confirm your new password: ");
+  input_to((:confirm_password:), I_NOECHO | I_NOESC, str, tp);
 }
 
 /**
@@ -61,11 +62,11 @@ private void new_password(string str, object tp) {
  * @param {STD_PLAYER} tp
  */
 private void confirm_password(string str, string pass, object tp) {
-    if(str == pass) {
-        _ok("Password accepted.");
-        ACCOUNT_D->write_account(tp->query_real_name(), "password", crypt(str, 0));
-        _ok("Password changed.");
-    } else {
-        _error("Passwords do not match.");
-    }
+  if(str == pass) {
+    _ok("Password accepted.");
+    ACCOUNT_D->write_account(tp->query_real_name(), "password", crypt(str, 0));
+    _ok("Password changed.");
+  } else {
+    _error("Passwords do not match.");
+  }
 }

--- a/cmds/std/quit.lpc
+++ b/cmds/std/quit.lpc
@@ -10,6 +10,20 @@
  * 2026-07-16 - Gesslar - Created
  */
 
+inherit STD_CMD;
+
+void setup() {
+  help_text =
+    "Leaves the game. You and everything you are carrying are saved on the "
+    "way out, so you will pick up exactly where you left off next time you "
+    "log in.\n"
+    "\n"
+    "If you keep a file called '.quit' in your home directory, each line of "
+    "it is run as a command just before you go.\n"
+    "\n"
+    "See also: save\n";
+}
+
 mixed main(
   /** @type {STD_PLAYER} */ object caller,
   string _str

--- a/cmds/std/save.lpc
+++ b/cmds/std/save.lpc
@@ -12,6 +12,15 @@
 
 inherit STD_CMD;
 
+void setup() {
+  help_text =
+    "Writes your character and everything you are carrying to disk. This is "
+    "rarely necessary — you are saved at the points that matter, quitting "
+    "among them — but it costs nothing to be sure.\n"
+    "\n"
+    "See also: quit\n";
+}
+
 mixed main(
   /** @type {STD_PLAYER} */ object caller,
   string _str

--- a/cmds/std/score.lpc
+++ b/cmds/std/score.lpc
@@ -14,32 +14,37 @@
 inherit STD_CMD;
 
 void setup() {
-    usage_text = "score";
-    help_text =
-        "Displays your character sheet: your name, level, and race, your "
-        "current hit points, spell points, and magic points, and your "
-        "accumulated experience along with the amount required to advance to "
-        "the next level. The command takes no arguments.";
+  usage_text = "score";
+  help_text =
+    "Displays your character sheet: your name, level, and race, your "
+    "current hit points, spell points, and magic points, and your "
+    "accumulated experience along with the amount required to advance to "
+    "the next level. The command takes no arguments.";
 }
 
-mixed main(/** @type {STD_BODY} */ object tp,
-    string _str) {
-    string result;
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string _str
+) {
+  string result;
 
-    result = sprintf("You are %s, a level %d %s.\n",
-        capitalize(tp->query_real_name()),
-        to_int(tp->query_level()),
-        tp->query_race());
+  result = sprintf("You are %s, a level %d %s.\n",
+    capitalize(tp->query_real_name()),
+    to_int(tp->query_level()),
+    tp->query_race()
+  );
 
-    result += sprintf("You have %.2f hp, %.2f sp, and %.2f mp.\n",
-        tp->query_hp(),
-        tp->query_sp(),
-        tp->query_mp());
+  result += sprintf("You have %.2f hp, %.2f sp, and %.2f mp.\n",
+    tp->query_hp(),
+    tp->query_sp(),
+    tp->query_mp()
+  );
 
-    result += sprintf("You have %s experience points and require %s "
-        "to advance.\n",
-        add_commas(tp->query_xp()),
-        add_commas(tp->query_tnl()));
+  result += sprintf("You have %s experience points and require %s "
+    "to advance.\n",
+    add_commas(tp->query_xp()),
+    add_commas(tp->query_tnl())
+  );
 
-    return result;
+  return result;
 }

--- a/cmds/std/set.lpc
+++ b/cmds/std/set.lpc
@@ -14,22 +14,27 @@ inherit STD_CMD;
 
 void setup() {
   usage_text =
-  "set - view your current preferences\n"
-  "set <preference> - delete a preference\n"
-  "set <preference> <value> - set a preference\n"
-  "set <preference>_colour prompt - prompt for a colour\n"
-;
+    "set - view your current preferences\n"
+    "set <preference> - delete a preference\n"
+    "set <preference> <value> - set a preference\n"
+    "set <preference>_colour prompt - prompt for a colour\n"
+  ;
 
   help_text =
-"This command allows you, the user, to setup, modify, or delete preferences "
-"for your player object.\n\n"
-"To set a preference, you would type 'set preference value'. If you omit "
-"the second argument and a preference with a name matching the first argument "
-"exists, then that preference will be deleted.\n\n"
-"If the preference name ends with '_colour', and the value is 'prompt', then "
-"you will be prompted to select a colour from the available colours.\n\n"
-"See also: preferences, colour\n\n"
-"View {{ul1}}help preferences{{ul0}} for available preferences.";
+    "This command allows you, the user, to setup, modify, or delete "
+    "preferences for your player object.\n"
+    "\n"
+    "To set a preference, you would type 'set preference value'. If you omit "
+    "the second argument and a preference with a name matching the first "
+    "argument exists, then that preference will be deleted.\n"
+    "\n"
+    "If the preference name ends with '_colour', and the value is 'prompt', "
+    "then you will be prompted to select a colour from the available "
+    "colours.\n"
+    "\n"
+    "See also: preferences, colour\n"
+    "\n"
+    "View {{ul1}}help preferences{{ul0}} for available preferences.";
 }
 
 private void prompt_colour_result(string input, object tp, string variable);

--- a/cmds/std/skills.lpc
+++ b/cmds/std/skills.lpc
@@ -19,39 +19,48 @@ void setup() {
     help_text = "This command will display your current skill levels.\n";
 }
 
-mixed main(/** @type {STD_BODY} */ object tp,
-    string str) {
-    mapping skills = tp->query_skills();
-    string result;
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string str
+) {
+  mapping skills = tp->query_skills();
+  string result;
 
-    result = process_skill_data(tp, skills, "", 0);
+  result = process_skill_data(tp, skills, "", 0);
 
-    return result;
+  return result;
 }
 
+/**
+ *
+ * @param {STD_BODY} tp
+ * @param s
+ * @param curr
+ * @param depth
+ */
 private string process_skill_data(object tp, mapping s, string curr, int depth) {
-    string *cles, cle;
-    string result = "";
+  string *cles, cle;
+  string result = "";
 
-    cles = keys(s);
-    cles = sort_array(cles, 1);
+  cles = keys(s);
+  cles = sort_array(cles, 1);
 
-    if(strlen(curr))
-        curr = curr + ".";
+  if(strlen(curr))
+    curr = curr + ".";
 
-    foreach(cle in cles) {
-        int level, progress;
-        mapping sub;
-        string skill;
+  foreach(cle in cles) {
+    int level, progress;
+    mapping sub;
+    string skill;
 
-        level = tp->query_skill_level(curr+cle);
-        progress = tp->query_skill_progress(curr+cle);
+    level = tp->query_skill_level(curr+cle);
+    progress = tp->query_skill_progress(curr+cle);
 
-        result += sprintf("%3d %*s %s (%d%%)\n", level, depth * 2, "", cle, progress);
-        sub = s[cle]["subskills"];
-        if(sizeof(sub))
-            result += process_skill_data(tp, sub, curr+cle, depth + 1);
-    }
+    result += sprintf("%3d %*s %s (%d%%)\n", level, depth * 2, "", cle, progress);
+    sub = s[cle]["subskills"];
+    if(sizeof(sub))
+      result += process_skill_data(tp, sub, curr+cle, depth + 1);
+  }
 
-    return result;
+  return result;
 }

--- a/cmds/std/su.lpc
+++ b/cmds/std/su.lpc
@@ -28,7 +28,10 @@ void setup() {
     "in use by an interactive connection cannot be possessed.";
 }
 
-mixed main(object user, string arg) {
+mixed main(
+  /** @type {STD_BODY} */ object user,
+  string arg
+) {
   object
   /** @type {STD_BODY} */     dest,
   /** @type {STD_BODY} */     su_body,

--- a/cmds/std/time.lpc
+++ b/cmds/std/time.lpc
@@ -14,12 +14,12 @@
 inherit STD_CMD;
 
 void setup() {
-    usage_text = "time";
-    help_text =
-        "Reports the current in-game time as tracked by the time daemon. The "
-        "command takes no arguments.";
+  usage_text = "time";
+  help_text =
+    "Reports the current in-game time as tracked by the time daemon. The "
+    "command takes no arguments.";
 }
 
 mixed main(object tp, string str) {
-    return sprintf("It is now %s.\n", TIME_D->query_full_time());
+  return sprintf("It is now %s.\n", TIME_D->query_full_time());
 }

--- a/cmds/std/waypoint.lpc
+++ b/cmds/std/waypoint.lpc
@@ -14,21 +14,25 @@ inherit STD_CMD;
 
 void setup() {
   usage_text =
-  "waypoint list - List all waypoints.\n"
-  "waypoint set - Set a waypoint at your current location.\n"
-  "waypoint remove <#> - Remove a waypoint.\n";
+    "waypoint list - List all waypoints.\n"
+    "waypoint set - Set a waypoint at your current location.\n"
+    "waypoint remove <#> - Remove a waypoint.\n";
 
   help_text =
-  "This command allows you to manage waypoints, which are saved locations "
-  "that you can quickly travel to using the `travel` command.\n\n"
-  "To set a waypoint, type `waypoint set`. This will save your current "
-  "location as waypoint 1. You can set additional waypoints by using the "
-  "`waypoint set` command again, which will save your current location as "
-  "waypoint 2, and so on.\n\n"
-  "To remove a waypoint, type `waypoint remove <#>`, replacing <#> with the "
-  "number of the waypoint you want to remove.\n\n"
-  "To use a waypoint, type: `travel <waypoint #>`.\n\n"
-  "You must have GMCP enabled to use this command.";
+    "This command allows you to manage waypoints, which are saved locations "
+    "that you can quickly travel to using the `travel` command.\n"
+    "\n"
+    "To set a waypoint, type `waypoint set`. This will save your current "
+    "location as waypoint 1. You can set additional waypoints by using the "
+    "`waypoint set` command again, which will save your current location as "
+    "waypoint 2, and so on.\n"
+    "\n"
+    "To remove a waypoint, type `waypoint remove <#>`, replacing <#> with the "
+    "number of the waypoint you want to remove.\n"
+    "\n"
+    "To use a waypoint, type: `travel <waypoint #>`.\n"
+    "\n"
+    "You must have GMCP enabled to use this command.";
 }
 
 private mixed list_waypoints(object tp);
@@ -36,9 +40,6 @@ private mixed set_waypoint(object tp);
 private mixed remove_waypoint(object tp, int num);
 
 mixed main(object tp, string str) {
-  string name = query_privs(tp);
-  string file = user_data_directory(name) + "waypoints.txt";
-  string *lines = ({});
   int num;
 
   if(!str)
@@ -94,9 +95,8 @@ private mixed set_waypoint(object tp) {
   mixed *wps;
   string *wp;
   int i, num;
-  string result = "";
   int max_waypoints = mud_config("WAYPOINTS_MAX");
-  object room = environment(tp);
+  /** @type {STD_ROOM} */ object room = environment(tp);
   string room_file = base_name(room);
   string room_short = room->query_short();
 

--- a/cmds/std/wealth.lpc
+++ b/cmds/std/wealth.lpc
@@ -14,25 +14,28 @@
 inherit STD_CMD;
 
 void setup() {
-    usage_text = "wealth";
-    help_text =
-        "Lists the amount of each currency you are currently carrying, one "
-        "line per currency in use. If no currency is defined in the game, it "
-        "reports that instead. The command takes no arguments.";
+  usage_text = "wealth";
+  help_text =
+    "Lists the amount of each currency you are currently carrying, one "
+    "line per currency in use. If no currency is defined in the game, it "
+    "reports that instead. The command takes no arguments.";
 }
 
-mixed main(/** @type {STD_BODY} */ object tp, string arg) {
-    string *currencies = CURRENCY_D->currency_list();
-    string *out = ({ });
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string _arg
+) {
+  string *currencies = CURRENCY_D->currency_list();
+  string *out = ({ });
 
-    if(!sizeof(currencies))
-        return "No currency is currently in use.";
+  if(!sizeof(currencies))
+    return "No currency is currently in use.";
 
-    currencies = reverse_array(currencies);
-    foreach(string currency in currencies)
-        out += ({ sprintf("%s: %d", currency, tp->query_wealth(currency)) });
+  currencies = reverse_array(currencies);
+  foreach(string currency in currencies)
+    out += ({ sprintf("%s: %d", currency, tp->query_wealth(currency)) });
 
-    out = ({ "You are carrying the following currencies:" }) + out;
+  out = ({ "You are carrying the following currencies:" }) + out;
 
-    return out;
+  return out;
 }

--- a/cmds/std/who.lpc
+++ b/cmds/std/who.lpc
@@ -12,6 +12,13 @@
 
 inherit STD_CMD;
 
+void setup() {
+  help_text =
+    "Lists everyone currently in the game. Owners are listed first, then "
+    "admins, then developers, then denizens, and names are sorted "
+    "alphabetically within each group. The command takes no arguments.";
+}
+
 int sort_users(object a, object b);
 
 mixed main(


### PR DESCRIPTION
This PR standardises the formatting and indentation of `help_text` and `usage_text` assignments across all command files, and adds missing `help_text` entries to commands that had none.

**Help text additions**

The following commands now have `help_text` for the first time: `look`, `wall`, `cd`, `ls`, `pwd`, `clean`, `dest`, `update`, `inventory`, `date`, `quit`, `save`, and `who`.

**Formatting standardisation**

All `help_text` and `usage_text` string literals are now indented with two spaces relative to the assignment, matching the rest of the codebase's style. Files that used four-space indentation or had the opening string on the same line as the assignment operator have been brought into line.

Inline `\n\n` sequences embedded inside string literals have been replaced with separate `"\n"` `"\n"` continuation strings, making paragraph breaks visually obvious in source.

**Spell and ability help text**

`sprintf`-based help text in the ability and spell commands (`punch`, `strike`, `embers`, `motes`, `shard`, `shock`, `wither`) has been rewritten using template strings, removing the format-string indirection and making the cost and cooldown values read inline.

**`con` command**

The `con` command's `main` function has been refactored to remove an unused variable, use `npcp` instead of `ob->is_npc()`, and use template strings for result assembly. The condition string is now fetched once and reused for both the self and other-target branches.

**`detail` command**

The `detail` command now calls `_usage` when invoked with no argument, gains a `help_text` entry, and has corrected parameter signatures on `finish_description`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR standardizes command help and usage text while making small behavioral cleanups.
- Adds missing help text across player, developer, file, and object commands.
- Replaces `sprintf` help construction with template strings for abilities and spells.
- Refactors `con` result construction and updates the `detail` usage/editor callback path.
</details>

<sub>Reviews (4): Last reviewed commit: ["uhh more changes"](https://github.com/gesslar/oxidus-mudlib/commit/93159460fcc86ea6f92a8e1b410c267932ef27e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47424546)</sub>

<!-- /greptile_comment -->