### PR TITLE
Show equipped and wielded items when looking at a living

### DIFF
--- a/cmds/action/look.lpc
+++ b/cmds/action/look.lpc
@@ -4,10 +4,12 @@
  * Command to look at things and the room and stuff.
  *
  * @created 2026-07-13 - Gesslar
- * @last_modified 2026-07-13 - Gesslar
+ * @last_modified 2026-07-27 - Gesslar
  *
  * @history
  * 2026-07-13 - Gesslar - Created
+ * 2026-07-27 - Gesslar - Show equipped and wielded items when looking at a
+ *                        living
  */
 
 inherit STD_ACT;
@@ -243,7 +245,31 @@ mixed describe_living(
   string *vitals = ob->query_condition_string();
   if(pointerp(vitals)) {
     if(strlen(result))
-      result += `${sub} ${verb} ${vitals[0]}.`;
+      result += `${sub} ${verb} ${vitals[0]}.\n`;
+  }
+
+  // Copied from eq.lpc. kekela
+  mapping eq, wielded;
+  string slot, *slots;
+  string out = "";
+  int max;
+
+  eq = ob->query_equipped();
+  wielded = ob->query_wielded();
+
+  if(sizeof(eq) || sizeof(wielded)) {
+    slots = keys(wielded);
+    slots += keys(eq);
+
+    max = max(map(slots, (: strlen :)));
+
+    foreach(slot in slots) {
+      object item = wielded[slot] || eq[slot];
+      out += sprintf("%*s : %s\n", max, capitalize(slot), get_short(item));
+    }
+
+    if(strlen(out))
+      result += `\n${out}`;
   }
 
   return result;


### PR DESCRIPTION
When looking at a living being, their equipped and wielded items are now displayed alongside the standard description and condition information, formatted with aligned slot labels similar to the `eq` command.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The look command now displays a living target’s equipped and wielded items beneath its description and condition, with aligned equipment-slot labels.
</details>

<sub>Reviews (3): Last reviewed commit: ["adding equipment to looking at livings"](https://github.com/gesslar/oxidus-mudlib/commit/501f37efd624d651cefe2db3591f52a8a223b2c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47503522)</sub>

<!-- /greptile_comment -->