### PR TITLE
Restructure LICENSE: split attribution clause into separate file and remove copyright header

### DIFF
--- a/LICENSE Part 2.txt
+++ b/LICENSE Part 2.txt
@@ -1,0 +1,3 @@
+Excepting any code specifically attributed to gesslar and where there remains
+pre-existing code from the defunct project "LPUniversity", the license in the
+archive/ folder applies.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,3 @@
-Copyright (C) 2026 by Brian M. Workman bmw@gesslar.dev
-
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted.
 
@@ -10,9 +8,3 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
-
----
-
-Excepting any code specifically attributed to gesslar and where there remains
-pre-existing code from the defunct project "LPUniversity", the license in the
-archive/ folder applies.


### PR DESCRIPTION
Separates the licensing terms into two distinct files. The main `LICENSE.txt` now contains only the ISC license text without attribution or exceptions, while the exception clause regarding LPUniversity pre-existing code is moved to a new `LICENSE Part 2.txt` file. The copyright header has also been removed from `LICENSE.txt`.