### PR TITLE
Add `errorp()` simul-efun predicate for duck-type error string detection

### DIFF
--- a/adm/include/simul_efun.h
+++ b/adm/include/simul_efun.h
@@ -202,8 +202,9 @@ string ob_short(object ob);
 string ob_long(object ob);
 
 // File: predicates.c
-int roomp(object ob);
 int alarmp(object ob);
+int errorp(mixed input);
+int roomp(object ob);
 
 // File: prompt.c
 varargs void prompt_colour(object body, mixed *cb, string prompt);

--- a/adm/simul_efun/predicates.lpc
+++ b/adm/simul_efun/predicates.lpc
@@ -25,3 +25,15 @@ int roomp(object ob) {
 int alarmp(object ob) {
   return objectp(ob) && file_name(ob) == ALARM_D;
 }
+
+/**
+ * Does duck-type checking to see if the input matches an error format. error()
+ * prepends string messages with '*'.
+ *
+ * @param {mixed} [input] - The value to test.
+ * @returns {int} 1 if it looks like an error string, 0 otherwise.
+ */
+int errorp(mixed input) {
+  return stringp(input) && input[0] == '*';
+
+}


### PR DESCRIPTION
Adds an `errorp` predicate function that performs duck-type checking to determine if a value matches an error format. Since `error()` prepends string messages with `*`, the function checks that the input is a string beginning with that character.