### PR TITLE
Update sefun help docs: add `errorp`/`load_json`, replace `null` with `undefined`, and fix signatures

### DIFF
--- a/doc/sefun/assert.help
+++ b/doc/sefun/assert.help
@@ -5,18 +5,11 @@
 ---
 ### NAME
 
-    assert() - Verifies a condition, throwing an error if false.
+    assert()
 
 ### SYNOPSIS
 
     varargs void assert( mixed condition, string message );
-
-### DESCRIPTION
-
-    Verifies a condition, throwing an error if false.
-
-    Enhanced assertion checking with custom error messages and evaluation of
-    complex conditions.
 
 ### PARAMETERS
 
@@ -28,7 +21,7 @@
 
 ### ERRORS
 
-    If statement evaluates to false or null
+    If statement evaluates to false or undefined
 
 ### EXAMPLE
 

--- a/doc/sefun/call_back.help
+++ b/doc/sefun/call_back.help
@@ -9,7 +9,7 @@
 
 ### SYNOPSIS
 
-    mixed call_back( mixed cb, mixed new_arg... );
+    mixed call_back( mixed *cb, mixed new_arg... );
 
 ### DESCRIPTION
 
@@ -25,7 +25,7 @@
 
 ### RETURN VALUES
 
-    (mixed) Result from callback execution
+    (mixed|undefined) Result from callback execution
 
 ### ERRORS
 

--- a/doc/sefun/call_if.help
+++ b/doc/sefun/call_if.help
@@ -15,11 +15,12 @@
 
     Safely calls a function on an object if it exists.
 
-    Attempts to call the named function, returning null if function doesn't
-    exist instead of throwing an error.
+    Attempts to call the named function, returning undefined if function
+    doesn't exist.
 
-    IMPORTANT: function_exists() requires that the needle function have
-    public visibility.
+    If a function being reached for is private or protected and the caller
+    is the same object as passed, `call_if()` will bind to the object,
+    ensuring that it is callable.
 
 ### PARAMETERS
 
@@ -31,7 +32,7 @@
 
 ### RETURN VALUES
 
-    (mixed) Function result or null if function doesn't exist
+    (mixed) Function result or undefined if function doesn't exist
 
 ### ERRORS
 

--- a/doc/sefun/delay_act.help
+++ b/doc/sefun/delay_act.help
@@ -31,7 +31,8 @@
 
 ### RETURN VALUES
 
-    (int) Action ID or 0 if already acting
+    (int | 0 | undefined) Action ID, 0 if already acting, or undefined if no
+    this_body() or missing arguments.
 
 ### EXAMPLE
 

--- a/doc/sefun/errorp.help
+++ b/doc/sefun/errorp.help
@@ -1,0 +1,27 @@
+---
+{
+  title: "errorp"
+}
+---
+### NAME
+
+    errorp() - Does duck-type checking to see if the input matches an error
+    format. error() prepends string messages with '*'.
+
+### SYNOPSIS
+
+    int errorp( mixed input );
+
+### DESCRIPTION
+
+    Does duck-type checking to see if the input matches an error format.
+    error() prepends string messages with '*'.
+
+### PARAMETERS
+
+    input  (mixed, optional)
+           The value to test.
+
+### RETURN VALUES
+
+    (int) 1 if it looks like an error string, 0 otherwise.

--- a/doc/sefun/has.help
+++ b/doc/sefun/has.help
@@ -21,16 +21,13 @@
 
 ### PARAMETERS
 
-    ob              (object)
-                    The object to check.
-
-    function_names  (string|string*)
-                    Function name(s) to look for `(string|string*)`
+    ob  (object)
+        The object to check.
 
 ### RETURN VALUES
 
-    (string|null) The filename where a function is defined, or null if none
-    found or if ob is not an object.
+    (string | undefined) The filename where a function is defined, or
+    undefined if none found or if ob is not an object.
 
 ### EXAMPLE
 

--- a/doc/sefun/load_json.help
+++ b/doc/sefun/load_json.help
@@ -1,0 +1,37 @@
+---
+{
+  title: "load_json"
+}
+---
+### NAME
+
+    load_json() - Loads and decodes a JSON file.
+
+### SYNOPSIS
+
+    mixed load_json( string file );
+
+### DESCRIPTION
+
+    Loads and decodes a JSON file.
+
+    Reads the file and parses it via json_decode(). Unlike load_lpml(), JSON
+    has no include mechanism, so there is no base path to resolve against.
+
+### PARAMETERS
+
+    file  (string)
+          Path to the JSON file to load
+
+### RETURN VALUES
+
+    (mixed) Decoded JSON value, "" if the file is missing or empty, or
+    undefined if it could not be read
+
+### ERRORS
+
+    If file is not a non-zero length string
+
+### EXAMPLE
+
+    {{di1}}mapping cfg = load_json("/d/village/spawn.json");{{di0}}

--- a/doc/sefun/log_file.help
+++ b/doc/sefun/log_file.help
@@ -34,4 +34,4 @@
 
 ### EXAMPLE
 
-    {{di1}}log_file("system.log", "Server started at %s", ctime());{{di0}}
+    {{di1}}log_file("system.log", "Server started at %s", ldatetime());{{di0}}


### PR DESCRIPTION
Updates documentation for several sefun help files with the following changes:

- Removes redundant description from `assert.help` and corrects error condition wording from "null" to "undefined"
- Corrects `call_back` parameter type from `mixed` to `mixed *` and updates return type to reflect possible undefined value
- Clarifies `call_if` behavior around private/protected function visibility and binding, replacing references to "null" with "undefined"
- Updates `delay_act` return value documentation to reflect undefined as a possible return when preconditions are not met
- Adds new `errorp.help` documenting the duck-type error string checking function
- Removes extraneous `function_names` parameter entry from `has.help` and updates return type wording to use "undefined" instead of "null"
- Adds new `load_json.help` documenting the JSON file loading function
- Replaces `ctime()` with `ldatetime()` in the `log_file` example