### PR TITLE
Add `relative_to` optional parameter to `source_file()` simul-efun

### DIFF
--- a/adm/include/simul_efun.h
+++ b/adm/include/simul_efun.h
@@ -105,7 +105,7 @@ varargs void implode_file(string file, string *lines, int overwrite);
 varargs mixed load_lpml(string file, string root);
 mixed load_json(string file);
 void assure_file(string file);
-string source_file(string path_and_file);
+varargs string source_file(string path_and_file, string relative_to);
 mapping as_directory(string str);
 mapping as_file(string str);
 varargs mapping read_directory(string directory, string pattern);

--- a/adm/simul_efun/file.lpc
+++ b/adm/simul_efun/file.lpc
@@ -490,16 +490,17 @@ int touch(string file) {
  * exists the .lpc form is returned anyway as a default — callers that need
  * to know whether the file is real should check file_size() on the result.
  *
- * @param {string} path_and_file - Path to a source file, with or without
- *                                 a .lpc / .c extension
- * @returns {string} Path to the existing source file, preferring .lpc; or
- *                   the .lpc form if no source file is found
+ * @param {string} path_and_file - Path to a source file, with or without a
+ *  .lpc / .c extension
+ * @param {string} [relative_to] - If provided, will resolve to this location.
+ * @returns {string} Path to the existing source file, preferring .lpc; or the
+ *  .lpc form if no source file is found
  * @example
  * source_file("/cmds/object/work");      // -> "/cmds/object/work.lpc"
  * source_file("/cmds/file/pwd.c");       // -> "/cmds/file/pwd.c"
  * source_file("/no/such/thing");         // -> "/no/such/thing.lpc"
  */
-string source_file(string path_and_file) {
+varargs string source_file(string path_and_file, string relative_to) {
   string temp;
 
   if(ends_with(path_and_file, ".lpc"))
@@ -507,11 +508,16 @@ string source_file(string path_and_file) {
   else if(ends_with(path_and_file, ".c"))
     path_and_file = path_and_file[0..<3];
 
+  if(stringp(relative_to) && truthy(relative_to))
+    temp = resolve_file(relative_to, temp);
+
   temp = append(path_and_file, ".lpc");
+  temp = resolve_file(relative_to, temp);
   if(file_size(temp) >= 0)
     return temp;
 
   temp = append(path_and_file, ".c");
+  temp = resolve_file(relative_to, temp);
   if(file_size(temp) >= 0)
     return temp;
 


### PR DESCRIPTION
Adds an optional `relative_to` parameter to `source_file()`, allowing callers to resolve source file paths relative to a given location. When provided, the resolved path is passed through `resolve_file()` before checking for `.lpc` and `.c` variants. The header declaration is updated to reflect the new `varargs` signature.