### PR TITLE
Expand and rewrite throw() and catch() efun documentation with structured examples

### DIFF
--- a/doc/driver/efun/catch.help
+++ b/doc/driver/efun/catch.help
@@ -20,8 +20,10 @@
     string (with a leading '*') will be returned.  The value of the body
     expression itself is discarded.
 
-    The function throw() can also be used to immediately return any  value,
-    except 0.
+    The function throw() can also be used to immediately return any value.
+    The one exception is 0, which is not rejected but cannot be detected:
+    catch() already returns 0 to mean "no error", so throw(0) cannot be
+    told apart from the body finishing normally.
 
     It is a compile-time error to `break` or `continue` out of a catch
     block.
@@ -54,6 +56,37 @@
     }
 
     // ERR: "*Error in loading object '/u/g/gesslar/two'"
+
+    // A caught value is not always an error message.  throw() hands back
+    // whatever it was given, so a class makes a tidy typed failure that
+    // the catching code can inspect field by field instead of parsing a
+    // string.
+    class failure {
+        string kind ;
+        mixed detail ;
+    }
+
+    private void charge(object who, int amount) {
+        int have = who->query_coins() ;
+
+        if(have < amount)
+            throw(new(class failure,
+                      kind: "insufficient_funds",
+                      detail: amount - have)) ;
+
+        who->add_coins(-amount) ;
+    }
+
+    void example3(object who, int price) {
+        mixed err = catch( charge(who, price) ) ;
+
+        // classp() must be tested first: err is just as likely to be a
+        // driver error string, and the && stops there when it is.
+        if(classp(err) && err.kind == "insufficient_funds")
+            write("You are " + err.detail + " coins short.\n") ;
+        else if(err)
+            throw(err) ;    // not ours to handle -- pass it along
+    }
 
 ### SEE ALSO
 

--- a/doc/driver/efun/throw.help
+++ b/doc/driver/efun/throw.help
@@ -1,29 +1,120 @@
 ### NAME
 
-    throw() - forces an error to occur in an object.
+    throw() - hand a value to the nearest enclosing catch()
 
 ### SYNOPSIS
 
-    void throw(mixed);
+    void throw(mixed value);
 
 ### DESCRIPTION
 
-    The  throw()  efun may be used to force an error to occur in an object.
-    When used in conjunction, throw() and catch() allow the  programmer  to
-    choose  what  error  message  is displayed when a runtime error occurs.
-    When throw() is used,  it  should  be  used  in  conjunction  with  the
-    catch(3) efun.  Here is a typical usage:
+    Stops what is currently running and hands `value` to the nearest
+    catch(3) above the current call.  That catch() returns `value` instead
+    of its usual 0.
 
-       string err;
-       int rc;
+    throw() never comes back, so anything written after it in the same
+    function will never run.
 
