### PR TITLE
Replace `@throws` with `@errors` and `throw()` with `error()` in doc comments and call sites

### DIFF
--- a/adm/daemons/alarm.lpc
+++ b/adm/daemons/alarm.lpc
@@ -124,7 +124,6 @@ void rehash_alarms() {
  * @param {...mixed} args - Optional trailing arguments handed to the
  *     target function when the alarm fires.
  * @returns {int} 1 on success, 0 if the alarm failed validation.
- * @throws If any of master, pattern, file, or func is null.
  */
 varargs int add_once(string master, string pattern, string file,
                      string func, mixed args...) {
@@ -151,7 +150,7 @@ varargs int add_once(string master, string pattern, string file,
  * @param {...mixed} args - Optional trailing arguments handed to the
  *     target function when the alarm fires.
  * @returns {int} 1 on success, 0 if the alarm failed validation.
- * @throws If any of type, master, pattern, file, or func is null.
+ * @errors If any of type, master, pattern, file, or func is undefined.
  */
 varargs int add_alarm(string type, string master, string pattern,
                       string file, string func, mixed args...) {
@@ -615,8 +614,6 @@ private int next_minute_start() {
  *
  * Only processes alarms of type "B" (Boot), scheduling them to execute
  * after their specified delay in seconds.
- *
- * @throws If called by anything other than the signal daemon
  */
 void execute_boot_alarms() {
   class Alarm *boot_alarms, boot_alarm;
@@ -652,7 +649,7 @@ void execute_boot_alarms() {
  * @param {class Alarm} alarm - The alarm to validate
  * @param {int} silent - Whether to throw errors (0) or log them (1)
  * @returns {int} 1 if valid, 0 if invalid
- * @throws If validation fails and silent is 0
+ * @errors If validation fails and silent is 0
  */
 int validate_alarm(class Alarm alarm, int silent) {
   mixed err;
@@ -662,7 +659,7 @@ int validate_alarm(class Alarm alarm, int silent) {
     log_file("system/alarm", "[%s] File %s does not exist\n%O",
       ldatetime(), alarm.file, alarm);
     if(!silent)
-      throw("File does not exist");
+      error("File does not exist");
     return 0;
   }
 
@@ -670,7 +667,7 @@ int validate_alarm(class Alarm alarm, int silent) {
     log_file("system/alarm", "[%s] Unable to load file %s: %O\n%O",
       ldatetime(), alarm.file, err, alarm);
     if(!silent)
-      throw("Unable to load file");
+      error("Unable to load file");
     return 0;
   }
 
@@ -679,7 +676,7 @@ int validate_alarm(class Alarm alarm, int silent) {
       "[%s] Function %s does not exist in file %s\n%O",
       ldatetime(), alarm.func, alarm.file, alarm);
     if(!silent)
-      throw("Function does not exist");
+      error("Function does not exist");
     return 0;
   }
 
@@ -690,7 +687,7 @@ int validate_alarm(class Alarm alarm, int silent) {
       log_file("system/alarm", "[%s] Time is in the past\n%O",
         ldatetime(), alarm);
       if(!silent)
-        throw("Time is in the past");
+        error("Time is in the past");
       return 0;
     }
   }

--- a/adm/simul_efun/number.lpc
+++ b/adm/simul_efun/number.lpc
@@ -104,8 +104,8 @@ int sum(int *arr) {
  * @param {int} number - The number to evaluate.
  * @param {string} condition - The condition to evaluate against.
  * @returns {int} 1 if the condition evaluates to true, 0 otherwise.
- * @throws If an invalid operator is provided.
- * @throws If the condition format is invalid.
+ * @errors If an invalid operator is provided.
+ * @errors If the condition format is invalid.
  */
 private int evaluate_simple_condition(int number, string condition) {
   string operator;
@@ -295,7 +295,7 @@ private int evaluate_or_expr(int number, string condition) {
  * @param {int} number - The number to evaluate.
  * @param {string} condition - The condition to evaluate against.
  * @returns {int} 1 if the condition evaluates to true, 0 otherwise.
- * @throws If the condition contains invalid syntax or operators.
+ * @errors If the condition contains invalid syntax or operators.
  */
 int evaluate_number(int number, string condition) {
   // Strip all spaces and normalise operator case before parsing.

--- a/adm/simul_efun/signal.lpc
+++ b/adm/simul_efun/signal.lpc
@@ -7,7 +7,7 @@
  *
  * @param {string} sig - string signal identifier (use `SIG_*` macros)
  * @param {mixed...} arg - arguments to pass to the signal handlers
- * @throws If `sig` is not a string this function calls `error()` and
+ * @errors If `sig` is not a string this function calls `error()` and
  *         thus raises an exception. This enforces use of the `SIG_*`
  *         defines and avoids silent mismatches.
  */
@@ -24,7 +24,7 @@ void emit(string sig, mixed arg...) {
  * @param {string} sig - string signal identifier (use `SIG_*` macros)
  * @param {string} func - function to call when the signal is emitted
  * @returns {int} `SIG_SLOT_OK` if the slot was registered successfully.
- * @throws If `sig` is not a string this function calls `error()` and
+ * @errors If `sig` is not a string this function calls `error()` and
  *         raises an exception to loudly indicate incorrect usage.
  */
 int slot(string sig, string func) {
@@ -39,7 +39,7 @@ int slot(string sig, string func) {
  *
  * @param {string} sig - string signal identifier (use `SIG_*` macros)
  * @returns {int} `SIG_SLOT_OK` if the slot was unregistered successfully.
- * @throws If `sig` is not a string this function calls `error()` and
+ * @errors If `sig` is not a string this function calls `error()` and
  *         raises an exception so incorrect calls fail loudly.
  */
 int unslot(string sig) {

--- a/std/object/persist.lpc
+++ b/std/object/persist.lpc
@@ -104,7 +104,7 @@ varargs string save_to_string(int recursep) {
  *
  * @param {mixed} value - String representation or mapping of object state
  * @param {int} recurse - Recursion level (used internally)
- * @throws If object creation fails
+ * @errors If object creation fails
  */
 void load_from_string(mixed value, int recurse) {
   mixed data;
@@ -138,7 +138,7 @@ void load_from_string(mixed value, int recurse) {
       if(intp(result) && result == 0)
         ob->load_from_string(val, recurse + 1);
       else
-        throw(result);
+        error((string)result);
     }
   }
 


### PR DESCRIPTION
Replace `@throws` JSDoc tags with `@errors` across daemon and simul_efun documentation, and switch `throw()` calls to `error()` in `validate_alarm` and `load_from_string`. Also removes the `@throws` note from `execute_boot_alarms` and the corresponding tag from `add_once`.