### PR TITLE
Add `detail features` subcommand, trim help text, and fix arg order in `finish_description`

### DIFF
--- a/cmds/std/detail.lpc
+++ b/cmds/std/detail.lpc
@@ -21,9 +21,7 @@ void setup() {
 
   help_text =
     "Fills in the descriptive details of your character. Name the feature "
-    "you want to work on and an editor opens for it — 'detail description' "
-    "sets the long description others read when they look at you, and is "
-    "limited to 800 characters.\n"
+    "you want to work on and an editor opens for it."
     "\n"
     "See also: look, score\n";
 }
@@ -37,9 +35,14 @@ mixed main(
   if(!str)
     return _usage(tp);
 
-  result = call_if(this_object(), sprintf("detail_%s", str), tp);
+  result = call_if(this_object(), `detail_${str}`, tp);
 
   return result || "Unknown feature.";
+}
+
+private mixed detail_features(object _tp) {
+  return "description - 800 character limit for your long description\n"
+  "\n";
 }
 
 private void finish_description(int status, string file, string temp_file, object tp);
@@ -59,8 +62,8 @@ private mixed detail_description(/** @type {STD_PLAYER} */ object tp) {
 
 private void finish_description(
   int status,
+  string _edit_file,
   string temp_file,
-  string _file,
   /** @type {STD_PLAYER} */ object tp
 ) {
   string text;


### PR DESCRIPTION
Adds a `detail features` subcommand that lists available features and their constraints, replacing the inline help text that previously described only the description field. Also fixes the parameter order in `finish_description` to match the actual callback signature, and updates the subcommand dispatch to use a template literal.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the character-detail command:
- Adds `detail features` to list editable features and constraints.
- Moves feature-specific guidance out of the general help text.
- Uses template interpolation for subcommand dispatch.
- Corrects the editor callback parameter order so the temporary edit file is processed correctly.
</details>

<sub>Reviews (3): Last reviewed commit: ["fixing up detail command"](https://github.com/gesslar/oxidus-mudlib/commit/e866c04f7c514533dccbd6cbcdd5286b3a8adba8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47503532)</sub>

**Context used:**

- Knowledge Base — [Commands And Dispatch](https://app.greptile.com/gesslar/-/custom-context/knowledge-base/gesslar/oxidus-mudlib/-/docs/commands-and-dispatch.md)

<!-- /greptile_comment -->