### PR TITLE
Add "from <container>" syntax to `eat` and `drink` commands

### DIFF
--- a/cmds/action/drink.lpc
+++ b/cmds/action/drink.lpc
@@ -4,16 +4,20 @@
  * Drink command.
  *
  * @created 2024-08-06 - Gesslar
- * @last_modified 2024-08-06 - Gesslar
+ * @last_modified 2026-08-03 - Gesslar
  *
  * @history
  * 2024-08-06 - Gesslar - Created
+ * 2026-08-03 - Gesslar - Added "drink <drink> from <container>" syntax
  */
 
 inherit STD_ACT;
 
 void setup() {
-  usage_text = "drink <drink>";
+  usage_text =
+    "drink <drink>\n"
+    "drink <drink> from <container>"
+    ;
   help_text =
     "This command will allow you to drink from a beverage you are holding. "
     "Drinking consumes the beverage more quickly than sipping it.\n"
@@ -21,29 +25,53 @@ void setup() {
     "See also: sip, eat, nibble";
 }
 
-/**
- *
- * @param {STD_BODY} tp - The player
- * @param {string} str - The item to be drunk.
- * @returns {string | int} 1 if successful, an error message otherwise.
- */
-mixed main(object tp, string str) {
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string str
+) {
   /** @type {STD_DRINK} */ object ob;
-  int uses;
+  /** @type {STD_CONTAINER} */ object container;
+  string from;
 
   if(!str)
     return _usage(tp);
 
-  if(!ob = find_target(tp, str, tp))
-    return "You don't have that.";
+  if(sscanf(str, "%s from %s", str, from) == 2) {
+    container = find_target(tp, from, tp);
+
+    if(!container)
+      return `You do not possess ${from}.`;
+
+    if(!container->is_container())
+      return `Your ${remove_article(ob_short(container))} doesn't contain anything.`;
+
+    if(container->is_closed())
+      return `Your ${remove_article(ob_short(container))} is closed.`;
+  } else {
+    container = tp;
+  }
+
+  if(!ob = find_target(tp, str, container)) {
+    if(container == tp)
+      return "You don't have that.";
+    else
+      return `Your ${remove_article(ob_short(container))} does not contain ${str}.`;
+  }
 
   if(!ob->is_drink())
     return "You can't drink that.";
 
-  uses = ob->query_uses();
+  int uses = ob->query_uses();
 
   if(uses < 1)
     return "There is nothing left to drink.";
+
+  if(!present(ob, tp)) {
+    if(ob->move(tp))
+      return `You are too encumbered to carry ${ob_short(ob)}`;
+
+    tp->simple_action("$N $vget a $o from $p $o1.", ob, container);
+  }
 
   if(!ob->drink_obj(tp))
     return "You couldn't drink that.";

--- a/cmds/action/eat.lpc
+++ b/cmds/action/eat.lpc
@@ -4,16 +4,20 @@
  * Eat command.
  *
  * @created 2024-08-06 - Gesslar
- * @last_modified 2024-08-06 - Gesslar
+ * @last_modified 2026-08-03 - Gesslar
  *
  * @history
  * 2024-08-06 - Gesslar - Created
+ * 2026-08-03 - Gesslar - Added "eat <object> from <container>" syntax
  */
 
 inherit STD_ACT;
 
 void setup() {
-  usage_text = "eat <object>";
+  usage_text =
+    "eat <object>\n"
+    "eat <object> from <container>"
+    ;
   help_text =
     "This command will allow you to eat food you are holding. Eating consumes "
     "the food more quickly than nibbling at it.\n"
@@ -21,17 +25,38 @@ void setup() {
     "See also: nibble, drink, sip";
 }
 
-/**
- *
- * @param {STD_BODY} tp - The player
- * @param {string} str - The item to be eaten.
- * @returns {string | int} 1 if successful, an error message otherwise.
- */
-mixed main(object tp, string str) {
+mixed main(
+  /** @type {STD_BODY} */ object tp,
+  string str
+) {
   /** @type {STD_FOOD} */ object ob;
+  /** @type {STD_CONTAINER} */ object container;
+  string from;
 
-  if(!ob = find_target(tp, str, tp))
-    return "You don't have that.";
+  if(!str)
+    return _usage(tp);
+
+  if(sscanf(str, "%s from %s", str, from) == 2) {
+    container = find_target(tp, from, tp);
+
+    if(!container)
+      return `You do not possess ${from}.`;
+
+    if(!container->is_container())
+      return `Your ${remove_article(ob_short(container))} doesn't contain anything.`;
+
+    if(container->is_closed())
+      return `Your ${remove_article(ob_short(container))} is closed.`;
+  } else {
+    container = tp;
+  }
+
+  if(!ob = find_target(tp, str, container)) {
+    if(container == tp)
+      return "You don't have that.";
+    else
+      return `Your ${remove_article(ob_short(container))} does not contain ${str}.`;
+  }
 
   if(!ob->is_edible())
     return "You can't eat that.";
@@ -41,6 +66,13 @@ mixed main(object tp, string str) {
 
   if(uses < 1)
     return "There is nothing left to eat.";
+
+  if(!present(ob, tp)) {
+    if(ob->move(tp))
+      return `You are too encumbered to carry ${ob_short(ob)}`;
+
+    tp->simple_action("$N $vget a $o from $p $o1.", ob, container);
+  }
 
   mapping healing = ob->get_healing();
   int eaten = ob->eat_obj(tp);


### PR DESCRIPTION
The `drink` and `eat` commands now support targeting items inside containers the player is carrying, using the syntax `drink <drink> from <container>` and `eat <food> from <container>`.

When a container is specified, the command validates that the player possesses it, that it is a container, and that it is open before searching for the target item within it. If the item is found in the container but not already in the player's inventory, it is automatically retrieved first, with an encumbrance check preventing the action if the player cannot carry it.