-       err = catch(rc = ob->move(dest));
-       if (err) {
-            throw("move.c: ob->move(dest): " + err + "\n");
-            return;
-       }
+    Any value can be thrown, and catch() gives it back exactly as it was
+    thrown -- a string, an array, a mapping, a class, an object.  Nothing
+    is converted to text and nothing is added to it.  That makes throw()
+    useful for more than error messages: you can hand a whole structured
+    result back to code that is prepared to deal with it.
+
+    Throwing 0 cannot be detected.  catch() already returns 0 to mean
+    "nothing went wrong", so throw(0) looks exactly like the body finishing
+    normally.  Throw anything else.
+
+    Only the innermost catch() sees the value.  It does not keep travelling
+    outward on its own -- if the code that caught it wants to pass it
+    along, it has to throw() it again.
+
+### HOW FAR IT TRAVELS
+
+    A thrown value travels up through as many ordinary calls as it needs
+    to.  It does not matter how deep you are, and it does not matter how
+    you got there: calls inside the same object, calls through
+    `ob->func()`, inherited functions, function pointers invoked with
+    evaluate(), and callbacks run by efuns such as filter() and
+    sort_array() all pass a thrown value straight through to the catch()
+    above them.  Even a create() that throws while the object is being
+    loaded inside `catch(load_object(...))` is caught normally.
+
+    What a thrown value cannot do is escape a call that the driver started
+    on its own.  A call_out(), an input_to() callback, and applies the
+    driver invokes on your object -- logon(), net_dead(),
+    process_input(), reset(), clean_up(), on_destruct(), the telnet and
+    GMCP applies -- each begin a fresh chain of calls with no catch()
+    above them.  That holds even if the code that scheduled the call_out()
+    was itself sitting inside a catch(): by the time the callback runs,
+    that catch() has long since returned.  A throw() in one of those
+    places is an error (see ERRORS below).  When a callback needs to
+    handle a failure, put the catch() inside the callback.
+
+### A THROWN VALUE IS NOT A DRIVER ERROR
+
+    A value that arrives at a catch() by way of throw() has not been
+    through the driver's error machinery at all.  No traceback is printed,
+    nothing is written to the debug log, and the error_handler() apply in
+    the master object is never called.
+
+    A thrown string also does not get the leading '*' that the driver puts
+    on its own error messages, and that '*' is how handling code tells the
+    two apart:
+
+    - `"*Bad argument 1 to move()\n"` came from the driver.
+    - `"took too long\n"` came from a throw() somewhere in the mudlib.
+
+    Keep that in mind when building a new message out of a caught one.
+    Writing `throw("context: " + err)` when `err` came from the driver
+    buries the '*' in the middle of the new string, and anything checking
+    `err[0] == '*'` will stop recognising it as a driver error.
+
+### ERRORS
+
+    A throw() with no catch() above it in the current chain of calls
+    raises a real runtime error, `"*Throw with no catch.\n"` -- traceback,
+    error handler and all -- and the value you threw is discarded.
+
+### EXAMPLE
+
+// Passing a failure further up, with more context added.
+void move_or_fail(object ob, object dest) {
+    mixed err = catch(ob->move(dest));
+
+    if (err) {
+        // Only a driver error carries the leading '*', so only put one
+        // back when it was there to begin with -- adding it to a mudlib
+        // value would disguise it as a driver error.
+        if (stringp(err) && err[0] == '*')
+            throw("*move_or_fail(): " + err[1..]);
+        else if (stringp(err))
+            throw("move_or_fail(): " + err);
+        else
+            throw(err);     // not a string -- pass it through untouched
+    }
+}
+
+// Throwing a value rather than a message, so the caller can act on the
+// details instead of picking a string apart.
+private void charge(object who, int amount) {
+    int have = who->query_coins();
+
+    if (have < amount)
+        throw(({ "insufficient_funds", amount - have }));
+
+    who->add_coins(-amount);
+}
+
+void buy(object who, int price) {
+    mixed err = catch(charge(who, price));
+
+    if (arrayp(err) && err[0] == "insufficient_funds")
+        write("You are " + err[1] + " coins short.\n");
+    else if (err)
+        throw(err);     // not ours to handle -- pass it along
+}
 
 ### SEE ALSO
 
     catch(3), error(3), error_handler(4)
-


### PR DESCRIPTION
Improves the documentation for `throw()` and `catch()` to more accurately reflect how they work together.

The `throw()` page has been rewritten to explain that `throw()` delivers any value directly to the nearest enclosing `catch()` without involving the driver's error machinery — no traceback, no debug log, no `error_handler()` call. It now covers how far a thrown value travels (through any depth of ordinary calls, across object boundaries, through `evaluate()` and efun callbacks), and where it cannot travel (across `call_out()`, `input_to()`, and driver-initiated applies, which each start a fresh call chain with no `catch()` above them). It also clarifies the `throw(0)` limitation, the distinction between driver error strings (leading `'*'`) and mudlib-thrown strings, and what happens when `throw()` is used with no `catch()` above it.

The `catch()` page receives a clarified explanation of the `throw(0)` edge case and a new example demonstrating throwing a class instance as a structured failure value, including how to inspect it field by field and re-throw anything the current code is not responsible for handling.