### PR TITLE
Add `deliver_mundane_damage` and `deliver_magic_damage` typed damage channels alongside `deliver_damage`

### DIFF
--- a/cmds/ability/punch.lpc
+++ b/cmds/ability/punch.lpc
@@ -53,7 +53,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
         float damage = percent_of(25.0, tp->query_damage());
 
         tp->targetted_action("$N $vpunch $t!", victim);
-        tp->deliver_damage(victim, damage, "bludgeoning");
+        tp->deliver_mundane_damage(victim, damage, "bludgeoning");
         tp->use_skill("combat.melee.unarmed");
       } else {
         tp->targetted_action("$N $vtry to punch $t, but $vmiss.", victim);

--- a/cmds/spell/arcanist/motes.lpc
+++ b/cmds/spell/arcanist/motes.lpc
@@ -55,7 +55,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
           "{{"+COLOUR_D->random_bright_hex()+"}}Motes of light strike $t!{{res}}",
           victim
         );
-        tp->deliver_damage(victim, damage, "light");
+        tp->deliver_magic_damage(victim, damage, "light");
         tp->use_skill("arcane.discipline.light", 1.15);
       } else {
         tp->simple_action("The motes of light disperse harmlessly.");

--- a/cmds/spell/arcanist/shard.lpc
+++ b/cmds/spell/arcanist/shard.lpc
@@ -58,7 +58,7 @@ mixed use(/** @type {STD_BODY} */ object tp, string arg) {
           "{{cef}}A wicked shard of magical ice drives into $t!{{res}}",
           victim
         );
-        tp->deliver_damage(victim, initial, "cold");
+        tp->deliver_magic_damage(victim, initial, "cold");
         tp->use_skill("arcane.discipline.frost", 1.15);
 
         // Shards stack — each caster's shard shatters on its own

--- a/cmds/spell/arcanist/shock.lpc
+++ b/cmds/spell/arcanist/shock.lpc
@@ -51,7 +51,7 @@ mixed use(
       "{{ff8}}$N $vcrackle as a bolt of lightning leaps to $t!{{res}}",
       victim
     );
-    tp->deliver_damage(victim, damage, "lightning");
+    tp->deliver_magic_damage(victim, damage, "lightning");
     tp->use_skill("arcane.discipline.lightning", 1.15);
   } else {
     tp->simple_action("The bolt of lightning fizzles harmlessly.");

--- a/obj/effect/burn.lpc
+++ b/obj/effect/burn.lpc
@@ -66,7 +66,7 @@ void tick() {
   victim->simple_action(
     "{{fc0}}$N $vwrithe as the flames sear $p flesh.{{res}}"
   );
-  __caster->deliver_damage(victim, __per_tick, "fire");
+  __caster->deliver_magic_damage(victim, __per_tick, "fire");
 
   if(--__remaining > 0) {
     call_out("tick", 2.5);

--- a/obj/effect/ice_shard.lpc
+++ b/obj/effect/ice_shard.lpc
@@ -64,7 +64,7 @@ int expire_obj(int expired) {
   );
 
   if(objectp(__caster))
-    __caster->deliver_damage(victim, __burst, "cold");
+    __caster->deliver_magic_damage(victim, __burst, "cold");
 
   return 1;
 }

--- a/obj/weapon/piercing/1h/rusty_sword.lpc
+++ b/obj/weapon/piercing/1h/rusty_sword.lpc
@@ -48,7 +48,7 @@ void bite(object attacker, object defender) {
       "{{555}}$P $o strikes $t viciously, biting deep into $p1 flesh.{{res}}",
       defender, this_object());
 
-    attacker->deliver_damage(defender, damage, "piercing");
+    attacker->deliver_mundane_damage(defender, damage, "piercing");
     attacker->use_skill("combat.melee.piercing");
   } else {
     attacker->targetted_action("$N $vswing $p $o wildly, missing $t.",

--- a/std/living/combat.lpc
+++ b/std/living/combat.lpc
@@ -373,7 +373,7 @@ void strike_enemy(object enemy, object weapon, int off_hand) {
   tell(enemy, messes[1], MSG_COMBAT_HIT);
   tell_down(environment(), messes[2], MSG_COMBAT_HIT, ({ this_object(), enemy }));
 
-  deliver_damage(enemy, dam, wtype);
+  deliver_mundane_damage(enemy, dam, wtype);
   adjust_mp(-random_float(5.0));
   add_threat(enemy, dam);
   add_seen_threat(enemy, dam);

--- a/std/living/damage.lpc
+++ b/std/living/damage.lpc
@@ -1,47 +1,45 @@
 /**
  * @file /std/living/damage.lpc
  *
- * Damage delivery and receipt for living objects. Provides the
- * attacker-side entry point (deliver_damage) and the victim-side
- * resolution (receive_damage), where the type-specific defence
- * value, the global DAMAGE_LEVEL_MODIFIER, and the level difference
- * combine to mitigate the incoming hit before it is applied to HP.
- * Records last-damaged-by and killed-by attribution as side
+ * Damage delivery and receipt for living objects. Provides the attacker-side
+ * entry point (deliver_damage) and the victim-side resolution (receive_damage),
+ * where the type-specific defence value, the global DAMAGE_LEVEL_MODIFIER, and
+ * the level difference combine to mitigate the incoming hit before it is
+ * applied to HP. Records last-damaged-by and killed-by attribution as side
  * effects.
  *
  * @created 2024-07-25 - Gesslar
- * @last_modified 2026-05-10 - Gesslar
+ * @last_modified 2026-07-30 - Gesslar
  *
  * @history
  * 2024-07-25 - Gesslar - Created
  * 2026-05-10 - Gesslar - Documentation pass
+ * 2026-07-30 - Gesslar - Documented calculate_damage and
+ *                        adjust_damage_by_severity
+ * 2026-07-30 - Gesslar - Documented the mundane and magic damage channels
  */
 
+#include <advancement.h>
 #include <combat.h>
 #include <damage.h>
 #include <skills.h>
 #include <vitals.h>
 
-// Functions from other objects
-float query_defence_amount(string type);
-float query_effective_level();
-object set_last_damaged_by(object ob);
-object set_killed_by(object ob);
-
 /**
- * Deliver a damage event to a victim. Validates inputs and routes
- * the call to the victim's receive_damage(), which is where
- * defence reduction, level scaling, and HP application happen.
+ * Deliver a damage event to a victim. Validates inputs and routes the call to
+ * the victim's receive_damage(), which is where defence reduction, level
+ * scaling, and HP application happen.
+ *
+ * Try not to use this function directly. Prefer to use `deliver_mundane_damage`
+ * or `deliver_magic_damage`.
  *
  * @param {STD_BODY} victim - The body to damage.
- * @param {float} damage - The pre-mitigation damage amount. Must
- *                         be non-negative.
- * @param {string} type - The damage type (e.g. "slashing", "fire").
- *                        Used by the victim to look up the
- *                        matching defence value.
- * @returns {float} The actual damage applied after the victim's
- *                  reductions, or 0 if the victim is missing or
- *                  the input damage was negative.
+ * @param {float} damage - The pre-mitigation damage amount. Must be non-
+ *  negative.
+ * @param {string} type - The damage type (e.g. "slashing", "fire"). Used by
+ *  the victim to look up the matching defence value.
+ * @returns {float} The actual damage applied after the victim's reductions, or
+ *  0 if the victim is missing or the input damage was negative.
  */
 public float deliver_damage(object victim, float damage, string type) {
   if(!victim)
@@ -60,24 +58,75 @@ public float deliver_damage(object victim, float damage, string type) {
 }
 
 /**
- * Apply damage to this body after defence reduction and level-
- * difference scaling.
+ * Deliver a mundane damage event to a victim. This is the attacker-side entry
+ * point for physical damage — weapon strikes, unarmed blows, falling rocks —
+ * and routes to the victim's receive_mundane_damage().
  *
- * The victim's defence amount for the given type is converted to
- * a percentage reduction. The global DAMAGE_LEVEL_MODIFIER is then
- * scaled by the level difference (attacker - victim) and used to
- * adjust that reduction: a higher-level attacker erodes the
- * victim's defence, a lower-level attacker has its damage further
- * reduced. After clamping at zero, the result is subtracted from
- * HP. If the body is already dead the call is a no-op. If this
- * hit brings HP to zero, the attacker is recorded as the killer.
+ * @param {STD_BODY} victim - The body to damage.
+ * @param {float} damage - The pre-mitigation damage amount. Must be non-
+ *  negative.
+ * @param {string} type - The damage type (e.g. "slashing", "bludgeoning").
+ *  Used by the victim to look up the matching defence value.
+ * @returns {float} The actual damage applied after the victim's reductions, or
+ *  0 if the victim is missing or the input damage was negative.
+ */
+public float deliver_mundane_damage(object victim, float damage, string type) {
+  if(!victim)
+    return 0;
+
+  if(damage < 0)
+    return 0;
+
+  float received = victim->receive_mundane_damage(this_object(), damage, type);
+
+  return received;
+}
+
+/**
+ * Deliver a magical damage event to a victim. This is the attacker-side entry
+ * point for spells, arcane procs, and other conjured harm, and routes to the
+ * victim's receive_magic_damage().
+ *
+ * @param {STD_BODY} victim - The body to damage.
+ * @param {float} damage - The pre-mitigation damage amount. Must be non-
+ *  negative.
+ * @param {string} type - The damage type (e.g. "fire", "shadow"). Used by the
+ *  victim to look up the matching defence value.
+ * @returns {float} The actual damage applied after the victim's reductions, or
+ *  0 if the victim is missing or the input damage was negative.
+ */
+public float deliver_magic_damage(object victim, float damage, string type) {
+  if(!victim)
+    return 0;
+
+  if(damage < 0)
+    return 0;
+
+  float received = victim->receive_magic_damage(this_object(), damage, type);
+
+  return received;
+}
+
+/**
+ * Apply damage to this body after defence reduction and level- difference
+ * scaling.
+ *
+ * The victim's defence amount for the given type is converted to a percentage
+ * reduction. The global DAMAGE_LEVEL_MODIFIER is then scaled by the level
+ * difference (attacker - victim) and used to adjust that reduction: a higher-
+ * level attacker erodes the victim's defence, a lower-level attacker has its
+ * damage further reduced. After clamping at zero, the result is subtracted
+ * from HP. If the body is already dead the call is a no-op. If this hit brings
+ * HP to zero, the attacker is recorded as the killer.
+ *
+ * Try not to use this function directly. Prefer to use `receive_mundane_damage`
+ * or `receive_magic_damage`.
  *
  * @param {STD_BODY} attacker - The body dealing the damage.
  * @param {float} damage - The pre-mitigation damage amount.
  * @param {string} type - The damage type for defence lookup.
- * @returns {float} The damage actually applied to HP, or 0 if the
- *                  attacker is missing, the input was negative, or
- *                  the body was already dead.
+ * @returns {float} The damage actually applied to HP, or 0.0 if the attacker
+ *  is missing, the input was negative, or the body was already dead.
  */
 public float receive_damage(object attacker, float damage, string type) {
   if(!attacker)
@@ -134,9 +183,64 @@ public float receive_damage(object attacker, float damage, string type) {
 }
 
 /**
+ * Resolve an incoming mundane damage event against this body. This is the
+ * victim-side counterpart to deliver_mundane_damage(), and applies the
+ * mitigation and HP bookkeeping of receive_damage() to physical harm.
  *
- * @param {STD_BODY} enemy
- * @param {object | string} weapon_or_skill
+ * @param {STD_BODY} attacker - The body dealing the damage.
+ * @param {float} damage - The pre-mitigation damage amount.
+ * @param {string} type - The damage type for defence lookup.
+ * @returns {float} The damage actually applied to HP, or 0.0 if the attacker
+ *  is missing, the input was negative, or the body was already dead.
+ */
+public float receive_mundane_damage(object attacker, float damage, string type) {
+  // later we'll add functionality specific to mundane damage, but for,
+  // just directly route.
+
+  return receive_damage(attacker, damage, type);
+}
+
+/**
+ * Resolve an incoming magical damage event against this body. This is the
+ * victim-side counterpart to deliver_magic_damage(), and applies the
+ * mitigation and HP bookkeeping of receive_damage() to conjured harm.
+ *
+ * @param {STD_BODY} attacker - The body dealing the damage.
+ * @param {float} damage - The pre-mitigation damage amount.
+ * @param {string} type - The damage type for defence lookup.
+ * @returns {float} The damage actually applied to HP, or 0.0 if the attacker
+ *  is missing, the input was negative, or the body was already dead.
+ */
+public float receive_magic_damage(object attacker, float damage, string type) {
+  // later we'll add functionality specific to magic damage, but for,
+  // just directly route.
+  return receive_damage(attacker, damage, type);
+}
+
+/**
+ * Calculate the raw, pre-mitigation damage for a single attack or ability
+ * against an enemy.
+ *
+ * The base damage comes from COMBAT.BASE_DAMAGE, reduced by
+ * COMBAT.DAMAGE_VARIANCE and then given back a random slice of that variance,
+ * so each call lands somewhere in the configured band. To that are added the
+ * weapon's base damage and the attacker's offensive skill (the full skill plus
+ * half of the general "combat" skill), and from it is subtracted the enemy's
+ * evasive skill — "combat.defence.evade" for arcane skills, otherwise
+ * "combat.defence.dodge". An enemy out of movement points (negative MP) is
+ * too winded to defend well, and takes a flat bonus.
+ *
+ * The result is pre-mitigation: type defence and level scaling are applied
+ * later by receive_damage().
+ *
+ * @param {STD_BODY} enemy - The intended target, consulted for its evasive
+ *  skill and movement points.
+ * @param {object | string} [weapon_or_skill] - A weapon object, whose info
+ *  supplies the base damage and the skill to test; or a skill name, tested
+ *  directly against unarmed weapon info. Omitted, unarmed weapon info is used
+ *  and its own skill is tested.
+ * @returns {float} The pre-mitigation damage. May be negative when the enemy's
+ *  evasive skill outweighs the attack.
  */
 public varargs float calculate_damage(object enemy, mixed weapon_or_skill) {
   mapping weapon_info;
@@ -188,6 +292,19 @@ public varargs float calculate_damage(object enemy, mixed weapon_or_skill) {
   return dam;
 }
 
+/**
+ * Scale a damage amount by a named severity band.
+ *
+ * Used by damage sources that describe their strength qualitatively — procs,
+ * for example — rather than computing a multiplier of their own. The bands are
+ * "weak" (0.25), "moderate" (0.75), "normal" (1.0), "heavy" (1.5), "high"
+ * (1.75), and "brutal" (2.0).
+ *
+ * @param {float} damage - The damage amount to scale.
+ * @param {string} severity - The severity band name.
+ * @returns {float} The scaled damage.
+ * @errors If the severity is not one of the recognised bands.
+ */
 public float adjust_damage_by_severity(float damage, string severity) {
   switch(severity) {
     case "weak":

--- a/std/living/include/damage.h
+++ b/std/living/include/damage.h
@@ -4,6 +4,10 @@
 public float adjust_damage_by_severity(float damage, string severity);
 public varargs float calculate_damage(object enemy, mixed weapon_or_skill);
 public float deliver_damage(object victim, float damage, string type);
+public float deliver_magic_damage(object victim, float damage, string type);
+public float deliver_mundane_damage(object victim, float damage, string type);
 public float receive_damage(object attacker, float damage, string type);
+public float receive_magic_damage(object attacker, float damage, string type);
+public float receive_mundane_damage(object attacker, float damage, string type);
 
 #endif // __DAMAGE_H__

--- a/std/living/proc.lpc
+++ b/std/living/proc.lpc
@@ -165,7 +165,8 @@ private void perform_simple_proc(string tag, mapping proc) {
   float raw = calculate_damage(enemy, skill_name);
   float damage = adjust_damage_by_severity(raw, proc.severity);
 
-  deliver_damage(enemy, damage, proc.damage_type);
+  // for now use mundane damage until we have defences sorted out
+  deliver_mundane_damage(enemy, damage, proc.damage_type);
 
   __npc_proc_cooldowns[tag] = time();
 }


### PR DESCRIPTION
## Introduce Distinct Mundane and Magic Damage Channels

Splits the single `deliver_damage` / `receive_damage` pipeline into two explicit channels:

- **`deliver_mundane_damage` / `receive_mundane_damage`** — for physical harm: weapon strikes, unarmed attacks, procs, and similar.
- **`deliver_magic_damage` / `receive_magic_damage`** — for conjured harm: spells, arcane procs, burn ticks, and ice shard bursts.

Both channels currently route through the existing `receive_damage` core, but the separation gives each a dedicated hook point where type-specific mitigation logic (e.g. magic resistance, physical armour bypass) can be added independently in the future. `deliver_damage` and `receive_damage` are retained as the underlying implementation but are now considered internal; callers should prefer the typed variants.

All existing call sites have been updated accordingly — unarmed punch, rusty sword, and the `strike_enemy` combat loop use the mundane channel; the arcanist spells (motes, shard, shock), burn effect ticks, and ice shard burst use the magic channel. NPC procs are routed through the mundane channel for now, pending defence system work.

Documentation has been added for `calculate_damage` and `adjust_damage_by_severity`, and the file header updated to reflect the new channels.