### PR TITLE
Rename `_tp` parameter to `tp` in `deep_scan`

### DIFF
--- a/cmds/dev/sc.lpc
+++ b/cmds/dev/sc.lpc
@@ -43,7 +43,7 @@ mixed main(object tp, string arg) {
   return str;
 }
 
-string deep_scan(object _tp, object *inv, int indent) {
+string deep_scan(object tp, object *inv, int indent) {
   object ob;
   string str;
 


### PR DESCRIPTION
Renamed the `_tp` parameter to `tp` in the `deep_scan` function to match the naming convention used in the `main` function.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Renames the unused `deep_scan` parameter from `_tp` to `tp` for consistency with `main`.
</details>

<sub>Reviews (2): Last reviewed commit: ["fixing deep scan args"](https://github.com/gesslar/oxidus-mudlib/commit/89eb8e386857da97f19d88bbf5d44f23ba4caafe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47503516)</sub>

<!-- /greptile_comment -->