### PR TITLE
Remove unused internal type string defines from `type.h`

### DIFF
--- a/include/type.h
+++ b/include/type.h
@@ -13,13 +13,4 @@
 #define T_BUFFER "buffer"
 #define T_CLASS "class"
 
-#define T_INVALID "*invalid*"
-#define T_LVALUE "*lvalue*"
-#define T_LVALUE_BYTE "*lvalue_byte*"
-#define T_LVALUE_RANGE "*lvalue_range*"
-#define T_LVALUE_CODEPOINT "*lvalue_codepoint*"
-#define T_ERROR_HANDLER "*error_handler*"
-#define T_FREED "*freed*"
-#define T_UNKNOWN "*unknown*"
-
 #endif


### PR DESCRIPTION
Removes unused internal type string constants (`T_INVALID`, `T_LVALUE`, `T_LVALUE_BYTE`, `T_LVALUE_RANGE`, `T_LVALUE_CODEPOINT`, `T_ERROR_HANDLER`, `T_FREED`, `T_UNKNOWN`) from the type definitions header.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes eight unused internal type-string constants from `include/type.h`.
</details>

<sub>Reviews (1): Last reviewed commit: ["removing unnecessary unreachable things"](https://github.com/gesslar/oxidus-mudlib/commit/7d6f7e64bda57bef34abbf85515c67000be8d111) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47503513)</sub>

<!-- /greptile_comment -->