### PR TITLE
Add null guard `objectp()` checks to `pcp()` and `npcp()` simul-efuns

### DIFF
--- a/adm/simul_efun/user.lpc
+++ b/adm/simul_efun/user.lpc
@@ -140,17 +140,17 @@ int ghostp(object ob) {
  * @returns {ob is STD_PLAYER} 1 if the object is a player, otherwise 0.
  */
 int pcp(object ob) {
-  return ob->is_pc();
+  return objectp(ob) && ob->is_pc();
 }
 
 /**
  * Returns 1 if the object is an npc, 0 if not.
  *
  * @param {STD_NPC} ob - The object to check.
- * @returns {ob is STD_PLAYER} 1 if the object is an npc, otherwise 0.
+ * @returns {ob is STD_NPC} 1 if the object is an npc, otherwise 0.
  */
 int npcp(object ob) {
-  return ob->is_npc();
+  return objectp(ob) && ob->is_npc();
 }
 
 /**


### PR DESCRIPTION
Add null safety checks to `pcp` and `npcp` functions

Both `pcp` and `npcp` now guard against null or invalid object references by checking `objectp(ob)` before calling `is_pc()` or `is_npc()`. This prevents potential errors when a non-object is passed to either function.

Also fixes an incorrect return type annotation in the `npcp` doc comment, which previously referenced `STD_PLAYER` instead of `STD_NPC`.