### PR TITLE
Remove extra blank line in `resource.lpc` `start_module`

### DIFF
--- a/std/modules/room/resource.lpc
+++ b/std/modules/room/resource.lpc
@@ -26,7 +26,6 @@ int start_module(mapping c) {
   return 1;
 }
 
-
 void stop_module() {
   RESOURCE_D->clean_up_obj(owner);
   RESOURCE_D->unregister_obj(owner);


### PR DESCRIPTION
Removes extra blank line between `start_module` and `stop_module` functions.