### PR TITLE
Default `log` command to `compile` log when no file given

### DIFF
--- a/cmds/dev/log.lpc
+++ b/cmds/dev/log.lpc
@@ -13,24 +13,25 @@
 inherit STD_CMD;
 
 void setup() {
-  usage_text = "log <file>";
+  usage_text = "log [file]";
   help_text =
     "This command shows the last few lines of a log file, like tail. The "
     "number of lines shown is determined by your 'morelines' preference.\n"
     "\n"
-    "If <file> does not begin with a slash, it is looked up relative to the "
+    "If [file] does not begin with a slash, it is looked up relative to the "
     "log directory (" + log_dir() + "). Otherwise it is treated as an "
     "absolute path.\n"
+    "\n"
+    "If no file is provided, the default will be `/log/compile`."
     "\n"
     "See also: more, cat";
 }
 
 mixed main(
   /** @type {STD_PLAYER} */ object caller,
-  string str
+  /** @type {string?} */    string str
 ) {
-  if(!str)
-    return _usage(caller);
+  str ??= "compile";
 
   string file;
 


### PR DESCRIPTION
Makes the `log` command default to `/log/compile` when no file argument is provided, rather than displaying the usage text. Updates the help text to document this default behavior and adjusts the usage syntax to reflect that the file argument is now optional.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The `log` developer command now treats its file argument as optional and defaults an omitted argument to the compile log.
- Updates the usage and help text to document the default.
- Replaces the no-argument usage response with a `"compile"` default before existing path handling.
</details>

<sub>Reviews (2): Last reviewed commit: ["updating log file"](https://github.com/gesslar/oxidus-mudlib/commit/fc0890fd342b4d64f788088adc1f7ac57548e5cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52104921)</sub>

<!-- /greptile_comment -->