### PR TITLE
Fix `call_trace()` colour mapping applied when colour disabled

### DIFF
--- a/adm/simul_efun/function.lpc
+++ b/adm/simul_efun/function.lpc
@@ -101,9 +101,8 @@ varargs string call_trace(int colour) {
   function match_body = (: $(source) && objectp($(source)) && living($(source)) && $(source) == $1 :);
 
   string *colours = colour
-    ? trace_colours
+    ? map(trace_colours, (:"{{"+$1[1..]+"}}":))
     : map(trace_colours, (: "" :));
-  colours = map(colours, (:"{{"+$1[1..]+"}}":));
 
   // We don't want to include the call_trace() function itself
   string res = reduce(objects[1..],


### PR DESCRIPTION
The `call_trace` function was applying the colour tag transformation unconditionally by running `map` on `colours` a second time after the initial assignment. This meant even when `colour` was false and `colours` was already mapped to empty strings, the second `map` would incorrectly transform those empty strings.

The fix inlines the colour tag transformation into the ternary expression so it is only applied when `colour` is truthy, and the empty-string mapping is used as-is when colour is disabled.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes `call_trace()` so colour-tag transformation occurs only when colour output is enabled.
- Moves the `{{...}}` colour mapping into the truthy ternary branch.
- Preserves empty strings unchanged when colour output is disabled.
</details>

<sub>Reviews (1): Last reviewed commit: ["asdf"](https://github.com/gesslar/oxidus-mudlib/commit/6f47cf3786eb21320993103dbcf7b0e126f25fda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52104916)</sub>

**Context used:**

- Knowledge Base — [Simul-efuns and Utilities](https://app.greptile.com/gesslar/-/custom-context/knowledge-base/gesslar/oxidus-mudlib/-/docs/simul-efuns-and-utilities.md)

<!-- /greptile_comment -->