### PR TITLE
Expand and correct `function_exists` and `shuffle` efun help documentation

### DIFF
--- a/doc/driver/efun/function_exists.help
+++ b/doc/driver/efun/function_exists.help
@@ -3,9 +3,10 @@
     function_exists()  -  find  the  file containing a given function in an
     object
 
-### SYNOPSYS
+### SYNOPSIS
 
     string function_exists( string str, object ob );
+    string function_exists( string str, object ob, int flag );
 
 ### DESCRIPTION
 
@@ -14,6 +15,11 @@
     the function is defined by an inherited object.
 
     0 is returned if the function was not defined.
+
+    By default, functions that cannot be called from outside the object
+    (protected and private functions) are treated as not defined. If
+    'flag' is specified and is nonzero, such functions are reported as
+    well.
 
     Note that function_exists() does not check shadows.
 

--- a/doc/driver/efun/shuffle.help
+++ b/doc/driver/efun/shuffle.help
@@ -1,6 +1,6 @@
 ### NAME
 
-    shuffle() - Rearrange the elements in the array in random order
+    shuffle() - rearrange the elements of an array in random order
 
 ### SYNOPSIS
 
@@ -8,4 +8,32 @@
 
 ### DESCRIPTION
 
-    Shuffle the array and return.
+    Rearranges the elements of `arr` into a random order.
+
+    The shuffle happens in place: `arr` itself is reordered, not a copy
+    of it.  Every variable holding a reference to that array sees the
+    new order after the call.
+
+### RETURN VALUE
+
+    Returns `arr` itself -- the same array that was passed in, after
+    shuffling -- not a shuffled copy.  The return value is a convenience
+    for use in expressions; ignoring it changes nothing, since the
+    argument array has already been reordered by the time the call
+    returns.
+
+    An array with fewer than two elements is returned unchanged.
+
+### EXAMPLE
+
+mixed *a = ({ 1, 2, 3, 4, 5 });
+mixed *b = shuffle(a);
+// a itself has been reordered; b is that same array, not a copy.
+
+// To keep the original order intact, shuffle a copy instead:
+mixed *c = shuffle(a[0..]);
+// the range expression builds a new array, so a is untouched
+
+### SEE ALSO
+
+    element_of(3), sort_array(3), random(3)


### PR DESCRIPTION
Updates documentation for `function_exists` and `shuffle` efuns.

For `function_exists`, fixes a typo in the `SYNOPSYS` heading, adds the overload signature accepting an integer `flag` parameter, and documents that protected and private functions are excluded by default but included when `flag` is nonzero.

For `shuffle`, rewrites the description to clarify that the reordering happens in-place on the original array rather than on a copy, adds a `RETURN VALUE` section explaining that the return value is the same array passed in, adds an example demonstrating the in-place behavior and how to shuffle a copy instead, and adds a `SEE ALSO` section.