### PR TITLE
Enhance `call_if()` to bind private/protected functions when caller is same object

### DIFF
--- a/adm/simul_efun/function.lpc
+++ b/adm/simul_efun/function.lpc
@@ -271,16 +271,17 @@ mixed call_back(mixed cb, mixed new_arg...) {
 /**
  * Safely calls a function on an object if it exists.
  *
- * Attempts to call the named function, returning null if function doesn't
- * exist instead of throwing an error.
+ * Attempts to call the named function, returning undefined if function doesn't
+ * exist.
  *
- * IMPORTANT: function_exists() requires that the needle function have public
- * visibility.
+ * If a function being reached for is private or protected and the caller is
+ * the same object as passed, `call_if()` will bind to the object, ensuring
+ * that it is callable.
  *
  * @param {object|string} ob - Target object or filename
  * @param {string} func - Function name to call
  * @param {...mixed} [arg] - Arguments to pass to function
- * @returns {mixed} Function result or null if function doesn't exist
+ * @returns {mixed} Function result or undefined if function doesn't exist
  * @errors If ob or func arguments are invalid types
  * @see function_exists
  * @see call_back
@@ -303,13 +304,30 @@ varargs mixed call_if(mixed ob, string func, mixed arg...) {
   if(stringp(ob))
     ob = load_object(ob);
 
-  if(function_exists(func, ob))
-    if(sizeof(arg))
-      return call_other(ob, func, arg...);
-    else
-      return call_other(ob, func);
+  if(!objectp(ob))
+    return undefined;
 
-  return null;
+  int self = ob == previous_object();
+  int bind_to_object = 0;
+
+  if(self) {
+    if(!function_exists(func, ob, 1))
+      return undefined;
+
+    bind_to_object = !function_exists(func, ob);
+  } else {
+    if(!function_exists(func, ob))
+      return undefined;
+  }
+
+  function f;
+
+  if(bind_to_object)
+    f = bind((: call_other, ob, func, arg... :), ob);
+  else
+    f = (: call_other, ob, func, arg... :);
+
+  return evaluate(f);
 }
 
 /**


### PR DESCRIPTION
## Enhance `call_if()` to Support Private and Protected Function Calls

`call_if()` previously relied solely on `function_exists()` without the visibility flag, meaning it could only reach public functions. This update adds support for calling private and protected functions when the caller is the same object as the target.

When the caller and target object are the same, `call_if()` now checks for the function's existence with the `include_hidden` flag. If the function exists but is not publicly visible, the call is bound directly to the object using `bind()`, ensuring private and protected methods are reachable in that context.

The return value on a missing or unreachable function has also been corrected from `null` to `undefined`, and an explicit `objectp()` guard was added to handle cases where `load_object()` fails to return a valid object.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends `call_if()` while preserving its public-call behavior.
- Allows self-calls to reach private and protected functions through an object-bound closure.
- Returns `undefined` when the target object or requested function is unavailable.
- Adds an explicit object-validity check after resolving string targets.
</details>

<sub>Reviews (3): Last reviewed commit: ["improving call\_if"](https://github.com/gesslar/oxidus-mudlib/commit/ea2dd7820fedcb9d476cf8b89a664e24eb0b9959) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47503526)</sub>

<!-- /greptile_comment -->