### PR TITLE
Refactor `command_hook` to use `falsy`/`truthy` and clean up whitespace

### DIFF
--- a/adm/daemons/alias.lpc
+++ b/adm/daemons/alias.lpc
@@ -205,9 +205,8 @@ public resolve_alias(string input, object who) {
 
   who ??= this_body();
 
-  mixed *input_parts = explode(input, " ");
-
-  string to_try = shift(ref input_parts);
+  string *input_parts = explode(input, " ");
+  string  to_try = shift(ref input_parts);
   string *found =
     find_personal_alias(who, to_try) ?? find_global_alias(to_try, who);
 
@@ -223,14 +222,14 @@ public resolve_alias(string input, object who) {
 
   // Now un-re-assemble so we can have everything word-separating. Not a
   // straightforward explode, because maybe sections of contiguous spaces.
-  input_parts = pcre_assoc(
+  mixed *assoc = pcre_assoc(
     input,
     ({ "\\s+"}),
     ({ INPUT_SPACES }),
     INPUT_WORD,
   );
-  string *input_words = input_parts[0];
-  int *input_matches = input_parts[1];
+  string *input_words = assoc[0];
+  int *input_matches = assoc[1];
 
   string alias = found[0];
   mixed *alias_parts = pcre_assoc(
@@ -318,7 +317,6 @@ public resolve_alias(string input, object who) {
     result = result[0 .. final_gobble_position-1];
     result += gobbled;
     result += positional_tokens[final_gobble_position+1..];
-
   }
 
   return trim(implode(result, ""));

--- a/std/object/command.lpc
+++ b/std/object/command.lpc
@@ -317,7 +317,7 @@ public int rem_path(string path) {
   __command_paths ??= ({});
 
   path = append(path, "/");
-  
+
   if(!includes(__command_paths, path))
     return 0;
 
@@ -328,7 +328,7 @@ public int rem_path(string path) {
 
 /**
  * Returns 1 if the body has access to the specified path. If not, 0.
- * 
+ *
  * @param {string} path - The file path to check.
  * @returns {int} 1 if has the path, 0 otherwise.
  */
@@ -444,22 +444,25 @@ public int command_hook(string arg) {
 
   verb = query_verb();
 
-  if(arg == "")
-    arg = 0;
+  if(falsy(arg))
+    arg = undefined;
 
   verb = lower_case(verb);
 
-  if(arg)
+  if(truthy(arg))
     complete = sprintf("%s %s", verb, arg);
   else
     complete = verb;
 
   string aliased = ALIAS_D->resolve_alias(complete, this_object());
 
-  if(aliased) {
-    arg = 0;
-
-    sscanf(aliased, "%s %s", verb, arg) || verb = aliased;
+  // If the alias resolved (it is different from what we typed), we need to
+  // split it out again.
+  if(aliased != complete) {
+    if(sscanf(aliased, "%s %s", verb, arg) != 2) {
+      verb = aliased;
+      arg = undefined;
+    }
   }
 
   obs = all_inventory();


### PR DESCRIPTION
Replaces `== ""` and `if(arg)` checks with `falsy()`/`truthy()` calls for consistency, changes `arg = 0` to `arg = undefined`, and simplifies the aliased command block by removing the redundant `arg = 0` assignment before `sscanf`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR standardizes command argument checks with `falsy()`/`truthy()`, tightens alias-change detection, and performs minor type and whitespace cleanup.
- Preserves the original command arguments when alias resolution leaves the command unchanged.
- Clears arguments when a changed alias expands to a single-word command.
- Refines local array types in the alias daemon without changing its resolution contract.
</details>

<sub>Reviews (3): Last reviewed commit: ["moo"](https://github.com/gesslar/oxidus-mudlib/commit/85721fdd9a9840ccddfe0bea4224c46b9511142e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52104930)</sub>

**Context used:**

- Knowledge Base — [Commands And Dispatch](https://app.greptile.com/gesslar/-/custom-context/knowledge-base/gesslar/oxidus-mudlib/-/docs/commands-and-dispatch.md)
- Knowledge Base — [Daemons Overview](https://app.greptile.com/gesslar/-/custom-context/knowledge-base/gesslar/oxidus-mudlib/-/docs/daemons-overview.md)

<!-- /greptile_comment -->