### PR TITLE
Remove trailing spaces from weapon `long` description strings

### DIFF
--- a/obj/weapon/bludgeoning/1h/mace.lpml
+++ b/obj/weapon/bludgeoning/1h/mace.lpml
@@ -5,9 +5,9 @@
   adj: ["iron"],
   name: "iron mace",
   short: "iron mace",
-  long: "A stout wooden haft topped with a heavy, flanged iron head. There is "
-        "nothing clever about it, but it lands with a solid, bone-jarring "
-        "weight and cares little for shields or armour. A blunt, honest tool "
+  long: "A stout wooden haft topped with a heavy, flanged iron head. There is"
+        "nothing clever about it, but it lands with a solid, bone-jarring"
+        "weight and cares little for shields or armour. A blunt, honest tool"
         "for a blunt, honest kind of fight.",
   mass: 65,
   value: 14,

--- a/obj/weapon/bludgeoning/2h/quarterstaff.lpml
+++ b/obj/weapon/bludgeoning/2h/quarterstaff.lpml
@@ -5,10 +5,11 @@
   adj: ["oak"],
   name: "oak quarterstaff",
   short: "oak quarterstaff",
-  long: "A long, straight length of seasoned oak, capped at either end with "
-        "banded iron ferrules to keep the wood from splitting. Held in both "
-        "hands it has reach and momentum enough to keep an opponent at bay, and "
-        "it asks for nothing more than a steady grip and a bit of practice.",
+  long: "A long, straight length of seasoned oak, capped at either end with"
+        "banded iron ferrules to keep the wood from splitting. Held in both"
+        "hands it has reach and momentum enough to keep an opponent at bay,"
+        "and it asks for nothing more than a steady grip and a bit of"
+        "practice.",
   mass: 50,
   value: 10,
   hands: 2,

--- a/obj/weapon/piercing/1h/dagger.lpml
+++ b/obj/weapon/piercing/1h/dagger.lpml
@@ -5,10 +5,10 @@
   adj: ["iron"],
   name: "iron dagger",
   short: "iron dagger",
-  long: "A short, double-edged iron dagger with a plain crossguard and a "
-        "leather-wrapped grip. It is light and quick in the hand, better suited "
-        "to a fast thrust than a heavy blow, but it holds an honest edge and "
-        "will not let you down in a pinch.",
+  long: "A short, double-edged iron dagger with a plain crossguard and a"
+        "leather-wrapped grip. It is light and quick in the hand, better"
+        "suited to a fast thrust than a heavy blow, but it holds an honest"
+        "edge and will not let you down in a pinch.",
   mass: 15,
   value: 8,
   hands: 1,

--- a/obj/weapon/piercing/2h/spear.lpml
+++ b/obj/weapon/piercing/2h/spear.lpml
@@ -5,11 +5,11 @@
   adj: ["ash"],
   name: "ash spear",
   short: "ash spear",
-  long: "A long ash shaft tipped with a leaf-shaped steel head, bound below the "
-        "point with iron collars to blunt a hacking blow. Wielded in both hands "
-        "it puts a comfortable distance between you and trouble, and a firm "
-        "thrust drives the point home with the whole weight of the haft behind "
-        "it.",
+  long: "A long ash shaft tipped with a leaf-shaped steel head, bound below"
+        "the point with iron collars to blunt a hacking blow. Wielded in both"
+        "hands it puts a comfortable distance between you and trouble, and a"
+        "firm thrust drives the point home with the whole weight of the haft"
+        "behind it.",
   mass: 60,
   value: 16,
   hands: 2,

--- a/obj/weapon/slashing/1h/short_sword.lpml
+++ b/obj/weapon/slashing/1h/short_sword.lpml
@@ -5,10 +5,11 @@
   adj: ["short"],
   name: "short sword",
   short: "short sword",
-  long: "A plain, single-handed short sword with a broad, tapering blade and a "
-        "simple steel guard. The edge has been honed many times and the leather "
-        "wrap on the hilt is worn smooth, but the balance is good and it swings "
-        "true. A dependable blade for anyone still finding their footing.",
+  long: "A plain, single-handed short sword with a broad, tapering blade and a"
+        "simple steel guard. The edge has been honed many times and the"
+        "leather wrap on the hilt is worn smooth, but the balance is good and"
+        "it swings true. A dependable blade for anyone still finding their"
+        "footing.",
   mass: 45,
   value: 15,
   hands: 1,

--- a/obj/weapon/slashing/2h/greatsword.lpml
+++ b/obj/weapon/slashing/2h/greatsword.lpml
@@ -5,10 +5,10 @@
   adj: ["great"],
   name: "greatsword",
   short: "greatsword",
-  long: "A long, straight blade meant to be swung from the shoulders with both "
-        "hands on the wire-bound grip. The steel is plain and unadorned, and "
-        "the length of it makes for tiring work, but a full stroke carries "
-        "enough weight to shear through a guard and whatever is behind it. Not "
+  long: "A long, straight blade meant to be swung from the shoulders with both"
+        "hands on the wire-bound grip. The steel is plain and unadorned, and"
+        "the length of it makes for tiring work, but a full stroke carries"
+        "enough weight to shear through a guard and whatever is behind it. Not"
         "a subtle weapon, but a decisive one.",
   mass: 90,
   value: 22,


### PR DESCRIPTION
Removed trailing spaces for string folding in weapon descriptions in LPML definition files. The LPML parser automatically supplies spaces when concatenating adjacent strings, this removes the unintended second space this creates.